### PR TITLE
fix(anthropic): support the Claude 4.7+ and 5 model generations

### DIFF
--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -34,16 +34,24 @@ from livekit.agents.types import (
 )
 from livekit.agents.utils import is_given
 
-from .models import ChatModels
+from .log import logger
+from .models import (
+    ChatModels,
+    _model_supports_prefill,
+    _model_supports_sampling_params,
+    _model_thinking_support,
+)
 from .utils import CACHE_CONTROL_EPHEMERAL
 
-# Claude 4.6+ no longer supports prefilling (trailing assistant messages).
-_NO_PREFILL_PATTERNS = ("claude-sonnet-4-6", "claude-opus-4-6")
+# Rejected by Claude 4.7 and later. `top_p` has no constructor argument: it can only
+# reach the request through `extra_kwargs`.
+_SAMPLING_PARAMS = ("temperature", "top_p", "top_k")
 
-
-def _model_disables_prefill(model: str) -> bool:
-    """Return True if the model does not support assistant message prefilling."""
-    return any(model.startswith(p) for p in _NO_PREFILL_PATTERNS)
+# `max_tokens` is a single ceiling over thinking *and* the reply. 1024 is plenty for a
+# spoken turn, but a model that always thinks would spend most of it reasoning and
+# return a truncated (or empty) answer, so those get more headroom.
+_DEFAULT_MAX_TOKENS = 1024
+_DEFAULT_MAX_TOKENS_THINKING = 8192
 
 
 @dataclass
@@ -99,9 +107,19 @@ class LLM(llm.LLM):
             Pass a custom ``httpx.Timeout`` to override (e.g. ``httpx.Timeout(5.0, read=60.0)``
             for very large contexts or extended thinking budgets).
         temperature (float, optional): The temperature for the Anthropic API. Defaults to None.
+            Claude 4.7 and later reject sampling parameters; on those models ``temperature``
+            and ``top_k`` are dropped from the request (with a one-time warning) instead of
+            failing it. Steer those models with the system prompt instead.
         parallel_tool_calls (bool, optional): Whether to parallelize tool calls. Defaults to None.
         tool_choice (ToolChoice, optional): The tool choice for the Anthropic API. Defaults to "auto".
         caching (Literal["ephemeral"], optional): If set to "ephemeral", caching will be enabled for the system prompt, tools, and chat history.
+
+        Thinking is disabled by default on every model that accepts the parameter: a voice
+        agent pays for it in latency and in ``max_tokens``, which caps thinking and the
+        reply together. Pass ``extra_kwargs={"thinking": {"type": "adaptive"}}`` to
+        ``chat()`` to opt back in — but note that thinking blocks are not kept in the chat
+        context, so a turn carrying a tool call is replayed without them, which Anthropic
+        can reject.
         """  # noqa: E501
 
         super().__init__()
@@ -117,6 +135,8 @@ class LLM(llm.LLM):
             max_tokens=max_tokens,
             strict_tool_schema=_strict_tool_schema,
         )
+        self._sampling_params_warned = False
+        self._thinking_tools_warned = False
         anthropic_api_key = api_key if is_given(api_key) else os.environ.get("ANTHROPIC_API_KEY")
         if not anthropic_api_key:
             raise ValueError(
@@ -168,13 +188,35 @@ class LLM(llm.LLM):
         if is_given(self._opts.user):
             extra["user"] = self._opts.user
 
-        if is_given(self._opts.temperature):
-            extra["temperature"] = self._opts.temperature
+        self._apply_sampling_params(extra)
 
-        if is_given(self._opts.top_k):
-            extra["top_k"] = self._opts.top_k
+        # Thinking costs latency and eats into max_tokens, so it is off wherever it can
+        # be turned off. `extra_kwargs` wins: it is the escape hatch for callers that do
+        # want the model to reason before answering.
+        thinking_support = _model_thinking_support(self._opts.model)
+        thinking: Any = extra.get("thinking")
+        if thinking is None and thinking_support == "configurable":
+            thinking = extra["thinking"] = {"type": "disabled"}
 
-        extra["max_tokens"] = self._opts.max_tokens if is_given(self._opts.max_tokens) else 1024
+        thinking_enabled = thinking_support == "always_on" or (
+            isinstance(thinking, dict) and thinking.get("type") != "disabled"
+        )
+
+        if thinking_enabled and tools and not self._thinking_tools_warned:
+            self._thinking_tools_warned = True
+            logger.warning(
+                "%s will reason before answering, but thinking blocks are not kept in the "
+                "chat context: the next turn replays the assistant turn without them, "
+                "which Anthropic can reject when that turn contains a tool call",
+                self._opts.model,
+            )
+
+        if is_given(self._opts.max_tokens):
+            extra["max_tokens"] = self._opts.max_tokens
+        elif "max_tokens" not in extra:
+            extra["max_tokens"] = (
+                _DEFAULT_MAX_TOKENS_THINKING if thinking_enabled else _DEFAULT_MAX_TOKENS
+            )
 
         beta_flag: str | None = None
         if tools:
@@ -218,7 +260,7 @@ class LLM(llm.LLM):
                     extra["tool_choice"] = anthropic_tool_choice
 
         # Claude 4.6+ does not support prefilling (trailing assistant messages).
-        inject_trailing = _model_disables_prefill(self._opts.model)
+        inject_trailing = not _model_supports_prefill(self._opts.model)
         anthropic_ctx, extra_data = chat_ctx.to_provider_format(
             format="anthropic", inject_trailing_user_message=inject_trailing
         )
@@ -279,7 +321,48 @@ class LLM(llm.LLM):
             chat_ctx=chat_ctx,
             tools=tools or [],
             conn_options=conn_options,
+            thinking_expected=thinking_enabled,
         )
+
+    def _apply_sampling_params(self, extra: dict[str, Any]) -> None:
+        """Add `temperature`/`top_k` to the request, unless the model rejects them.
+
+        Claude 4.7 and later answer a request carrying sampling parameters with a 400, so
+        they are dropped instead — including the ones that came in through
+        ``extra_kwargs``, which are already in ``extra`` by the time this runs. The
+        warning is logged once per instance to stay visible without flooding a
+        long-running session.
+        """
+        if _model_supports_sampling_params(self._opts.model):
+            if is_given(self._opts.temperature):
+                extra["temperature"] = self._opts.temperature
+
+            if is_given(self._opts.top_k):
+                extra["top_k"] = self._opts.top_k
+
+            return
+
+        from_extra = {name for name in _SAMPLING_PARAMS if name in extra}
+        for name in from_extra:
+            del extra[name]
+
+        from_opts = {
+            name
+            for name, value in (
+                ("temperature", self._opts.temperature),
+                ("top_k", self._opts.top_k),
+            )
+            if is_given(value)
+        }
+        dropped = [name for name in _SAMPLING_PARAMS if name in from_extra | from_opts]
+        if dropped and not self._sampling_params_warned:
+            self._sampling_params_warned = True
+            logger.warning(
+                "%s rejects sampling parameters, dropping %s from the request; "
+                "steer the model with the system prompt instead",
+                self._opts.model,
+                ", ".join(dropped),
+            )
 
 
 class LLMStream(llm.LLMStream):
@@ -293,9 +376,11 @@ class LLMStream(llm.LLMStream):
         chat_ctx: llm.ChatContext,
         tools: list[Tool],
         conn_options: APIConnectOptions,
+        thinking_expected: bool = False,
     ) -> None:
         super().__init__(llm, chat_ctx=chat_ctx, tools=tools, conn_options=conn_options)
         self._create_anthropic_stream = create_anthropic_stream
+        self._thinking_expected = thinking_expected
 
         # current function call that we're waiting for full completion (args are streamed)
         self._tool_call_id: str | None = None
@@ -304,6 +389,8 @@ class LLMStream(llm.LLMStream):
 
         self._request_id: str = ""
         self._ignoring_cot = False  # ignore chain of thought
+        self._thinking_blocks = 0
+        self._thinking_chars = 0
         self._input_tokens = 0
         self._cache_creation_tokens = 0
         self._cache_read_tokens = 0
@@ -313,17 +400,19 @@ class LLMStream(llm.LLMStream):
         """Clear the state a single attempt builds up.
 
         The base class re-enters `_run` on the same instance, and it only retries when the
-        failed attempt emitted no chunk — a stream that died mid chain-of-thought or mid
-        tool-call would otherwise carry that state into the next attempt, including the
-        `_ignoring_cot` latch that swallows text. `_input_tokens` and `_output_tokens`
-        are reassigned unconditionally at `message_start`, but the cache counters are
-        only assigned there when the new attempt reports a non-zero value, so they are
-        cleared here.
+        failed attempt emitted no chunk — a stream that died mid-thinking, mid
+        chain-of-thought or mid tool-call would otherwise carry that state into the next
+        attempt, including the `_ignoring_cot` latch that swallows text. `_input_tokens`
+        and `_output_tokens` are reassigned unconditionally at `message_start`, but the
+        cache counters are only assigned there when the new attempt reports a non-zero
+        value, so they are cleared here.
         """
         self._tool_call_id = None
         self._fnc_name = None
         self._fnc_raw_arguments = None
         self._ignoring_cot = False
+        self._thinking_blocks = 0
+        self._thinking_chars = 0
         self._cache_creation_tokens = 0
         self._cache_read_tokens = 0
 
@@ -337,6 +426,14 @@ class LLMStream(llm.LLMStream):
                     if chat_chunk is not None:
                         self._event_ch.send_nowait(chat_chunk)
                         retryable = False
+
+                if self._thinking_blocks:
+                    logger.debug(
+                        "anthropic: %s returned %d thinking block(s), %d characters",
+                        self._llm.model,
+                        self._thinking_blocks,
+                        self._thinking_chars,
+                    )
 
                 # https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#tracking-cache-performance
                 prompt_token = (
@@ -383,9 +480,18 @@ class LLMStream(llm.LLMStream):
                 self._tool_call_id = event.content_block.id
                 self._fnc_name = event.content_block.name
                 self._fnc_raw_arguments = ""
+            elif event.content_block.type in ("thinking", "redacted_thinking"):
+                self._note_thinking_block()
         elif event.type == "content_block_delta":
             delta = event.delta
-            if delta.type == "text_delta":
+            if delta.type == "thinking_delta":
+                # Reasoning is not part of the answer: it must not reach the caller (a
+                # voice agent would speak it), but it is billed and it is counted below.
+                self._thinking_chars += len(delta.thinking)
+                return None
+            elif delta.type == "signature_delta":
+                return None
+            elif delta.type == "text_delta":
                 text = delta.text
 
                 if self._tools is not None:
@@ -429,3 +535,13 @@ class LLMStream(llm.LLMStream):
                 return chat_chunk
 
         return None
+
+    def _note_thinking_block(self) -> None:
+        """Record a thinking block, warning once when one was not expected."""
+        self._thinking_blocks += 1
+        if self._thinking_blocks == 1 and not self._thinking_expected:
+            logger.warning(
+                "anthropic: %s returned a thinking block although thinking was not "
+                "requested; the reasoning is dropped but still counts against max_tokens",
+                self._llm.model,
+            )

--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/llm.py
@@ -309,8 +309,27 @@ class LLMStream(llm.LLMStream):
         self._cache_read_tokens = 0
         self._output_tokens = 0
 
+    def _reset_stream_state(self) -> None:
+        """Clear the state a single attempt builds up.
+
+        The base class re-enters `_run` on the same instance, and it only retries when the
+        failed attempt emitted no chunk — a stream that died mid chain-of-thought or mid
+        tool-call would otherwise carry that state into the next attempt, including the
+        `_ignoring_cot` latch that swallows text. `_input_tokens` and `_output_tokens`
+        are reassigned unconditionally at `message_start`, but the cache counters are
+        only assigned there when the new attempt reports a non-zero value, so they are
+        cleared here.
+        """
+        self._tool_call_id = None
+        self._fnc_name = None
+        self._fnc_raw_arguments = None
+        self._ignoring_cot = False
+        self._cache_creation_tokens = 0
+        self._cache_read_tokens = 0
+
     async def _run(self) -> None:
         retryable = True
+        self._reset_stream_state()
         try:
             async with await self._create_anthropic_stream() as stream:
                 async for event in stream:

--- a/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/models.py
+++ b/livekit-plugins/livekit-plugins-anthropic/livekit/plugins/anthropic/models.py
@@ -1,17 +1,150 @@
+from __future__ import annotations
+
+import re
 from typing import Literal
 
 # https://docs.anthropic.com/en/docs/about-claude/model-deprecations#model-status
 
 ChatModels = Literal[
-    "claude-3-5-sonnet-20240620",  # deprecated
-    "claude-3-opus-20240229",  # deprecated
-    "claude-3-5-sonnet-20241022",  # deprecated
-    "claude-3-haiku-20240307",
+    # retired: these ids are no longer served and return 404
+    "claude-3-opus-20240229",
+    "claude-3-5-sonnet-20240620",
+    "claude-3-5-sonnet-20241022",
     "claude-3-5-haiku-20241022",
     "claude-3-7-sonnet-20250219",
+    # deprecated, still served
+    "claude-3-haiku-20240307",
     "claude-sonnet-4-20250514",
-    "claude-sonnet-4-6",
     "claude-opus-4-20250514",
     "claude-opus-4-1-20250805",
+    # current
+    "claude-haiku-4-5",
+    "claude-sonnet-4-5",
+    "claude-opus-4-5",
+    "claude-sonnet-4-6",
     "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-sonnet-5",
+    "claude-opus-5",
+    # `claude-fable-5` and `claude-mythos-5` are intentionally left out: thinking cannot
+    # be turned off on them and a single request can run for minutes, which does not fit
+    # a real-time voice session.
 ]
+
+ThinkingSupport = Literal["always_on", "configurable", "unknown"]
+
+# Length of the release-date suffix that some model ids carry ("20250514").
+_DATE_SEGMENT_LEN = 8
+
+# Separators seen in the wild: "-" everywhere, "." and "/" in gateway prefixes
+# ("anthropic.claude-opus-5", "anthropic/claude-opus-5"), "@" in Vertex snapshots
+# ("claude-opus-4-5@20251101") and ":" in legacy Bedrock ARNs.
+_SEGMENT_SPLIT = re.compile(r"[-_./@:]+")
+_LEADING_DIGITS = re.compile(r"^(\d+)")
+
+# The family name anchors the version: modern ids write it before the version
+# ("claude-opus-4-6"), the legacy 3.x ids after it ("claude-3-5-sonnet-20241022").
+_FAMILIES = frozenset({"opus", "sonnet", "haiku", "fable", "mythos"})
+
+# Assistant prefilling (a trailing assistant message) was removed with the 4.6
+# generation: sending one returns a 400. See livekit/agents#4907.
+_PREFILL_REMOVED_FROM = (4, 6)
+
+# `temperature`, `top_p` and `top_k` were removed one generation later, with 4.7.
+_SAMPLING_REMOVED_FROM = (4, 7)
+
+# From 4.6 onwards every model accepts an explicit `thinking` configuration, so
+# thinking can be turned off deterministically instead of relying on the default
+# (which is "off" up to 4.8 but "adaptive" on the 5 generation).
+_THINKING_CONFIGURABLE_FROM = (4, 6)
+
+# Families whose thinking cannot be turned off: sending `{"type": "disabled"}` returns a
+# 400, so the parameter has to be omitted instead. They are not in `ChatModels`, but
+# `model` accepts any string, so the guard has to exist at runtime.
+_ALWAYS_THINKING_FAMILIES = frozenset({"fable", "mythos"})
+
+
+def _segment_version(segment: str) -> int | None:
+    """Read a version number out of one id segment, or None if it isn't one."""
+    if segment.isdigit() and len(segment) == _DATE_SEGMENT_LEN:
+        return None  # a release date ("20250514"), not a version
+
+    match = _LEADING_DIGITS.match(segment)
+    return int(match.group(1)) if match else None
+
+
+def _model_version(model: str) -> tuple[int, ...]:
+    """Read the version out of an Anthropic model id.
+
+    The version is the run of numeric segments next to the family name: after it on
+    current ids (``claude-opus-4-6``, ``claude-sonnet-5``) and before it on the legacy
+    3.x ids (``claude-3-5-sonnet-20241022``). Eight-digit segments are release dates,
+    not version numbers, and end the run.
+
+    Anchoring on the family name keeps provider-prefixed and suffixed ids working:
+    ``anthropic.claude-opus-5`` (Bedrock), ``claude-opus-4-5@20251101`` (Vertex) and a
+    proxy alias such as ``gw-1-claude-opus-5`` all resolve to the underlying model.
+
+    Returns an empty tuple for an id that hides the family name; callers then have to
+    fall back to the pre-4.6 behaviour rather than guess.
+    """
+    # A bracketed suffix ("claude-opus-5[1m]") marks a deployment variant, not a version.
+    segments = [segment for segment in _SEGMENT_SPLIT.split(model.split("[")[0].lower()) if segment]
+    family = next((i for i, segment in enumerate(segments) if segment in _FAMILIES), None)
+    if family is None:
+        return ()
+
+    after: list[int] = []
+    for segment in segments[family + 1 :]:
+        version = _segment_version(segment)
+        if version is None:
+            break
+        after.append(version)
+    if after:
+        return tuple(after)
+
+    before: list[int] = []
+    for segment in reversed(segments[:family]):
+        version = _segment_version(segment)
+        if version is None:
+            break
+        before.append(version)
+    return tuple(reversed(before))
+
+
+def _model_supports_prefill(model: str) -> bool:
+    """Whether the model accepts a prefilled (trailing) assistant message."""
+    version = _model_version(model)
+    if not version:
+        return True
+
+    return version < _PREFILL_REMOVED_FROM
+
+
+def _model_supports_sampling_params(model: str) -> bool:
+    """Whether the model accepts `temperature`, `top_p` and `top_k`."""
+    version = _model_version(model)
+    if not version:
+        return True
+
+    return version < _SAMPLING_REMOVED_FROM
+
+
+def _model_thinking_support(model: str) -> ThinkingSupport:
+    """How the model handles the `thinking` request parameter.
+
+    - ``always_on``: thinking cannot be turned off; sending `{"type": "disabled"}`
+      returns a 400, so the parameter must be omitted entirely.
+    - ``configurable``: `{"type": "disabled"}` is accepted.
+    - ``unknown``: the model predates configurable thinking, or its id could not be
+      parsed; the parameter is left out of the request.
+    """
+    if _ALWAYS_THINKING_FAMILIES.intersection(_SEGMENT_SPLIT.split(model.lower())):
+        return "always_on"
+
+    version = _model_version(model)
+    if version and version >= _THINKING_CONFIGURABLE_FROM:
+        return "configurable"
+
+    return "unknown"

--- a/livekit-plugins/livekit-plugins-anthropic/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-anthropic/pyproject.toml
@@ -21,7 +21,11 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3 :: Only",
 ]
-dependencies = ["livekit-agents>=1.7.0", "anthropic>=0.41", "httpx"]
+# `anthropic>=0.47` is the first release whose `messages.create()` accepts the
+# `thinking` parameter (and defines the thinking/signature delta events the stream
+# parser reads). `create()` has no `**kwargs`, so an older client raises a TypeError
+# on every request instead of answering.
+dependencies = ["livekit-agents>=1.7.0", "anthropic>=0.47", "httpx"]
 
 [project.urls]
 Documentation = "https://docs.livekit.io"

--- a/tests/test_plugin_anthropic.py
+++ b/tests/test_plugin_anthropic.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+import anthropic
 import httpx
 import pytest
 
 from livekit.agents import APIConnectOptions, llm
 from livekit.plugins.anthropic.llm import LLMStream
 
-pytestmark = pytest.mark.plugin("anthropic")
+# these tests are hermetic (fake client, no API key, no network), so they belong to the
+# `unit` category that CI actually runs — no job in `.github/workflows` runs `--plugin`
+pytestmark = pytest.mark.unit
 
 
 def _make_llm(**kwargs):
@@ -86,6 +91,18 @@ class _EmptyAnthropicStream:
         raise StopAsyncIteration
 
 
+class _ScriptedAnthropicStream(_EmptyAnthropicStream):
+    """Yields the given events, then raises — the shape of a stream dying mid-turn."""
+
+    def __init__(self, events: list[Any]) -> None:
+        self._events = list(events)
+
+    async def __anext__(self):
+        if self._events:
+            return self._events.pop(0)
+        raise RuntimeError("stream died mid-turn")
+
+
 class TestAnthropicStreamRetry:
     @pytest.mark.asyncio
     async def test_retry_creates_a_fresh_stream_awaitable(self) -> None:
@@ -114,3 +131,90 @@ class TestAnthropicStreamRetry:
 
         assert calls == 2
         assert response.usage is not None
+
+
+class TestPerAttemptState:
+    """`_run` is re-entered on every retry with the same instance."""
+
+    async def _collect_after_one_failed_attempt(
+        self, first_attempt_events: list[Any]
+    ) -> tuple[LLMStream, llm.CollectedResponse]:
+        attempts = 0
+
+        async def create_stream():
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                return _ScriptedAnthropicStream(first_attempt_events)
+            return _EmptyAnthropicStream()
+
+        stream = LLMStream(
+            _make_llm(),
+            create_anthropic_stream=create_stream,
+            chat_ctx=llm.ChatContext.empty(),
+            tools=[],
+            conn_options=APIConnectOptions(max_retry=1, retry_interval=0),
+        )
+        response = await stream.collect()
+        assert attempts == 2
+        return stream, response
+
+    @pytest.mark.asyncio
+    async def test_chain_of_thought_latch_does_not_survive_a_retry(self) -> None:
+        """Left set, it would swallow every text chunk of the successful attempt."""
+        cot = anthropic.types.RawContentBlockDeltaEvent(
+            type="content_block_delta",
+            index=0,
+            delta=anthropic.types.TextDelta(type="text_delta", text="<thinking>reasoning"),
+        )
+
+        stream, _ = await self._collect_after_one_failed_attempt([cot])
+
+        assert stream._ignoring_cot is False
+
+    @pytest.mark.asyncio
+    async def test_half_read_tool_call_does_not_survive_a_retry(self) -> None:
+        start = anthropic.types.RawContentBlockStartEvent(
+            type="content_block_start",
+            index=0,
+            content_block=anthropic.types.ToolUseBlock(
+                type="tool_use", id="toolu_1", name="lookup_order", input={}
+            ),
+        )
+
+        stream, _ = await self._collect_after_one_failed_attempt([start])
+
+        assert stream._tool_call_id is None
+        assert stream._fnc_name is None
+        assert stream._fnc_raw_arguments is None
+
+    @pytest.mark.asyncio
+    async def test_cache_token_counters_do_not_survive_a_retry(self) -> None:
+        """`message_start` only reassigns them when non-zero, so a stale write is double-counted."""
+        # input_tokens is left at 0 so prompt_tokens reflects the cache counters alone
+        start = anthropic.types.RawMessageStartEvent(
+            type="message_start",
+            message=anthropic.types.Message(
+                id="msg_1",
+                type="message",
+                role="assistant",
+                model="claude-opus-5",
+                content=[],
+                usage=anthropic.types.Usage(
+                    input_tokens=0,
+                    output_tokens=0,
+                    cache_creation_input_tokens=1000,
+                    cache_read_input_tokens=500,
+                ),
+            ),
+        )
+
+        stream, response = await self._collect_after_one_failed_attempt([start])
+
+        assert response.usage is not None
+        assert response.usage.cache_creation_tokens == 0
+        assert response.usage.cache_read_tokens == 0
+        assert response.usage.prompt_cached_tokens == 0
+        assert response.usage.prompt_tokens == 0
+        assert stream._cache_creation_tokens == 0
+        assert stream._cache_read_tokens == 0

--- a/tests/test_plugin_anthropic.py
+++ b/tests/test_plugin_anthropic.py
@@ -2,14 +2,21 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import anthropic
 import httpx
 import pytest
 
-from livekit.agents import APIConnectOptions, llm
+from livekit.agents import APIConnectOptions, function_tool, llm
 from livekit.plugins.anthropic.llm import LLMStream
+from livekit.plugins.anthropic.models import (
+    _model_supports_prefill,
+    _model_supports_sampling_params,
+    _model_thinking_support,
+    _model_version,
+)
 
 # these tests are hermetic (fake client, no API key, no network), so they belong to the
 # `unit` category that CI actually runs — no job in `.github/workflows` runs `--plugin`
@@ -133,6 +140,455 @@ class TestAnthropicStreamRetry:
         assert response.usage is not None
 
 
+class _RecordingAnthropicClient:
+    """Stand-in for anthropic.AsyncClient that records the request it was handed."""
+
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self._base_url = httpx.URL("https://api.anthropic.com")
+        outer = self
+
+        class _Messages:
+            async def create(self, **kwargs: Any) -> _EmptyAnthropicStream:
+                outer.requests.append(kwargs)
+                return _EmptyAnthropicStream()
+
+        self.messages = _Messages()
+
+
+async def _request_for(model: str, *, chat_ctx: llm.ChatContext | None = None, **kwargs: Any):
+    """Run one chat() round-trip against a fake client and return the request payload."""
+    client = _RecordingAnthropicClient()
+    anthropic_llm = _make_llm(model=model, client=client, **kwargs)
+    await anthropic_llm.chat(chat_ctx=chat_ctx or llm.ChatContext.empty()).collect()
+    assert len(client.requests) == 1
+    return client.requests[0]
+
+
+class TestModelVersionParsing:
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("claude-opus-4-6", (4, 6)),
+            ("claude-sonnet-4-6", (4, 6)),
+            ("claude-opus-4-8", (4, 8)),
+            ("claude-opus-5", (5,)),
+            ("claude-sonnet-5", (5,)),
+            ("claude-fable-5", (5,)),
+            ("claude-haiku-4-5", (4, 5)),
+            # the trailing 8-digit segment is a release date, not a version
+            ("claude-sonnet-4-20250514", (4,)),
+            ("claude-opus-4-1-20250805", (4, 1)),
+            ("claude-3-5-sonnet-20241022", (3, 5)),
+            ("claude-3-haiku-20240307", (3,)),
+            # provider prefixes and snapshot suffixes must not shift the version
+            ("anthropic.claude-opus-5", (5,)),
+            ("anthropic/claude-opus-4-6", (4, 6)),
+            ("claude-opus-4-5@20251101", (4, 5)),  # Vertex snapshot
+            ("claude-opus-5[1m]", (5,)),
+            ("claude-opus-4-6-fast", (4, 6)),
+            ("anthropic.claude-3-5-sonnet-20241022-v2:0", (3, 5)),  # legacy Bedrock ARN
+            # a number in a proxy's own name is not the model's version
+            ("gw-1-claude-opus-5", (5,)),
+            # gateway / proxy aliases that hide the family carry no version at all
+            ("my-claude-proxy", ()),
+        ],
+    )
+    def test_version_is_read_from_the_id(self, model: str, expected: tuple[int, ...]) -> None:
+        assert _model_version(model) == expected
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "anthropic.claude-opus-5",
+            "anthropic/claude-opus-4-6",
+            "claude-opus-5[1m]",
+            "gw-1-claude-opus-5",
+        ],
+    )
+    def test_prefixed_and_suffixed_ids_keep_the_4_6_guards(self, model: str) -> None:
+        """A misparsed id silently re-enables prefilling — the 400 this guard exists for."""
+        assert not _model_supports_prefill(model)
+
+
+class TestPrefillGuard:
+    """Regression guard for livekit/agents#4907 (400 on prefilled assistant messages)."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-sonnet-4-6",
+            "claude-opus-4-6",
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "claude-opus-5",
+            "claude-sonnet-5",
+            "claude-fable-5",
+        ],
+    )
+    def test_prefill_rejected_from_4_6_onwards(self, model: str) -> None:
+        assert not _model_supports_prefill(model)
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-haiku-4-5",
+            "claude-sonnet-4-5",
+            "claude-sonnet-4-20250514",
+            "claude-opus-4-1-20250805",
+            "claude-3-5-sonnet-20241022",
+            # an unrecognised id keeps the behaviour it had before the guard existed
+            "my-claude-proxy",
+        ],
+    )
+    def test_prefill_still_allowed_elsewhere(self, model: str) -> None:
+        assert _model_supports_prefill(model)
+
+    @pytest.mark.asyncio
+    async def test_trailing_assistant_message_is_closed_with_a_user_turn(self) -> None:
+        chat_ctx = llm.ChatContext.empty()
+        chat_ctx.add_message(role="user", content="hello")
+        chat_ctx.add_message(role="assistant", content="prefilled")
+
+        request = await _request_for("claude-opus-5", chat_ctx=chat_ctx)
+        assert request["messages"][-1]["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_prefill_is_preserved_on_older_models(self) -> None:
+        chat_ctx = llm.ChatContext.empty()
+        chat_ctx.add_message(role="user", content="hello")
+        chat_ctx.add_message(role="assistant", content="prefilled")
+
+        request = await _request_for("claude-haiku-4-5", chat_ctx=chat_ctx)
+        assert request["messages"][-1]["role"] == "assistant"
+
+
+class TestSamplingParams:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "claude-opus-5",
+            "claude-sonnet-5",
+            "claude-fable-5",
+        ],
+    )
+    def test_rejected_from_4_7_onwards(self, model: str) -> None:
+        assert not _model_supports_sampling_params(model)
+
+    @pytest.mark.parametrize(
+        "model",
+        ["claude-sonnet-4-6", "claude-opus-4-6", "claude-haiku-4-5", "my-claude-proxy"],
+    )
+    def test_accepted_up_to_4_6(self, model: str) -> None:
+        assert _model_supports_sampling_params(model)
+
+    @pytest.mark.asyncio
+    async def test_dropped_from_the_request_instead_of_failing_it(self) -> None:
+        request = await _request_for("claude-opus-5", temperature=0.7, top_k=5)
+        assert "temperature" not in request
+        assert "top_k" not in request
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("param", ["temperature", "top_p", "top_k"])
+    async def test_dropped_when_they_arrive_through_extra_kwargs(self, param: str) -> None:
+        """`extra_kwargs` reaches the payload first; leaving it there still 400s."""
+        client = _RecordingAnthropicClient()
+        anthropic_llm = _make_llm(model="claude-opus-5", client=client)
+        await anthropic_llm.chat(
+            chat_ctx=llm.ChatContext.empty(), extra_kwargs={param: 0.7}
+        ).collect()
+
+        assert param not in client.requests[0]
+
+    @pytest.mark.asyncio
+    async def test_warns_about_the_ones_dropped_from_extra_kwargs(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        client = _RecordingAnthropicClient()
+        anthropic_llm = _make_llm(model="claude-opus-5", client=client)
+
+        with caplog.at_level(logging.WARNING, logger="livekit.plugins.anthropic"):
+            await anthropic_llm.chat(
+                chat_ctx=llm.ChatContext.empty(), extra_kwargs={"top_p": 0.9}
+            ).collect()
+
+        warnings = [
+            r.getMessage() for r in caplog.records if "sampling parameters" in r.getMessage()
+        ]
+        assert len(warnings) == 1
+        assert "top_p" in warnings[0]
+
+    @pytest.mark.asyncio
+    async def test_still_sent_to_models_that_accept_them(self) -> None:
+        request = await _request_for("claude-sonnet-4-6", temperature=0.7, top_k=5)
+        assert request["temperature"] == 0.7
+        assert request["top_k"] == 5
+
+    @pytest.mark.asyncio
+    async def test_warns_once_per_instance(self, caplog: pytest.LogCaptureFixture) -> None:
+        client = _RecordingAnthropicClient()
+        anthropic_llm = _make_llm(model="claude-opus-5", client=client, temperature=0.7)
+
+        with caplog.at_level(logging.WARNING, logger="livekit.plugins.anthropic"):
+            for _ in range(3):
+                await anthropic_llm.chat(chat_ctx=llm.ChatContext.empty()).collect()
+
+        warnings = [r for r in caplog.records if "sampling parameters" in r.getMessage()]
+        assert len(warnings) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_nothing_was_dropped(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger="livekit.plugins.anthropic"):
+            await _request_for("claude-opus-5")
+
+        assert not [r for r in caplog.records if "sampling parameters" in r.getMessage()]
+
+
+class TestThinking:
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("claude-sonnet-4-6", "configurable"),
+            ("claude-opus-4-8", "configurable"),
+            ("claude-opus-5", "configurable"),
+            ("claude-sonnet-5", "configurable"),
+            ("claude-fable-5", "always_on"),
+            ("claude-mythos-5", "always_on"),
+            ("claude-haiku-4-5", "unknown"),
+            ("claude-3-5-sonnet-20241022", "unknown"),
+            ("my-claude-proxy", "unknown"),
+        ],
+    )
+    def test_support_is_derived_from_the_id(self, model: str, expected: str) -> None:
+        assert _model_thinking_support(model) == expected
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("model", ["claude-sonnet-4-6", "claude-opus-4-8", "claude-opus-5"])
+    async def test_disabled_where_the_model_allows_it(self, model: str) -> None:
+        request = await _request_for(model)
+        assert request["thinking"] == {"type": "disabled"}
+
+    @pytest.mark.asyncio
+    async def test_omitted_where_it_cannot_be_disabled(self) -> None:
+        """Claude Fable rejects {"type": "disabled"} with a 400, so it must not be sent."""
+        request = await _request_for("claude-fable-5")
+        assert "thinking" not in request
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("model", ["claude-haiku-4-5", "my-claude-proxy"])
+    async def test_omitted_on_models_that_predate_the_parameter(self, model: str) -> None:
+        request = await _request_for(model)
+        assert "thinking" not in request
+
+    @pytest.mark.asyncio
+    async def test_extra_kwargs_can_opt_back_in(self) -> None:
+        client = _RecordingAnthropicClient()
+        anthropic_llm = _make_llm(model="claude-opus-5", client=client)
+        await anthropic_llm.chat(
+            chat_ctx=llm.ChatContext.empty(),
+            extra_kwargs={"thinking": {"type": "adaptive"}},
+        ).collect()
+
+        assert client.requests[0]["thinking"] == {"type": "adaptive"}
+
+    @pytest.mark.asyncio
+    async def test_each_request_gets_its_own_thinking_dict(self) -> None:
+        """The dict lands in the payload by reference; a shared one is process-wide state."""
+        client = _RecordingAnthropicClient()
+        anthropic_llm = _make_llm(model="claude-opus-5", client=client)
+        for _ in range(2):
+            await anthropic_llm.chat(chat_ctx=llm.ChatContext.empty()).collect()
+
+        first, second = client.requests[0]["thinking"], client.requests[1]["thinking"]
+        assert first is not second
+
+        first["type"] = "adaptive"  # a caller (or a test) mutating one request
+        assert (await _request_for("claude-opus-5"))["thinking"] == {"type": "disabled"}
+
+
+def _one_tool() -> list[Any]:
+    """A minimal, valid tool list for `chat(tools=...)`."""
+
+    @function_tool
+    async def lookup_order(order_id: str) -> str:
+        """Look up the status of an order.
+
+        Args:
+            order_id: The identifier of the order.
+        """
+        return "shipped"
+
+    return [lookup_order]
+
+
+class TestThinkingWithTools:
+    """Thinking blocks are never persisted, which breaks a turn carrying a tool call."""
+
+    async def _chat(self, model: str, *, tools: list[Any] | None, times: int = 1, **kwargs: Any):
+        client = _RecordingAnthropicClient()
+        anthropic_llm = _make_llm(model=model, client=client)
+        for _ in range(times):
+            await anthropic_llm.chat(
+                chat_ctx=llm.ChatContext.empty(), tools=tools, **kwargs
+            ).collect()
+        return client
+
+    @staticmethod
+    def _warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+        return [r.getMessage() for r in caplog.records if "thinking blocks" in r.getMessage()]
+
+    @pytest.mark.asyncio
+    async def test_warns_once_per_instance(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="livekit.plugins.anthropic"):
+            # not in ChatModels, but `model` takes any string and the guard recognises
+            # it from the id as a model that always thinks
+            await self._chat("claude-fable-5", tools=_one_tool(), times=3)
+
+        warnings = self._warnings(caplog)
+        assert len(warnings) == 1
+        assert "claude-fable-5" in warnings[0]
+
+    @pytest.mark.asyncio
+    async def test_warns_when_thinking_is_opted_back_in(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger="livekit.plugins.anthropic"):
+            await self._chat(
+                "claude-opus-5",
+                tools=_one_tool(),
+                extra_kwargs={"thinking": {"type": "adaptive"}},
+            )
+
+        assert len(self._warnings(caplog)) == 1
+
+    @pytest.mark.asyncio
+    async def test_silent_when_thinking_is_off(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The default on a configurable model: no reasoning, nothing to lose."""
+        with caplog.at_level(logging.WARNING, logger="livekit.plugins.anthropic"):
+            client = await self._chat("claude-opus-5", tools=_one_tool())
+
+        assert client.requests[0]["thinking"] == {"type": "disabled"}
+        assert not self._warnings(caplog)
+
+    @pytest.mark.asyncio
+    async def test_silent_without_tools(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Without a tool call in the turn, replaying it without thinking blocks is fine."""
+        with caplog.at_level(logging.WARNING, logger="livekit.plugins.anthropic"):
+            await self._chat("claude-fable-5", tools=None)
+
+        assert not self._warnings(caplog)
+
+
+class TestMaxTokens:
+    @pytest.mark.asyncio
+    async def test_default_stays_small_when_thinking_is_off(self) -> None:
+        request = await _request_for("claude-opus-5")
+        assert request["max_tokens"] == 1024
+
+    @pytest.mark.asyncio
+    async def test_default_grows_when_the_model_always_thinks(self) -> None:
+        """max_tokens caps thinking and the reply together, so reasoning needs room."""
+        request = await _request_for("claude-fable-5")
+        assert request["max_tokens"] > 1024
+
+    @pytest.mark.asyncio
+    async def test_explicit_value_always_wins(self) -> None:
+        request = await _request_for("claude-fable-5", max_tokens=256)
+        assert request["max_tokens"] == 256
+
+
+def _thinking_start_event() -> anthropic.types.RawContentBlockStartEvent:
+    return anthropic.types.RawContentBlockStartEvent(
+        type="content_block_start",
+        index=0,
+        content_block=anthropic.types.ThinkingBlock(type="thinking", thinking="", signature=""),
+    )
+
+
+class TestThinkingBlocksInStream:
+    async def _stream(self, *, thinking_expected: bool = False) -> LLMStream:
+        async def create_stream() -> _EmptyAnthropicStream:
+            return _EmptyAnthropicStream()
+
+        stream = LLMStream(
+            _make_llm(model="claude-opus-5"),
+            create_anthropic_stream=create_stream,
+            chat_ctx=llm.ChatContext.empty(),
+            tools=[],
+            conn_options=APIConnectOptions(max_retry=0, retry_interval=0),
+            thinking_expected=thinking_expected,
+        )
+        # drain the (empty) stream so no background task outlives the test
+        await stream.collect()
+        return stream
+
+    @pytest.mark.asyncio
+    async def test_thinking_text_never_reaches_the_caller(self) -> None:
+        stream = await self._stream()
+        delta = anthropic.types.RawContentBlockDeltaEvent(
+            type="content_block_delta",
+            index=0,
+            delta=anthropic.types.ThinkingDelta(type="thinking_delta", thinking="let me think"),
+        )
+
+        assert stream._parse_event(_thinking_start_event()) is None
+        assert stream._parse_event(delta) is None
+        assert stream._thinking_blocks == 1
+        assert stream._thinking_chars == len("let me think")
+
+    @pytest.mark.asyncio
+    async def test_signature_delta_is_ignored(self) -> None:
+        stream = await self._stream()
+        delta = anthropic.types.RawContentBlockDeltaEvent(
+            type="content_block_delta",
+            index=0,
+            delta=anthropic.types.SignatureDelta(type="signature_delta", signature="abc"),
+        )
+
+        assert stream._parse_event(delta) is None
+
+    @pytest.mark.asyncio
+    async def test_redacted_thinking_is_counted(self) -> None:
+        stream = await self._stream()
+        start = anthropic.types.RawContentBlockStartEvent(
+            type="content_block_start",
+            index=0,
+            content_block=anthropic.types.RedactedThinkingBlock(
+                type="redacted_thinking", data="opaque"
+            ),
+        )
+
+        assert stream._parse_event(start) is None
+        assert stream._thinking_blocks == 1
+
+    @pytest.mark.asyncio
+    async def test_unexpected_thinking_is_reported_once(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        stream = await self._stream(thinking_expected=False)
+
+        with caplog.at_level(logging.WARNING, logger="livekit.plugins.anthropic"):
+            stream._parse_event(_thinking_start_event())
+            stream._parse_event(_thinking_start_event())
+
+        assert len([r for r in caplog.records if "thinking block" in r.getMessage()]) == 1
+
+    @pytest.mark.asyncio
+    async def test_expected_thinking_is_not_warned_about(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        stream = await self._stream(thinking_expected=True)
+
+        with caplog.at_level(logging.WARNING, logger="livekit.plugins.anthropic"):
+            stream._parse_event(_thinking_start_event())
+
+        assert not [r for r in caplog.records if "thinking block" in r.getMessage()]
+
+
 class TestPerAttemptState:
     """`_run` is re-entered on every retry with the same instance."""
 
@@ -149,7 +605,7 @@ class TestPerAttemptState:
             return _EmptyAnthropicStream()
 
         stream = LLMStream(
-            _make_llm(),
+            _make_llm(model="claude-opus-5"),
             create_anthropic_stream=create_stream,
             chat_ctx=llm.ChatContext.empty(),
             tools=[],
@@ -158,6 +614,19 @@ class TestPerAttemptState:
         response = await stream.collect()
         assert attempts == 2
         return stream, response
+
+    @pytest.mark.asyncio
+    async def test_thinking_counters_do_not_accumulate_across_retries(self) -> None:
+        delta = anthropic.types.RawContentBlockDeltaEvent(
+            type="content_block_delta",
+            index=0,
+            delta=anthropic.types.ThinkingDelta(type="thinking_delta", thinking="let me think"),
+        )
+
+        stream, _ = await self._collect_after_one_failed_attempt([_thinking_start_event(), delta])
+
+        assert stream._thinking_blocks == 0
+        assert stream._thinking_chars == 0
 
     @pytest.mark.asyncio
     async def test_chain_of_thought_latch_does_not_survive_a_retry(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.41" },
+    { name = "anthropic", specifier = ">=0.47" },
     { name = "httpx" },
     { name = "livekit-agents", editable = "livekit-agents" },
 ]


### PR DESCRIPTION
**Problem**

The Anthropic plugin decides what to put in a request from hardcoded model ids, and Anthropic has changed the request contract twice since Claude 4.6. Every model released after that list was written now sends a request the API rejects.

1. **Prefilling.** `_NO_PREFILL_PATTERNS` lists `claude-sonnet-4-6` and `claude-opus-4-6` literally, so on Opus 4.7/4.8, Opus 5 and Sonnet 5 the plugin still sends a trailing assistant message and livekit/agents#4907 ("Prefilling assistant messages is no longer supported") comes back.
2. **Sampling parameters.** `temperature`, `top_p` and `top_k` are rejected with a 400 from Claude 4.7 onwards, so a documented constructor argument breaks every request:

   ```python
   anthropic.LLM(model="claude-opus-5", temperature=0.7)
   ```
3. **Thinking.** On Sonnet 5 and Opus 5 thinking is on unless the request turns it off, and `max_tokens` caps thinking and the reply together — with the plugin's 1024 default a voice turn can spend most of its budget reasoning and come back truncated. On the way out, `thinking_delta` and `signature_delta` fall through `_parse_event`, so the reasoning is generated and billed but never surfaces anywhere.

Separately, `LLMStream._run` is re-entered on the same instance on every retry and nothing clears the state of the failed attempt.

**Fix**

Two commits.

`reset per-attempt state before a stream retry` — the framework only retries when the attempt emitted no chunk, which is exactly when a `<thinking>` block or a tool call was left open. `_ignoring_cot` left set makes the retry's answer get swallowed as chain of thought; a half-read tool call keeps collecting arguments from the next attempt. Both are cleared at the top of `_run`.

`support the Claude 4.7+ and 5 generations` — the hardcoded id list is replaced by the generation read out of the model id, and the three behaviours are gated on it:

<!-- linear:table-colwidths:266,266,266 -->
|  | applies from | behaviour |
| -- | -- | -- |
| prefilling | 4.6 | a trailing assistant message is closed with a user turn |
| sampling params | 4.7 | `temperature`/`top_p`/`top_k` are dropped, warned once per instance |
| thinking | 4.6 | `thinking: {"type": "disabled"}` is sent; `extra_kwargs` still wins |

Version parsing anchors on the family name, so gateway and snapshot ids keep resolving to the underlying model: `anthropic.claude-opus-5`, `claude-opus-4-5@20251101`, `claude-opus-5[1m]`, `gw-1-claude-opus-5`. When the family cannot be found in the id — a proxy alias such as `my-claude-proxy` — no version is returned and every guard keeps the behaviour it had before, rather than guessing at the model's capabilities.

`thinking_delta` and `signature_delta` are now recognised: the reasoning is kept out of the caller's text (a voice agent would speak it) and logged at debug level, with a one-time warning if thinking appears when it was not requested.

`models.py` gains Opus 4.5/4.7/4.8, Opus 5, Sonnet 4.5, Sonnet 5 and Haiku 4.5, and marks the ids that now return 404. `claude-fable-5` and `claude-mythos-5` are deliberately left out — thinking cannot be turned off on them and a single request can run for minutes, which does not fit a voice session — but the runtime guard still recognises them, since `model` accepts any string.

**Behaviour change**

Requests to 4.6+ models now carry `thinking: {"type": "disabled"}` where they previously carried nothing. That is a no-op on 4.6/4.7/4.8, where thinking was already off by default, and a real change on Sonnet 5 / Opus 5, where it was on. Callers who want the model to reason opt back in with `chat(extra_kwargs={"thinking": {"type": "adaptive"}})`; note that thinking blocks are not kept in the chat context, so a turn carrying a tool call is replayed without them, which Anthropic can reject — the plugin logs a warning when that combination is used.

**Tests**

`tests/test_plugin_anthropic.py` moves from the `plugin` category to `unit`. It is hermetic — fake client, no API key, no network — and no CI job runs `--plugin`, so nothing in it was running; the other hermetic plugin tests (cerebras, aws, openai, google) are already marked `unit`.

```
uv run pytest tests/test_plugin_anthropic.py --unit   # 94 passed
uv run pytest --unit                                  # 2055 passed, 5 skipped
make format-check && make lint
uv run mypy -p livekit.plugins.anthropic
```

Coverage: version parsing including gateway/snapshot/unparseable ids, the prefill guard as a regression test for livekit/agents#4907, sampling parameters from both the constructor and `extra_kwargs`, the thinking configuration per model family, `max_tokens` defaults, the stream-side thinking blocks, and the per-attempt state reset.