### PR TITLE
feat(openai): add with_orcarouter LLM factory for OrcaRouter

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/__init__.py
@@ -17,7 +17,7 @@
 Support for OpenAI Realtime API, LLM, TTS, and STT APIs.
 
 Also includes support for a large number of OpenAI-compatible APIs including Azure OpenAI, Cerebras,
-Fireworks, Perplexity, Telnyx, xAI, Ollama, DeepSeek, OpenRouter, and OVHcloud AI Endpoints.
+Fireworks, Perplexity, Telnyx, xAI, Ollama, DeepSeek, OpenRouter, OrcaRouter, and OVHcloud AI Endpoints.
 
 See https://docs.livekit.io/agents/integrations/openai/ and
 https://docs.livekit.io/agents/integrations/llm/ for more information.

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -512,6 +512,62 @@ class LLM(llm.LLM):
         )
 
     @staticmethod
+    def with_orcarouter(
+        *,
+        model: str = "orcarouter/auto",
+        api_key: str | None = None,
+        base_url: str = "https://api.orcarouter.ai/v1",
+        client: openai.AsyncClient | None = None,
+        site_url: str | None = None,
+        app_name: str | None = None,
+        user: NotGivenOr[str] = NOT_GIVEN,
+        temperature: NotGivenOr[float] = NOT_GIVEN,
+        parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
+        tool_choice: ToolChoice = "auto",
+        reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
+        safety_identifier: NotGivenOr[str] = NOT_GIVEN,
+        prompt_cache_key: NotGivenOr[str] = NOT_GIVEN,
+        top_p: NotGivenOr[float] = NOT_GIVEN,
+        timeout: httpx.Timeout | None = None,
+    ) -> LLM:
+        """
+        Create a new instance of OrcaRouter LLM.
+
+        ``api_key`` must be set to your OrcaRouter API key, either using the argument or by setting
+        the ``ORCAROUTER_API_KEY`` environment variable.
+        """
+
+        api_key = api_key or os.environ.get("ORCAROUTER_API_KEY")
+        if api_key is None:
+            raise ValueError(
+                "OrcaRouter API key is required, either as argument or set ORCAROUTER_API_KEY environment variable"
+            )
+
+        # Set up analytics headers for OrcaRouter
+        default_headers: dict[str, str] = {}
+        if site_url:
+            default_headers["HTTP-Referer"] = site_url
+        if app_name:
+            default_headers["X-Title"] = app_name
+
+        return LLM(
+            model=model,
+            api_key=api_key,
+            client=client,
+            base_url=base_url,
+            user=user,
+            temperature=temperature,
+            parallel_tool_calls=parallel_tool_calls,
+            tool_choice=tool_choice,
+            reasoning_effort=reasoning_effort,
+            safety_identifier=safety_identifier,
+            prompt_cache_key=prompt_cache_key,
+            top_p=top_p,
+            extra_headers=default_headers,
+            timeout=timeout,
+        )
+
+    @staticmethod
     def with_deepseek(
         *,
         model: str | DeepSeekChatModels = "deepseek-chat",


### PR DESCRIPTION
## Summary

Adds a `LLM.with_orcarouter()` factory method to the `livekit-plugins-openai` plugin, mirroring the existing `with_openrouter()` wiring for [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible LLM routing gateway.

- Reads the `ORCAROUTER_API_KEY` environment variable (or accepts an explicit `api_key`)
- Defaults `base_url` to `https://api.orcarouter.ai/v1` and `model` to `orcarouter/auto`
- Sets `HTTP-Referer` / `X-Title` attribution headers when `site_url` / `app_name` are provided, matching the OpenRouter factory
- Omits OpenRouter-specific body params (`provider`, `fallback_models`, `plugins`), which OrcaRouter does not support

Also updates the package docstring's OpenAI-compatible provider list to include OrcaRouter.

## Verification

- `ruff format --check` and `ruff check` pass (pinned `ruff==0.15.22`)
- `mypy --platform linux -p livekit.plugins.openai` reports no issues (the repo's CI gate)
- Live test against the real OrcaRouter endpoint: `LLM.with_orcarouter().chat(...)` returned `ORCAROUTER_OK`

## Disclosure

I'm an engineer on the OrcaRouter team.

This change only adds a new factory method and a docstring line; no existing behavior is modified. No credentials or secrets are involved in the diff.
