### PR TITLE
feat: correlate inference requests with session ids

### DIFF
--- a/livekit-agents/livekit/agents/inference/_utils.py
+++ b/livekit-agents/livekit/agents/inference/_utils.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 
 from livekit import api
 
+from ..utils.misc import shortuuid
 from ..version import __version__
 
 DEFAULT_INFERENCE_URL = "https://agent-gateway.livekit.cloud/v1"
@@ -16,6 +17,7 @@ HEADER_USER_AGENT = "User-Agent"
 HEADER_ROOM_ID = "X-LiveKit-Room-ID"
 HEADER_JOB_ID = "X-LiveKit-Job-ID"
 HEADER_AGENT_ID = "X-LiveKit-Agent-ID"
+HEADER_SESSION_ID = "X-LiveKit-Session-ID"
 HEADER_WORKER_TOKEN = "X-LiveKit-Worker-Token"
 HEADER_INFERENCE_PROVIDER = "X-LiveKit-Inference-Provider"
 HEADER_INFERENCE_PRIORITY = "X-LiveKit-Inference-Priority"
@@ -71,13 +73,14 @@ def get_inference_headers(*, inference_class: str | None = None) -> dict[str, st
     """Build identification headers for inference requests.
 
     Always includes User-Agent with SDK version and Python version.
-    Includes X-LiveKit-Room-ID, X-LiveKit-Job-ID, and X-LiveKit-Agent-ID
-    when running inside a job context (omitted in console mode or tests).
+    Includes X-LiveKit-Room-ID, X-LiveKit-Job-ID, X-LiveKit-Agent-ID, and a
+    client-generated X-LiveKit-Session-ID when running inside a job context
+    (omitted in console mode or tests).
     Includes X-LiveKit-Worker-Token when LIVEKIT_WORKER_TOKEN is set (hosted agents).
 
     ``inference_class`` is the class the caller configured, if any; it lands in
     X-LiveKit-Inference-Priority. A job can override it through
-    :attr:`JobContext.inference_headers`, which is merged last.
+    :attr:`JobContext.inference_headers`. The SDK-owned session ID remains reserved.
     """
     headers: dict[str, str] = {
         HEADER_USER_AGENT: (f"LiveKit Agents/{__version__} (python {platform.python_version()})"),
@@ -106,10 +109,24 @@ def get_inference_headers(*, inference_class: str | None = None) -> dict[str, st
         # merged last: what the job asserts about itself outranks what an individual
         # model was configured with.
         headers.update(ctx.inference_headers)
+        # The session ID identifies this outbound HTTP request or WebSocket
+        # connection. It is SDK-owned so custom inference headers cannot replace it.
+        headers[HEADER_SESSION_ID] = shortuuid("inference_")
     except RuntimeError:
         pass
 
     return headers
+
+
+def create_inference_request_id(
+    session_id: str | None,
+    inference_type: str,
+    *,
+    fallback_prefix: str = "",
+) -> str:
+    """Create a logical request ID linked to its inference connection."""
+    prefix = f"{session_id}_{inference_type}_" if session_id else fallback_prefix
+    return shortuuid(prefix)
 
 
 def create_access_token(api_key: str | None, api_secret: str | None, ttl: float = 600) -> str:

--- a/livekit-agents/livekit/agents/inference/_utils.py
+++ b/livekit-agents/livekit/agents/inference/_utils.py
@@ -121,12 +121,12 @@ def get_inference_headers(*, inference_class: str | None = None) -> dict[str, st
 
 def create_inference_request_id(
     session_id: str | None,
-    inference_type: Literal["tts", "eot"],
+    request_kind: Literal["tts", "eot"],
     *,
     fallback_prefix: str = "",
 ) -> str:
     """Create a logical request ID linked to its inference connection."""
-    prefix = f"{session_id}_{inference_type}_" if session_id else fallback_prefix
+    prefix = f"{session_id}_{request_kind}_" if session_id else fallback_prefix
     return shortuuid(prefix)
 
 

--- a/livekit-agents/livekit/agents/inference/_utils.py
+++ b/livekit-agents/livekit/agents/inference/_utils.py
@@ -4,6 +4,7 @@ import datetime
 import os
 import platform
 from collections.abc import Mapping
+from typing import Literal
 
 from livekit import api
 
@@ -120,7 +121,7 @@ def get_inference_headers(*, inference_class: str | None = None) -> dict[str, st
 
 def create_inference_request_id(
     session_id: str | None,
-    inference_type: str,
+    inference_type: Literal["tts", "eot"],
     *,
     fallback_prefix: str = "",
 ) -> str:

--- a/livekit-agents/livekit/agents/inference/eot/base.py
+++ b/livekit-agents/livekit/agents/inference/eot/base.py
@@ -15,7 +15,6 @@ from typing import Literal, Protocol, runtime_checkable
 
 from livekit import rtc
 
-from ... import utils
 from ..._exceptions import APITimeoutError
 from ...language import LanguageCode
 from ...log import logger
@@ -25,6 +24,7 @@ from ...types import (
 )
 from ...utils import aio
 from ...voice.turn import TurnDetectionEvent
+from .._utils import create_inference_request_id
 from .languages import ThresholdOptions, TurnDetectorModels
 
 DEFAULT_SAMPLE_RATE: int = 16000
@@ -45,6 +45,9 @@ class TurnDetectorOptions:
 
 @runtime_checkable
 class _StreamingTurnDetectionTransport(Protocol):
+    @property
+    def session_id(self) -> str | None: ...
+
     async def run(self) -> None: ...
 
     def run_inference(self, request_id: str) -> None: ...
@@ -175,7 +178,11 @@ class _BaseStreamingTurnDetectorStream:
             return fut
 
         self.cancel_inference()  # supersede any previous request
-        self._request_id = utils.shortuuid("turn_request_")
+        self._request_id = create_inference_request_id(
+            self._transport.session_id,
+            "eot",
+            fallback_prefix="turn_request_",
+        )
         self._request_fut = asyncio.get_running_loop().create_future()
         self._transport.run_inference(self._request_id)
         return self._request_fut

--- a/livekit-agents/livekit/agents/inference/eot/transports.py
+++ b/livekit-agents/livekit/agents/inference/eot/transports.py
@@ -40,7 +40,7 @@ from ...metrics import EOTInferenceMetrics
 from ...metrics.base import Metadata
 from ...types import APIConnectOptions
 from ...utils import aio, is_given
-from .._utils import create_access_token, get_inference_headers
+from .._utils import HEADER_SESSION_ID, create_access_token, get_inference_headers
 from .base import (
     DEFAULT_SAMPLE_RATE,
     TurnDetectorOptions,
@@ -93,10 +93,15 @@ class _CloudTransport:
         self._conn_options = cloud_opts.conn_options
         self._session_holder = http_session
         self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._session_id: str | None = None
         self._num_retries = 0
 
         self._send_ch: aio.Chan[ClientMessage] | None = None
         self._stream_ref: weakref.ref[_BaseStreamingTurnDetectorStream] | None = None
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
 
     def attach(self, stream: _BaseStreamingTurnDetectorStream) -> None:
         self._stream_ref = weakref.ref(stream)
@@ -152,12 +157,14 @@ class _CloudTransport:
         base_url = self._cloud_opts.base_url
         if base_url.startswith(("http://", "https://")):
             base_url = base_url.replace("http", "ws", 1)
+        headers = self._build_auth_headers()
+        session_id = headers.get(HEADER_SESSION_ID)
 
         try:
             ws = await asyncio.wait_for(
                 self._ensure_session().ws_connect(
                     f"{base_url}/eot",
-                    headers=self._build_auth_headers(),
+                    headers=headers,
                 ),
                 self._conn_options.timeout,
             )
@@ -173,6 +180,7 @@ class _CloudTransport:
             created_at.GetCurrentTime()
             session_create_msg.created_at.CopyFrom(created_at)
             await ws.send_bytes(session_create_msg.SerializeToString())
+            self._session_id = session_id
         except aiohttp.ClientResponseError as e:
             exc = create_api_error_from_http(e.message, status=e.status)
             exc.retryable = False
@@ -368,6 +376,7 @@ class _CloudTransport:
             if self._send_ch is send_ch:
                 self._send_ch = None
             self._ws = None
+            self._session_id = None
             if ws is not None:
                 await ws.close()
 
@@ -383,6 +392,10 @@ class _LocalTransport:
         self._eot = _EOT()
         self._stream_ref: weakref.ref[_BaseStreamingTurnDetectorStream] | None = None
         self._tasks: set[asyncio.Task[Any]] = set()
+
+    @property
+    def session_id(self) -> str | None:
+        return None
 
     def attach(self, stream: _BaseStreamingTurnDetectorStream) -> None:
         self._stream_ref = weakref.ref(stream)

--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -41,7 +41,6 @@ from ..utils import (
     aio,
     http_context,
     is_given,
-    shortuuid,
 )
 from ._utils import (
     create_access_token,
@@ -769,7 +768,6 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
         self, *, model: AdaptiveInterruptionDetector, conn_options: APIConnectOptions
     ) -> None:
         super().__init__(model=model, conn_options=conn_options)
-        self._request_id = str(shortuuid("interruption_request_"))
         self._reconnect_event = asyncio.Event()
 
     def update_options(

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -30,7 +30,12 @@ from ..types import (
     TimedString,
 )
 from ..utils import is_given
-from ._utils import create_access_token, get_default_inference_url, get_inference_headers
+from ._utils import (
+    HEADER_SESSION_ID,
+    create_access_token,
+    get_default_inference_url,
+    get_inference_headers,
+)
 
 if TYPE_CHECKING:
     from ..voice.events import ConversationItemAddedEvent
@@ -1073,6 +1078,7 @@ class SpeechStream(stt.SpeechStream):
             **get_inference_headers(),
             "Authorization": f"Bearer {create_access_token(self._opts.api_key, self._opts.api_secret)}",
         }
+        session_id = headers.get(HEADER_SESSION_ID)
         try:
             ws = await asyncio.wait_for(
                 http_session.ws_connect(
@@ -1082,6 +1088,8 @@ class SpeechStream(stt.SpeechStream):
             )
             params["type"] = "session.create"
             await ws.send_str(json.dumps(params))
+            if session_id is not None:
+                self._request_id = session_id
         except aiohttp.ClientResponseError as e:
             raise create_api_error_from_http(e.message, status=e.status) from e
         except asyncio.TimeoutError as e:

--- a/livekit-agents/livekit/agents/inference/tts.py
+++ b/livekit-agents/livekit/agents/inference/tts.py
@@ -30,7 +30,13 @@ from ..types import (
     TimedString,
 )
 from ..utils import is_given
-from ._utils import create_access_token, get_default_inference_url, get_inference_headers
+from ._utils import (
+    HEADER_SESSION_ID,
+    create_access_token,
+    create_inference_request_id,
+    get_default_inference_url,
+    get_inference_headers,
+)
 
 CartesiaModels = Literal[
     "cartesia",
@@ -249,6 +255,12 @@ class _TTSOptions:
     extra_kwargs: dict[str, Any]
     fallback: NotGivenOr[list[FallbackModel]]
     conn_options: NotGivenOr[APIConnectOptions]
+
+
+@dataclass(eq=False)
+class _TTSConnection:
+    ws: aiohttp.ClientWebSocketResponse
+    session_id: str | None
 
 
 class TTS(tts.TTS):
@@ -505,7 +517,7 @@ class TTS(tts.TTS):
             conn_options=conn_options if is_given(conn_options) else DEFAULT_API_CONNECT_OPTIONS,
         )
         self._session = http_session
-        self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
+        self._pool = utils.ConnectionPool[_TTSConnection](
             connect_cb=self._connect_ws,
             close_cb=self._close_ws,
             max_session_duration=300,
@@ -551,7 +563,7 @@ class TTS(tts.TTS):
     def provider(self) -> str:
         return "livekit"
 
-    async def _connect_ws(self, timeout: float) -> aiohttp.ClientWebSocketResponse:
+    async def _connect_ws(self, timeout: float) -> _TTSConnection:
         session = self._ensure_session()
         base_url = self._opts.base_url
         if base_url.startswith(("http://", "https://")):
@@ -561,6 +573,7 @@ class TTS(tts.TTS):
             **get_inference_headers(),
             "Authorization": f"Bearer {create_access_token(self._opts.api_key, self._opts.api_secret)}",
         }
+        session_id = headers.get(HEADER_SESSION_ID)
         ws = None
         try:
             ws = await asyncio.wait_for(
@@ -613,10 +626,10 @@ class TTS(tts.TTS):
                 "failed to send session.create message to LiveKit Inference TTS"
             ) from e
 
-        return ws
+        return _TTSConnection(ws=ws, session_id=session_id)
 
-    async def _close_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:
-        await ws.close()
+    async def _close_ws(self, connection: _TTSConnection) -> None:
+        await connection.ws.close()
 
     def _ensure_session(self) -> aiohttp.ClientSession:
         if not self._session:
@@ -693,14 +706,7 @@ class SynthesizeStream(tts.SynthesizeStream):
         self._held_tokens: list[TimedString] = []
 
     async def _run(self, output_emitter: tts.AudioEmitter) -> None:
-        request_id = utils.shortuuid()
-        output_emitter.initialize(
-            request_id=request_id,
-            sample_rate=self._opts.sample_rate,
-            num_channels=1,
-            stream=True,
-            mime_type="audio/pcm",
-        )
+        request_id = ""
 
         # chunking defaults (cap + expressive batch size) live in _provider_format
         from ..tts._provider_format import sentence_tokenizer
@@ -814,9 +820,18 @@ class SynthesizeStream(tts.SynthesizeStream):
                     raise APIError(f"LiveKit Inference TTS returned error: {msg.data}")
 
         try:
-            async with self._tts._pool.connection(timeout=self._conn_options.timeout) as ws:
+            async with self._tts._pool.connection(timeout=self._conn_options.timeout) as connection:
                 self._acquire_time = self._tts._pool.last_acquire_time
                 self._connection_reused = self._tts._pool.last_connection_reused
+                request_id = create_inference_request_id(connection.session_id, "tts")
+                output_emitter.initialize(
+                    request_id=request_id,
+                    sample_rate=self._opts.sample_rate,
+                    num_channels=1,
+                    stream=True,
+                    mime_type="audio/pcm",
+                )
+                ws = connection.ws
                 tasks = [
                     asyncio.create_task(_input_task()),
                     asyncio.create_task(_sentence_stream_task(ws)),

--- a/tests/test_audio_turn_detector_fallback.py
+++ b/tests/test_audio_turn_detector_fallback.py
@@ -85,6 +85,7 @@ class _ScriptedTransport:
     ) -> None:
         self.run_behavior = run_behavior  # "idle" | "raise" | "return"
         self.run_exc = run_exc
+        self.session_id: str | None = None
         self.run_calls = 0
         self.stream_ref: Any = None
         self.events: list[tuple[str, Any]] = []

--- a/tests/test_inference_llm_retry.py
+++ b/tests/test_inference_llm_retry.py
@@ -15,8 +15,10 @@ import httpx
 import openai
 import pytest
 
-from livekit.agents import APIConnectOptions, APITimeoutError, llm
+import livekit.agents.inference.llm as inference_llm
+from livekit.agents import APIConnectionError, APIConnectOptions, APITimeoutError, llm
 from livekit.agents.inference import LLM
+from livekit.agents.inference._utils import HEADER_SESSION_ID
 from livekit.agents.metrics import LLMMetrics
 
 pytestmark = pytest.mark.unit
@@ -194,6 +196,29 @@ async def test_partial_tool_arguments_stay_retryable() -> None:
     _, attempts = await _run([_METADATA_ONLY, _TOOL_NAME, _TOOL_ARGS], max_retry=2)
 
     assert len(attempts) == 3, "arguments still streaming have reached nobody"
+
+
+@pytest.mark.asyncio
+async def test_retries_get_fresh_sdk_session_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    session_ids = iter(("inference_first", "inference_second", "inference_third"))
+    monkeypatch.setattr(
+        inference_llm,
+        "get_inference_headers",
+        lambda **_kwargs: {HEADER_SESSION_ID: next(session_ids)},
+    )
+    llm_model, attempts, _ = _llm_for(lambda _: _StallingStream([_METADATA_ONLY]))
+    llm_model._opts.extra_kwargs["extra_headers"] = {HEADER_SESSION_ID: "caller_value"}
+
+    with pytest.raises(APIConnectionError):
+        async with _drain(llm_model, max_retry=2) as stream:
+            async for _ in stream:
+                pass
+
+    assert [request.headers[HEADER_SESSION_ID] for request in attempts] == [
+        "inference_first",
+        "inference_second",
+        "inference_third",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_inference_stt_start_of_speech.py
+++ b/tests/test_inference_stt_start_of_speech.py
@@ -12,6 +12,9 @@ from types import SimpleNamespace
 
 import pytest
 
+import livekit.agents.inference.stt as inference_stt
+from livekit.agents import APIConnectOptions
+from livekit.agents.inference._utils import HEADER_SESSION_ID
 from livekit.agents.inference.stt import SpeechStream as InferenceSpeechStream
 from livekit.agents.stt import SpeechEventType
 from livekit.agents.utils.aio.channel import Chan, ChanEmpty
@@ -112,3 +115,49 @@ def test_onset_resets_after_the_turn_ends() -> None:
 
     stream._process_start_of_speech()
     assert SpeechEventType.START_OF_SPEECH in _drain(stream)
+
+
+async def test_connection_session_id_becomes_fallback_request_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeWebSocket:
+        async def send_str(self, data: str) -> None:
+            pass
+
+    class _FakeHTTPSession:
+        def __init__(self) -> None:
+            self.headers: dict[str, str] = {}
+
+        async def ws_connect(self, url: str, *, headers: dict[str, str]) -> _FakeWebSocket:
+            self.headers = headers
+            return _FakeWebSocket()
+
+    stream = InferenceSpeechStream.__new__(InferenceSpeechStream)
+    stream._stt = SimpleNamespace(_session_keyterms=[])
+    stream._opts = SimpleNamespace(
+        sample_rate=16000,
+        encoding="pcm_s16le",
+        extra_kwargs={},
+        model="auto",
+        language=None,
+        fallback=None,
+        conn_options=None,
+        base_url="https://example.livekit.cloud/v1",
+        api_key="key",
+        api_secret="secret",
+    )
+    stream._conn_options = APIConnectOptions(timeout=1.0, max_retry=0)
+    stream._request_id = "stt_request_fallback"
+    http_session = _FakeHTTPSession()
+
+    monkeypatch.setattr(
+        inference_stt,
+        "get_inference_headers",
+        lambda: {HEADER_SESSION_ID: "inference_connection"},
+    )
+    monkeypatch.setattr(inference_stt, "create_access_token", lambda *_args: "token")
+
+    await stream._connect_ws(http_session)  # type: ignore[arg-type]
+
+    assert http_session.headers[HEADER_SESSION_ID] == "inference_connection"
+    assert stream._request_id == "inference_connection"

--- a/tests/test_inference_tts_alignment.py
+++ b/tests/test_inference_tts_alignment.py
@@ -9,7 +9,9 @@ from typing import Any
 import aiohttp
 import pytest
 
+import livekit.agents.inference.tts as inference_tts
 from livekit.agents import APIConnectOptions
+from livekit.agents.inference._utils import HEADER_SESSION_ID
 from livekit.agents.inference.tts import TTS
 from livekit.agents.types import USERDATA_TIMED_TRANSCRIPT
 
@@ -34,17 +36,19 @@ class _FakeWebSocket:
 
 
 class _FakePool:
-    def __init__(self, websocket: _FakeWebSocket) -> None:
+    def __init__(self, websocket: _FakeWebSocket, *, session_id: str | None = None) -> None:
         self._websocket = websocket
+        self._session_id = session_id
         self.last_acquire_time = 0.0
         self.last_connection_reused = False
 
     def connection(self, *, timeout: float):  # noqa: ANN201, ARG002
         websocket = self._websocket
+        session_id = self._session_id
 
         class _Context:
             async def __aenter__(self):  # noqa: ANN204
-                return websocket
+                return SimpleNamespace(ws=websocket, session_id=session_id)
 
             async def __aexit__(self, *_exc: object) -> bool:  # noqa: ANN204
                 return False
@@ -77,7 +81,7 @@ async def test_cartesia_inference_preserves_word_separators() -> None:
         base_url="https://example.livekit.cloud",
         extra_kwargs={"add_timestamps": True},
     )
-    tts._pool = _FakePool(websocket)  # type: ignore[assignment]
+    tts._pool = _FakePool(websocket, session_id="inference_connection")  # type: ignore[assignment]
 
     async with tts.stream(conn_options=APIConnectOptions(max_retry=0, timeout=1.0)) as stream:
         stream.push_text("hello world.")
@@ -90,8 +94,42 @@ async def test_cartesia_inference_preserves_word_separators() -> None:
         for timed_text in event.frame.userdata[USERDATA_TIMED_TRANSCRIPT]
     ]
 
+    assert all(event.request_id.startswith("inference_connection_tts_") for event in events)
     assert list(map(str, timed_transcript)) == ["hello ", "world. "]
     assert [(word.start_time, word.end_time) for word in timed_transcript] == [
         (0.0, 0.2),
         (0.2, 0.5),
     ]
+
+
+async def test_connection_retains_header_session_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    websocket = _FakeWebSocket([])
+
+    class _FakeHTTPSession:
+        def __init__(self) -> None:
+            self.headers: dict[str, str] = {}
+
+        async def ws_connect(self, url: str, *, headers: dict[str, str]) -> _FakeWebSocket:
+            self.headers = headers
+            return websocket
+
+    http_session = _FakeHTTPSession()
+    tts = TTS(
+        model="cartesia/sonic-3",
+        api_key="test-key",
+        api_secret="test-secret",
+        base_url="https://example.livekit.cloud",
+        http_session=http_session,  # type: ignore[arg-type]
+    )
+    monkeypatch.setattr(
+        inference_tts,
+        "get_inference_headers",
+        lambda: {HEADER_SESSION_ID: "inference_connection"},
+    )
+    monkeypatch.setattr(inference_tts, "create_access_token", lambda *_args: "token")
+
+    connection = await tts._connect_ws(timeout=1.0)
+
+    assert http_session.headers[HEADER_SESSION_ID] == "inference_connection"
+    assert connection.session_id == "inference_connection"
+    assert connection.ws is websocket

--- a/tests/test_inference_utils.py
+++ b/tests/test_inference_utils.py
@@ -1,19 +1,75 @@
-"""Unit tests for LiveKit Inference quota telemetry."""
+"""Unit tests for shared LiveKit Inference request metadata."""
 
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 
 import httpx
 import openai
 import pytest
 
+import livekit.agents.inference._utils as inference_utils
+import livekit.agents.job as job_module
 from livekit.agents.inference._utils import (
+    HEADER_SESSION_ID,
+    create_inference_request_id,
     extract_quota_usage,
+    get_inference_headers,
 )
 from livekit.agents.inference.llm import LLMStream
 
 pytestmark = pytest.mark.unit
+
+
+def test_inference_session_id_is_omitted_without_job_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _no_job_context() -> None:
+        raise RuntimeError("no job context")
+
+    monkeypatch.setattr(job_module, "get_job_context", _no_job_context)
+
+    assert HEADER_SESSION_ID not in get_inference_headers()
+
+
+def test_inference_session_id_is_fresh_and_sdk_owned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    room = SimpleNamespace(sid="RM_test", isconnected=lambda: False)
+    ctx = SimpleNamespace(
+        job=SimpleNamespace(id="job_test", room=room),
+        room=room,
+        inference_headers={HEADER_SESSION_ID: "caller_value"},
+    )
+    suffixes = iter(("first", "second"))
+
+    monkeypatch.setattr(job_module, "get_job_context", lambda: ctx)
+    monkeypatch.setattr(
+        inference_utils,
+        "shortuuid",
+        lambda prefix="": prefix + next(suffixes),
+    )
+
+    first = get_inference_headers()
+    second = get_inference_headers()
+
+    assert first[HEADER_SESSION_ID] == "inference_first"
+    assert second[HEADER_SESSION_ID] == "inference_second"
+
+
+def test_inference_request_id_links_to_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        inference_utils,
+        "shortuuid",
+        lambda prefix="": prefix + "suffix",
+    )
+
+    assert create_inference_request_id("inference_parent", "tts") == "inference_parent_tts_suffix"
+    assert (
+        create_inference_request_id(None, "eot", fallback_prefix="turn_request_")
+        == "turn_request_suffix"
+    )
 
 
 def test_extract_quota_usage_returns_all_stamped_dimensions() -> None:

--- a/tests/test_turn_detection_fsm.py
+++ b/tests/test_turn_detection_fsm.py
@@ -33,6 +33,7 @@ class _FakeTransport:
     def __init__(self) -> None:
         self.events: list[tuple[str, ...]] = []
         self._stream: _BaseStreamingTurnDetectorStream | None = None
+        self.session_id: str | None = None
 
     def attach(self, stream: _BaseStreamingTurnDetectorStream) -> None:
         self._stream = stream
@@ -93,6 +94,16 @@ class TestAudioTurnDetectionRequests:
             assert s._request_id is not None
             assert not fut.done()
             assert s.events == [("run_inference", s._request_id)]
+        finally:
+            await s.aclose()
+
+    async def test_predict_links_request_to_inference_session(self) -> None:
+        s = _make_stream()
+        s._fake_transport.session_id = "inference_connection"
+        try:
+            s.predict()
+            assert s._request_id is not None
+            assert s._request_id.startswith("inference_connection_eot_")
         finally:
             await s.aclose()
 


### PR DESCRIPTION
Inference gateway calls need a correlation key that follows each transport lifecycle. Session IDs are SDK-owned.

**In-job correlation:**

| Component | Session header (`key: value`) | Session scope | Per-request ID pattern |
| --- | --- | --- | --- |
| STT | `X-LiveKit-Session-ID: inference_<hex12>` | WebSocket | Service-defined; fallback: session ID |
| TTS | `X-LiveKit-Session-ID: inference_<hex12>` | Pooled WebSocket | `inference_<hex12>_tts_<hex12>` per synthesis |
| LLM | `X-LiveKit-Session-ID: inference_<hex12>` | HTTP attempt | Service-defined; no derived SDK ID |
| EOT | `X-LiveKit-Session-ID: inference_<hex12>` | WebSocket | `inference_<hex12>_eot_<hex12>` per prediction |
| Barge-in | `X-LiveKit-Session-ID: inference_<hex12>` | WebSocket | `created_at` nanoseconds per frame; no string ID |

Outside a job, no session header is sent and existing request-ID formats remain. Custom headers cannot replace the SDK-owned session ID.

Addresses LKINF-344

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> we need to pass the client side request id to inference as a session id header $grill-me
>
> I am not asking about job, I am talking about inference stt/tts/llm/eot/bargein
>
> we should change this a bit to make it semantic:
>
> - connection session id: generated once, use for the connection header (stt, tts, and llm http requests)
> - tts per request: reuse the session_id but append a suffix so as to correlate locally.
>
> _tts_ or _eot_
>
> inference_ is enough

</details>
