### PR TITLE
fix(tokenize): include the last character in the final sentence span

### DIFF
--- a/livekit-agents/livekit/agents/tokenize/_basic_sent.py
+++ b/livekit-agents/livekit/agents/tokenize/_basic_sent.py
@@ -74,6 +74,6 @@ def split_sentences(
             buff = ""
 
     if buff:
-        sentences.append((buff[len(pre_pad) :], start_pos, len(text) - 1))
+        sentences.append((buff[len(pre_pad) :], start_pos, len(text)))
 
     return sentences

--- a/tests/test_tokenize_sentence_spans.py
+++ b/tests/test_tokenize_sentence_spans.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import functools
+
+import pytest
+
+from livekit.agents.tokenize import token_stream
+from livekit.agents.tokenize._basic_sent import split_sentences
+
+pytestmark = pytest.mark.unit
+
+
+def test_basic_sent_last_span_covers_whole_text() -> None:
+    # Regression: the basic sentence splitter used to return len(text) - 1 as
+    # the end index of the final sentence, silently excluding its last
+    # character from the span.
+    text = "Hello world."
+    sentences = split_sentences(text, min_sentence_len=20)
+    assert sentences == [("Hello world.", 0, len(text))], sentences
+
+
+def test_basic_sent_last_span_multi_sentence() -> None:
+    text = "This is the first sentence. Second one here."
+    sentences = split_sentences(text, min_sentence_len=20)
+    assert sentences[-1][2] == len(text), sentences
+    assert text[sentences[-1][1] : sentences[-1][2]].strip() == sentences[-1][0]
+
+
+def test_basic_sent_xml_wrapper_keeps_last_char() -> None:
+    # The xml-aware wrapper remaps the sentence spans back onto the original
+    # text; with the old end index the final period was split into its own
+    # sentence token.
+    wrapped = token_stream._xml_wrap_tokenizer(
+        functools.partial(split_sentences, min_sentence_len=20)
+    )
+    text = "<expr type='expression' label='happy'/>Hello world."
+    toks = wrapped(text)
+    assert len(toks) == 1, toks
+    assert toks[0][0] == text
+    assert toks[0][2] == len(text)


### PR DESCRIPTION
## What this does

The basic (rule-based) sentence splitter returned `len(text) - 1` as the end index of the final sentence, so the last character of the input was always excluded from its span. That is inconsistent with the blingfire implementation (which uses `len(text)` for the tail) and with the documented return contract ("start and end indices of the original text").

It is observable in the xml-aware tokenizer wrapper used for expressive TTS: with the span stopping one character short, the final period of the last sentence was remapped into its own sentence token, e.g. `"<expr type='expression' label='happy'/>Hello world."` became `"<expr .../>Hello world"` + `"."`.

Fix: use `len(text)` for the trailing sentence's end index, matching the in-loop spans.

## How to test

- `pytest tests/test_tokenize_sentence_spans.py` - added three regression tests: the final span covers the whole text, the final span of a multi-sentence input ends at `len(text)`, and the xml-aware wrapper no longer splits the final period into its own token.
- The existing `test_tokenizer.py` expectations (token text) are unaffected; verified against the same fixture with the public `basic.SentenceTokenizer`.
- `ruff check` and `ruff format --check` pass on the changed files.
