### PR TITLE
feat(agents): serialize the inline AgentTasks awaited from one turn

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import time
 from collections.abc import AsyncGenerator, AsyncIterable, Coroutine, Generator
 from dataclasses import dataclass
@@ -915,6 +914,7 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 f"{self.__class__.__name__} should only be awaited inside tool_functions or the on_enter/on_exit methods of an Agent"  # noqa: E501
             )
 
+        # imported at call time: agent_activity imports Agent at module scope, so the reverse can't
         from .agent_activity import _AgentActivityContextVar, _SpeechHandleContextVar
 
         speech_handle = _SpeechHandleContextVar.get(None)
@@ -922,11 +922,6 @@ class AgentTask(Agent, Generic[TaskResult_T]):
         old_agent = old_activity.agent
         session = old_activity.session
         self._old_agent = old_agent
-
-        if speech_handle and speech_handle.interrupted:
-            raise RuntimeError(
-                f"{self.__class__.__name__} cannot be awaited inside a function tool that is already interrupted"
-            )
 
         def _handle_task_done(_: asyncio.Task[Any]) -> None:
             if self.__fut.done():
@@ -944,17 +939,6 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 )
             )
 
-        # registered only past the checks above: they raise instead of completing the task,
-        # so an early exit must not report the task as finishing prematurely
-        current_task.add_done_callback(_handle_task_done)
-
-        old_allow_interruptions = True
-        if speech_handle:
-            # lock the speech handle to prevent interruptions until the task is complete
-            # there should be no await before this line to avoid race conditions
-            old_allow_interruptions = speech_handle.allow_interruptions
-            speech_handle.allow_interruptions = False
-
         blocked_tasks = [current_task]
         if (
             old_activity._on_enter_task
@@ -963,119 +947,114 @@ class AgentTask(Agent, Generic[TaskResult_T]):
         ):
             blocked_tasks.append(old_activity._on_enter_task)
 
-        # register before any await so a concurrent drain (e.g. session close)
-        # won't wait for tasks blocked on this handoff
-        old_activity._add_drain_blocked_tasks(blocked_tasks)
-
-        # watch the blocked tasks so an active run won't complete mid-handoff
-        # (the parent speech may predate the run, e.g. created in on_enter)
-        if (run_state := session._global_run_state) and not run_state.done():
-            for task in blocked_tasks:
-                run_state._watch_handle(task)
-
-        if (
-            task_info.function_call
-            and isinstance(old_activity.llm, RealtimeModel)
-            and not old_activity.llm.capabilities.manual_function_calls
+        async with old_activity._inline_task_slot(
+            speech_handle=speech_handle, blocked_tasks=blocked_tasks
         ):
-            logger.error(
-                f"Realtime model '{old_activity.llm.label}' does not support resuming function calls from chat context, "
-                "using AgentTask inside a function tool may have unexpected behavior."
-            )
+            current_task.add_done_callback(_handle_task_done)
 
-        # TODO(theomonnom): could the RunResult watcher & the blocked_tasks share the same logic?
-        self.__inactive_ev.clear()
-        suspended_handles: list[SpeechHandle | asyncio.Future[Any]] = []
-        pending_on_enter_task: asyncio.Task[None] | None = None
-        try:
-            # use wait_on_enter=False to avoid deadlock: on_enter may spawn nested
-            # AgentTasks that require user input, but session.run() can't return until
-            # all watched handles complete — creating a circular wait.
-            await session._update_activity(
-                self, previous_activity="pause", blocked_tasks=blocked_tasks, wait_on_enter=False
-            )
-
-            if not self._activity and not self.done():
-                self.complete(
-                    ToolError(
-                        f"activity doesn't start for {self.id}, likely due to session closing"
-                    )
+            if (
+                task_info.function_call
+                and isinstance(old_activity.llm, RealtimeModel)
+                and not old_activity.llm.capabilities.manual_function_calls
+            ):
+                logger.error(
+                    f"Realtime model '{old_activity.llm.label}' does not support resuming function calls from chat context, "
+                    "using AgentTask inside a function tool may have unexpected behavior."
                 )
 
-            run_state = session._global_run_state
-
-            if self._activity and (on_enter_task := self._activity._on_enter_task):
-                if run_state and not run_state.done():
-                    # watch the on_enter task as a guard so RunResult won't complete
-                    # before on_enter has registered its own speech handles
-                    run_state._watch_handle(on_enter_task)
-                    pending_on_enter_task = on_enter_task
-                else:
-                    # no active run to guard — just wait for on_enter directly
-                    await asyncio.shield(on_enter_task)
-
-            # now unwatch the parent speech handle and blocked tasks that belong to the
-            # old activity — they can't complete while this AgentTask is running, and
-            # keeping them watched would block RunResult from completing. A foreground
-            # hold waiting on this task is in the same position, so its guard suspends too.
-            if run_state and not run_state.done():
-                if speech_handle and run_state._unwatch_handle(speech_handle):
-                    suspended_handles.append(speech_handle)
-                for blocked in [*blocked_tasks, *session._foreground_guards]:
-                    if run_state._unwatch_handle(blocked):
-                        suspended_handles.append(blocked)
-                if suspended_handles:
-                    run_state._mark_done_if_needed(None)
-        except Exception:
-            self.__inactive_ev.set()
-            raise
-
-        try:
-            return await asyncio.shield(self.__fut)
-
-        finally:
-            if speech_handle:
-                with contextlib.suppress(RuntimeError):
-                    speech_handle.allow_interruptions = old_allow_interruptions
-
-            # run_state could have changed after self.__fut
-            run_state = session._global_run_state
-
-            # re-watch the suspended handles so the resumed parent activity
-            # is tracked by the current RunResult again
-            if run_state and not run_state.done():
-                for handle in suspended_handles:
-                    run_state._watch_handle(handle)
-
-            if pending_on_enter_task:
-                try:
-                    await asyncio.shield(pending_on_enter_task)
-                except BaseException:
-                    logger.exception("error in on_enter task of agent %s", self.id)
-
-            if session._closing and self._activity is None:
-                # the activity never started (session closing), skip the handoff;
-                # the close path owns the previous activity
-                pass
-            elif session.current_agent != self:
-                logger.warning(
-                    f"{self.__class__.__name__} completed, but the agent has changed in the meantime. "
-                    "Ignoring handoff to the previous agent, likely due to `AgentSession.update_agent` being invoked."
-                )
-                await old_activity.aclose()
-            else:
-                merged_chat_ctx = old_agent.chat_ctx.merge(
-                    self.chat_ctx,
-                    exclude_function_call=not self._preserve_function_call_history,
-                    exclude_instructions=True,
-                )
-                # set the chat_ctx directly, `session._update_activity` will sync it to the rt_session if needed
-                old_agent._chat_ctx.items[:] = merged_chat_ctx.items
-
+            # TODO(theomonnom): could the RunResult watcher & the blocked_tasks share the same logic?
+            self.__inactive_ev.clear()
+            suspended_handles: list[SpeechHandle | asyncio.Future[Any]] = []
+            pending_on_enter_task: asyncio.Task[None] | None = None
+            try:
+                # use wait_on_enter=False to avoid deadlock: on_enter may spawn nested
+                # AgentTasks that require user input, but session.run() can't return until
+                # all watched handles complete — creating a circular wait.
                 await session._update_activity(
-                    old_agent, new_activity="resume", wait_on_enter=False
+                    self,
+                    previous_activity="pause",
+                    blocked_tasks=blocked_tasks,
+                    wait_on_enter=False,
                 )
-            self.__inactive_ev.set()
+
+                if not self._activity and not self.done():
+                    self.complete(
+                        ToolError(
+                            f"activity doesn't start for {self.id}, likely due to session closing"
+                        )
+                    )
+
+                run_state = session._global_run_state
+
+                if self._activity and (on_enter_task := self._activity._on_enter_task):
+                    if run_state and not run_state.done():
+                        # watch the on_enter task as a guard so RunResult won't complete
+                        # before on_enter has registered its own speech handles
+                        run_state._watch_handle(on_enter_task)
+                        pending_on_enter_task = on_enter_task
+                    else:
+                        # no active run to guard — just wait for on_enter directly
+                        await asyncio.shield(on_enter_task)
+
+                # now unwatch the parent speech handle and blocked tasks that belong to the
+                # old activity — they can't complete while this AgentTask is running, and
+                # keeping them watched would block RunResult from completing. A foreground
+                # hold waiting on this task is in the same position, so its guard suspends too.
+                if run_state and not run_state.done():
+                    if speech_handle and run_state._unwatch_handle(speech_handle):
+                        suspended_handles.append(speech_handle)
+                    for blocked in [*blocked_tasks, *session._foreground_guards]:
+                        if run_state._unwatch_handle(blocked):
+                            suspended_handles.append(blocked)
+                    if suspended_handles:
+                        run_state._mark_done_if_needed(None)
+            # asyncio.CancelledError derives from BaseException, not Exception
+            except BaseException:
+                self.__inactive_ev.set()
+                raise
+
+            try:
+                return await asyncio.shield(self.__fut)
+
+            finally:
+                # run_state could have changed after self.__fut
+                run_state = session._global_run_state
+
+                # re-watch the suspended handles so the resumed parent activity
+                # is tracked by the current RunResult again
+                if run_state and not run_state.done():
+                    for handle in suspended_handles:
+                        run_state._watch_handle(handle)
+
+                if pending_on_enter_task:
+                    try:
+                        await asyncio.shield(pending_on_enter_task)
+                    except BaseException:
+                        logger.exception("error in on_enter task of agent %s", self.id)
+
+                if session._closing and self._activity is None:
+                    # the activity never started (session closing), skip the handoff;
+                    # the close path owns the previous activity
+                    pass
+                elif session.current_agent != self:
+                    logger.warning(
+                        f"{self.__class__.__name__} completed, but the agent has changed in the meantime. "
+                        "Ignoring handoff to the previous agent, likely due to `AgentSession.update_agent` being invoked."
+                    )
+                    await old_activity.aclose()
+                else:
+                    merged_chat_ctx = old_agent.chat_ctx.merge(
+                        self.chat_ctx,
+                        exclude_function_call=not self._preserve_function_call_history,
+                        exclude_instructions=True,
+                    )
+                    # set the chat_ctx directly, `session._update_activity` will sync it to the rt_session if needed
+                    old_agent._chat_ctx.items[:] = merged_chat_ctx.items
+
+                    await session._update_activity(
+                        old_agent, new_activity="resume", wait_on_enter=False
+                    )
+                self.__inactive_ev.set()
 
     def __await__(self) -> Generator[None, None, TaskResult_T]:
         return self.__await_impl().__await__()

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -915,6 +915,19 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 f"{self.__class__.__name__} should only be awaited inside tool_functions or the on_enter/on_exit methods of an Agent"  # noqa: E501
             )
 
+        from .agent_activity import _AgentActivityContextVar, _SpeechHandleContextVar
+
+        speech_handle = _SpeechHandleContextVar.get(None)
+        old_activity = _AgentActivityContextVar.get()
+        old_agent = old_activity.agent
+        session = old_activity.session
+        self._old_agent = old_agent
+
+        if speech_handle and speech_handle.interrupted:
+            raise RuntimeError(
+                f"{self.__class__.__name__} cannot be awaited inside a function tool that is already interrupted"
+            )
+
         def _handle_task_done(_: asyncio.Task[Any]) -> None:
             if self.__fut.done():
                 return
@@ -931,26 +944,12 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                 )
             )
 
+        # registered only past the checks above: they raise instead of completing the task,
+        # so an early exit must not report the task as finishing prematurely
         current_task.add_done_callback(_handle_task_done)
-
-        from .agent_activity import _AgentActivityContextVar, _SpeechHandleContextVar
-
-        # TODO(theomonnom): add a global lock for inline tasks
-        # This may currently break in the case we use parallel tool calls.
-
-        speech_handle = _SpeechHandleContextVar.get(None)
-        old_activity = _AgentActivityContextVar.get()
-        old_agent = old_activity.agent
-        session = old_activity.session
-        self._old_agent = old_agent
 
         old_allow_interruptions = True
         if speech_handle:
-            if speech_handle.interrupted:
-                raise RuntimeError(
-                    f"{self.__class__.__name__} cannot be awaited inside a function tool that is already interrupted"
-                )
-
             # lock the speech handle to prevent interruptions until the task is complete
             # there should be no await before this line to avoid race conditions
             old_allow_interruptions = speech_handle.allow_interruptions

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import contextvars
 import heapq
 import json
@@ -20,6 +21,7 @@ from ..llm.chat_context import Instructions
 from ..llm.realtime_fallback_adapter import _FallbackRealtimeSession
 from ..llm.tool_context import (
     StopResponse,
+    ToolError,
     ToolFlag,
     get_fnc_tool_names,
 )
@@ -213,6 +215,8 @@ class AgentActivity(RecognitionHooks):
         self._realtime_spans: utils.BoundedDict[str, trace.Span] | None = None
         self._audio_recognition: AudioRecognition | None = None
         self._lock = asyncio.Lock()
+        # one awaited inline AgentTask may pause this activity at a time
+        self._inline_task_lock = asyncio.Lock()
         self._tool_choice: llm.ToolChoice | None = None
 
         self._started = False
@@ -1215,6 +1219,56 @@ class AgentActivity(RecognitionHooks):
             # This means that even if the SpeechHandle themselves have finished,
             # we still wait for the entire execution (e.g function_tools)
             await asyncio.shield(self._scheduling_atask)
+
+    @contextlib.asynccontextmanager
+    async def _inline_task_slot(
+        self,
+        *,
+        speech_handle: SpeechHandle | None,
+        blocked_tasks: list[asyncio.Task[Any]],
+    ) -> AsyncGenerator[None, None]:
+        """Grants the floor to one awaited inline AgentTask at a time.
+
+        Pausing an activity is a single slot: concurrent handoffs would leave every switch
+        but the last overwritten, and those tasks awaiting a result nothing can produce. The
+        inline tasks of a turn's parallel tool calls queue here and take the slot in turn.
+
+        The queue is per activity, which is the thing a handoff contends for. A nested task
+        pauses the activity of the task it is nested in, so it takes that activity's slot
+        and never waits on the one its parent is holding.
+
+        Each step below is ordered against the queue, and inverting any of them hangs the
+        session in its own way, so they belong together rather than at the call site.
+        """
+        # before the queue: the tasks behind it share this speech, and a hold released
+        # between them lets one task's user turns interrupt it out from under the rest
+        if speech_handle is not None:
+            if speech_handle.interrupted:
+                raise RuntimeError("the speech that awaited the inline task is interrupted")
+
+            speech_handle._hold_interruptions()
+
+        try:
+            # before the queue: a queued task absent from the drain set makes session close
+            # wait on the slot it is still queued for
+            self._add_drain_blocked_tasks(blocked_tasks)
+
+            async with self._inline_task_lock:
+                if self._closed or self._session._closing:
+                    # reported to the model as a tool failure, the way a tool awaiting an
+                    # inline task through a session close has always been
+                    raise ToolError("the activity that awaited the inline task is closing")
+
+                # past the queue: a run watching a task still waiting its turn waits for
+                # the user input the task ahead of it needs
+                if (run_state := self._session._global_run_state) and not run_state.done():
+                    for task in blocked_tasks:
+                        run_state._watch_handle(task)
+
+                yield
+        finally:
+            if speech_handle is not None:
+                speech_handle._release_interruptions()
 
     def _add_drain_blocked_tasks(self, tasks: list[asyncio.Task[Any]]) -> None:
         # tasks blocked on an agent handoff are excluded from the drain wait,

--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -35,6 +35,8 @@ class SpeechHandle:
     ) -> None:
         self._id = speech_id
         self._allow_interruptions = allow_interruptions
+        self._interruption_holds = 0
+        self._interruption_holds_restore = allow_interruptions
         self._input_details = input_details
 
         self._interrupt_fut = asyncio.Future[None]()
@@ -131,6 +133,29 @@ class SpeechHandle:
             )
 
         self._allow_interruptions = value
+
+    def _hold_interruptions(self) -> None:
+        """Disallow interruptions until every hold taken here is released.
+
+        Counted rather than set, because the holders of one speech are not serialised
+        against each other: the inline tasks awaited from a turn's parallel tool calls run
+        one at a time, and a hold released between them would let the user turns of one
+        task's sub-conversation interrupt the speech the rest are still anchored to. An
+        interrupted handle can no longer disallow interruptions, so those tasks could then
+        never run. The first holder owns the value the last one restores.
+        """
+        if self._interruption_holds == 0:
+            self._interruption_holds_restore = self._allow_interruptions
+            self.allow_interruptions = False
+
+        self._interruption_holds += 1
+
+    def _release_interruptions(self) -> None:
+        self._interruption_holds -= 1
+        if self._interruption_holds == 0:
+            # a forced interrupt lands regardless of the hold, and leaves nothing to restore
+            with contextlib.suppress(RuntimeError):
+                self.allow_interruptions = self._interruption_holds_restore
 
     @property
     def chat_items(self) -> list[llm.ChatItem]:

--- a/tests/test_nested_agent_task.py
+++ b/tests/test_nested_agent_task.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 
 import pytest
 
 from livekit.agents import Agent, AgentSession, AgentTask, RunContext, function_tool
-from livekit.agents.llm import FunctionToolCall
+from livekit.agents.llm import FunctionToolCall, ToolError
 
 from .fake_llm import FakeLLM, FakeLLMResponse
 
@@ -152,6 +153,116 @@ async def test_handoff_from_pre_run_speech():
         assert isinstance(sess.current_agent, EnterHandoffAgent)
 
 
+class DialogTask(AgentTask):
+    """A task that needs a user turn to complete, like a detail-capture dialog."""
+
+    def __init__(self) -> None:
+        super().__init__(instructions="dialog task")
+
+    async def on_enter(self) -> None:
+        self.session.generate_reply(instructions="dialog_greeting")
+
+    @function_tool
+    async def finish(self, ctx: RunContext) -> str:
+        """Called to complete the dialog."""
+        self.complete(None)
+        return "done"
+
+
+class ParallelDialogAgent(Agent):
+    """Two tools that each await an AgentTask, for an LLM turn that calls both."""
+
+    def __init__(self) -> None:
+        super().__init__(instructions="root agent")
+        self.outcomes: list[str] = []
+
+    @function_tool
+    async def open_name_dialog(self, ctx: RunContext) -> str:
+        """Collects the name."""
+        return await self._open("name")
+
+    @function_tool
+    async def open_email_dialog(self, ctx: RunContext) -> str:
+        """Collects the email."""
+        return await self._open("email")
+
+    async def _open(self, which: str) -> str:
+        # a refusal is reported back as the tool's output, the way the model would see
+        # it; re-raising would instead surface through the awaiting session.run()
+        try:
+            await DialogTask()
+        except ToolError as e:
+            self.outcomes.append(f"{which}:refused")
+            return f"{which} refused: {e}"
+        self.outcomes.append(f"{which}:ran")
+        return f"{which} captured"
+
+
+@pytest.mark.asyncio
+async def test_parallel_agent_tasks_run_in_turn() -> None:
+    """Two AgentTasks awaited from one turn's parallel tool calls both pause the same
+    activity, so they queue and run one after the other. Running them concurrently would
+    leave every handoff but the last overwritten, and those tasks waiting on a result
+    nothing can produce - function calls that never return and a speech that never ends."""
+    llm = FakeLLM(
+        fake_responses=[
+            # one turn, two tool calls - each tool awaits a DialogTask
+            FakeLLMResponse(
+                input="go",
+                content="",
+                ttft=0,
+                duration=0,
+                tool_calls=[
+                    FunctionToolCall(name="open_name_dialog", arguments="{}", call_id="call_1"),
+                    FunctionToolCall(name="open_email_dialog", arguments="{}", call_id="call_2"),
+                ],
+            ),
+            FakeLLMResponse(input="dialog_greeting", content="what is it?", ttft=0, duration=0),
+            # each dialog completes on its own user turn
+            FakeLLMResponse(
+                input="done",
+                content="",
+                ttft=0,
+                duration=0,
+                tool_calls=[FunctionToolCall(name="finish", arguments="{}", call_id="call_3")],
+            ),
+        ]
+    )
+    agent = ParallelDialogAgent()
+    sess = AgentSession(llm=llm)
+    try:
+        await sess.start(agent)
+
+        await asyncio.wait_for(sess.run(user_input="go"), timeout=5.0)
+        first = sess.current_agent
+        assert isinstance(first, DialogTask)
+
+        # the first dialog hands back, and the one queued behind it takes the activity
+        await asyncio.wait_for(sess.run(user_input="done"), timeout=5.0)
+        second = sess.current_agent
+        assert isinstance(second, DialogTask) and second is not first
+
+        await asyncio.wait_for(sess.run(user_input="done"), timeout=5.0)
+        assert isinstance(sess.current_agent, ParallelDialogAgent)
+    finally:
+        # a queued task that hung instead of running would leave its function call
+        # unfinished and the close waiting on it - bounded so that regression reports
+        # these assertions rather than stalling the loop with nothing left to schedule
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(sess.aclose(), timeout=30.0)
+
+    assert sorted(agent.outcomes) == ["email:ran", "name:ran"]
+
+    # both calls carry an output: neither func_exec was left awaiting a result forever
+    outputs = {
+        item.call_id: item.output
+        for item in agent.chat_ctx.items
+        if item.type == "function_call_output" and item.call_id in ("call_1", "call_2")
+    }
+    assert set(outputs) == {"call_1", "call_2"}
+    assert not any("refused" in out for out in outputs.values())
+
+
 def _build_fake_llm() -> FakeLLM:
     return FakeLLM(
         fake_responses=[
@@ -204,3 +315,53 @@ def _build_fake_llm() -> FakeLLM:
             ),
         ]
     )
+
+
+@pytest.mark.asyncio
+async def test_nested_agent_task_from_a_later_turn() -> None:
+    """The nested task is awaited from a tool call that arrives on a user turn after the
+    outer task is already running, rather than from the outer task's own on_enter reply.
+
+    The tool of a later turn runs in a task the outer handoff never created, so it does
+    not inherit the outer's floor hold and has to be let past it explicitly - otherwise
+    it waits for a release that only its own completion can produce."""
+    llm = FakeLLM(
+        fake_responses=[
+            FakeLLMResponse(
+                input="go",
+                content="",
+                ttft=0,
+                duration=0,
+                tool_calls=[FunctionToolCall(name="start_outer", arguments="{}", call_id="call_1")],
+            ),
+            # the outer task only asks a question on entry - no tool call this turn
+            FakeLLMResponse(
+                input="outer_greeting", content="what is your name?", ttft=0, duration=0
+            ),
+            # the nested handoff is triggered by this later user turn
+            FakeLLMResponse(
+                input="Dana",
+                content="",
+                ttft=0,
+                duration=0,
+                tool_calls=[FunctionToolCall(name="start_inner", arguments="{}", call_id="call_2")],
+            ),
+            FakeLLMResponse(
+                input="inner_greeting", content="and your date of birth?", ttft=0, duration=0
+            ),
+        ]
+    )
+    sess = AgentSession(llm=llm)
+    try:
+        await sess.start(RootAgent())
+
+        await asyncio.wait_for(sess.run(user_input="go"), timeout=5.0)
+        assert isinstance(sess.current_agent, OuterTask)
+
+        await asyncio.wait_for(sess.run(user_input="Dana"), timeout=5.0)
+        assert isinstance(sess.current_agent, InnerTask)
+    finally:
+        # a nested task that never got the floor leaves its function call unfinished and
+        # the close waiting on it - bounded so a regression reports the assertion above
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(sess.aclose(), timeout=30.0)


### PR DESCRIPTION
Inline `AgentTask`s awaited from one turn's parallel tool calls now queue for a slot on the activity they pause and take it in turn, instead of overwriting each other's handoffs and leaving the session wedged until close times out; scoping the slot to the activity is what keeps a nested task, which pauses a different one, from waiting on its parent. Supersedes #6860.
