### PR TITLE
fix(utils): keep whole samples when flushing a partial trailing sample

### DIFF
--- a/livekit-agents/livekit/agents/utils/audio.py
+++ b/livekit-agents/livekit/agents/utils/audio.py
@@ -179,10 +179,12 @@ class AudioByteStream:
             list[rtc.AudioFrame]: A list containing any remaining `AudioFrame` objects.
 
         This method processes any remaining data in the buffer that does not
-        fill a complete frame. If the remaining data forms a partial frame
-        (i.e., its size is not a multiple of the expected sample size), a warning is
-        logged and an empty list is returned. Otherwise, it returns the final
-        `AudioFrame` containing the remaining data.
+        fill a complete frame, and returns it as the final `AudioFrame`.
+
+        If the buffer does not end on a sample boundary, the trailing incomplete
+        sample cannot be represented and is dropped with a warning; the complete
+        samples before it are still returned. The buffer is always left empty, so
+        a partial sample can never offset the samples of a later push.
 
         Use this method when you have no more data to push and want to ensure
         that all buffered audio data has been processed.
@@ -190,8 +192,16 @@ class AudioByteStream:
         if len(self._buf) == 0:
             return []
 
-        if len(self._buf) % self._bytes_per_sample != 0:
-            logger.warning("AudioByteStream: incomplete frame during flush, dropping")
+        remainder = len(self._buf) % self._bytes_per_sample
+        if remainder:
+            logger.warning(
+                "AudioByteStream: buffer does not end on a sample boundary during "
+                "flush, dropping the trailing %d byte(s)",
+                remainder,
+            )
+            del self._buf[len(self._buf) - remainder :]
+
+        if len(self._buf) == 0:
             return []
 
         frames = [

--- a/tests/test_utils_audio.py
+++ b/tests/test_utils_audio.py
@@ -1,0 +1,103 @@
+import logging
+
+import pytest
+
+from livekit.agents.utils.audio import AudioByteStream
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_RATE = 8000
+SAMPLES_PER_FRAME = 1600  # 200ms
+BYTES_PER_SAMPLE = 2  # mono, 16 bit
+
+
+def _stream() -> AudioByteStream:
+    return AudioByteStream(
+        sample_rate=SAMPLE_RATE,
+        num_channels=1,
+        samples_per_channel=SAMPLES_PER_FRAME,
+    )
+
+
+class TestAudioByteStreamFlush:
+    """flush() must not lose complete samples to a partial trailing one."""
+
+    def test_flush_returns_buffered_samples(self):
+        stream = _stream()
+        assert stream.push(b"\x11\x22" * 1500) == []
+
+        frames = stream.flush()
+        assert len(frames) == 1
+        assert frames[0].samples_per_channel == 1500
+        assert len(stream._buf) == 0
+
+    def test_flush_keeps_complete_samples_when_buffer_ends_mid_sample(self):
+        stream = _stream()
+        stream.push(b"\x11\x22" * 1500 + b"\x33")
+
+        frames = stream.flush()
+        assert len(frames) == 1, "the 1500 complete samples must survive the partial one"
+        assert frames[0].samples_per_channel == 1500
+
+    def test_flush_drops_only_the_trailing_partial_sample(self):
+        stream = _stream()
+        body = b"\x11\x22" * 3
+        stream.push(body + b"\x33")
+
+        frames = stream.flush()
+        assert bytes(frames[0].data)[: len(body)] == body
+
+    def test_flush_empties_the_buffer_after_a_partial_sample(self):
+        """A leftover byte would offset every sample of a later push."""
+        stream = _stream()
+        stream.push(b"\x11\x22" * 10 + b"\x33")
+        stream.flush()
+        assert len(stream._buf) == 0
+
+    def test_flush_warns_with_the_dropped_byte_count(self, caplog):
+        stream = _stream()
+        stream.push(b"\x11\x22" * 10 + b"\x33")
+
+        with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+            stream.flush()
+
+        assert "dropping the trailing 1 byte(s)" in caplog.text
+
+    def test_flush_of_a_lone_partial_sample_returns_nothing(self):
+        stream = _stream()
+        stream.push(b"\x33")
+
+        assert stream.flush() == []
+        assert len(stream._buf) == 0
+
+    def test_flush_of_an_empty_buffer_returns_nothing(self, caplog):
+        stream = _stream()
+        with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+            assert stream.flush() == []
+        assert caplog.text == ""
+
+    def test_flush_after_whole_frames_were_emitted(self):
+        stream = _stream()
+        frames = stream.push(b"\x11\x22" * (SAMPLES_PER_FRAME + 500) + b"\x33")
+        assert len(frames) == 1
+        assert frames[0].samples_per_channel == SAMPLES_PER_FRAME
+
+        remaining = stream.flush()
+        assert len(remaining) == 1
+        assert remaining[0].samples_per_channel == 500
+
+    def test_flush_is_idempotent(self):
+        stream = _stream()
+        stream.push(b"\x11\x22" * 10 + b"\x33")
+        assert len(stream.flush()) == 1
+        assert stream.flush() == []
+
+    def test_stereo_partial_sample_keeps_whole_frames(self):
+        """bytes_per_sample is 4 for stereo, so a 3 byte tail is partial."""
+        stream = AudioByteStream(sample_rate=SAMPLE_RATE, num_channels=2, samples_per_channel=1600)
+        stream.push(b"\x11\x22\x33\x44" * 100 + b"\x55\x66\x77")
+
+        frames = stream.flush()
+        assert len(frames) == 1
+        assert frames[0].samples_per_channel == 100
+        assert len(stream._buf) == 0


### PR DESCRIPTION
Fixes #6874.

`AudioByteStream.flush()` bailed out with an empty list whenever the buffer did not end on a sample boundary, so one stray byte took every complete sample with it. On an 8 kHz mono stream with a 200 ms target frame that is up to 200 ms of speech, and the warning called it an incomplete frame while what it actually dropped was the whole buffer.

The buffer was also left in place on that path, since only the success path called `clear()`. So the misaligned byte stayed in the stream and offset every later frame by a byte, which comes out as noise rather than as missing audio. That second part is the one that worried me more, because it is silent.

The fix drops only the trailing bytes that cannot form a sample, returns the samples before them, and leaves the buffer empty on both paths. The warning now says how many bytes went.

I ran into this on a telephony feed at 8 kHz where the source can hand over an odd number of bytes. It may also be worth a look next to #5158, which tracks truncation on the PCM path from the other end, though I have not confirmed they are the same thing.

Tests are in a new `tests/test_utils_audio.py`, since `AudioByteStream` did not have a module of its own. Ten cases: whole samples surviving a partial tail, only the tail being dropped, the buffer ending up empty, the warning naming the byte count, a lone partial byte, an empty buffer staying quiet, flush after whole frames were emitted, idempotence, and the stereo case where a sample is 4 bytes. Eight of the ten fail on main; the other two are guards for behaviour this does not change.

`uv run pytest --unit` gives 1566 passed against 1556 on main, which is the ten new ones and no regressions. `make check` is clean, formatting, ruff and mypy. There are 9 errors in the unit run on my machine from the OTLP metrics exporter at teardown, but they are identical on a clean checkout of main so they are not from this change.
