### PR TITLE
fix(openai): warn when semantic_vad is configured with Azure Realtime

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -585,7 +585,7 @@ class RealtimeModel(llm.RealtimeModel):
             modalities (list[Literal["text", "audio"]] | NotGiven): Modalities to enable. Defaults to ["text", "audio"] if not provided.
             input_audio_transcription (AudioTranscription | InputAudioTranscription | None | NotGiven): Transcription options; defaults to Azure-optimized values when not provided.
             input_audio_noise_reduction (NoiseReductionType | InputAudioNoiseReduction | None): Input noise reduction settings. Defaults to None.
-            turn_detection (RealtimeAudioInputTurnDetection | TurnDetection | None | NotGiven): Server-side VAD; defaults to Azure-optimized values when not provided.
+            turn_detection (RealtimeAudioInputTurnDetection | TurnDetection | None | NotGiven): Server-side VAD; defaults to Azure-optimized values (server_vad) when not provided. Note: Azure has been observed to accept semantic_vad but never emit input_audio_buffer.speech_started, breaking server-side interruption/barge-in.
             speed (float | NotGiven): Audio playback speed multiplier.
             tracing (Tracing | None | NotGiven): Tracing configuration for OpenAI Realtime.
             reasoning (RealtimeReasoning | None | NotGiven): Reasoning config for reasoning-capable models, e.g. ``RealtimeReasoning(effort="low")``.
@@ -690,6 +690,13 @@ class RealtimeModel(llm.RealtimeModel):
         can_disable_turn_detection = not is_given(turn_detection)
         if not is_given(turn_detection):
             turn_detection = AZURE_DEFAULT_TURN_DETECTION
+        elif turn_detection is not None and getattr(turn_detection, "type", None) == "semantic_vad":
+            logger.warning(
+                "semantic_vad on Azure OpenAI Realtime has been observed to accept the "
+                "session config but never emit input_audio_buffer.speech_started, so "
+                "server-side interruption/barge-in will not fire. Consider server_vad "
+                "(the Azure default here) until this is resolved on the Azure side."
+            )
 
         model = RealtimeModel(
             voice=voice,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/utils.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/utils.py
@@ -46,7 +46,10 @@ DEFAULT_INPUT_AUDIO_TRANSCRIPTION = AudioTranscription(
     model="gpt-4o-mini-transcribe",
 )
 
-# use beta version TurnDetection and InputAudioTranscription for compatibility
+# use beta version TurnDetection and InputAudioTranscription for compatibility.
+# server_vad (not semantic_vad) is intentional: Azure OpenAI Realtime has been
+# observed to accept a semantic_vad session config but never emit
+# input_audio_buffer.speech_started, which breaks server-side interruption/barge-in.
 AZURE_DEFAULT_TURN_DETECTION = TurnDetection(
     type="server_vad",
     threshold=0.5,


### PR DESCRIPTION


Azure OpenAI Realtime (observed on `gpt-realtime` deployments, raw WebSocket, Aug 2026) **accepts** a `semantic_vad` session config — `session.updated` reflects it — but then **never emits `input_audio_buffer.speech_started`** and never cancels an active response. Server-side interruption/barge-in is silently dead. The identical audio injected under `server_vad` fires `speech_started` and cancels with `reason: turn_detected`.

This appears to be why `AZURE_DEFAULT_TURN_DETECTION` is already `server_vad` (while the OpenAI default is `semantic_vad`) — but nothing warns a user who explicitly opts into `semantic_vad` via `with_azure()`, and the `with_azure` docstring's own example configures `semantic_vad`.

## Changes (warning-only, no behavior change)

- `logger.warning` in `with_azure()` when the caller explicitly passes `semantic_vad` turn detection
- caveat added to the `turn_detection` arg docs
- rationale comment next to `AZURE_DEFAULT_TURN_DETECTION`

## Corroboration

- Microsoft Q&A: [Azure OpenAI Realtime API Ignores semantic_vad Turn Detection Setting](https://learn.microsoft.com/en-us/answers/questions/5521485/azure-openai-realtime-api-ignores-semantic-vad-tur)
- OpenAI community reports of semantic_vad speech_started unreliability: [1363428](https://community.openai.com/t/bug-report-inconsistent-speech-started-speech-ended-behavior-with-semantic-vad-realtime-api/1363428), [1360239](https://community.openai.com/t/realtime-semantic-vad-issues/1360239)
- Reproduced independently with a minimal raw-WS harness (inject real TTS speech mid-generation; watch for `speech_started` + cancellation) against Azure `gpt-realtime-2.1`; happy to share the repro script if useful.

If/when Azure fixes this server-side, the warning can simply be removed.

