### PR TITLE
feat(spatius): forward avatar session extra params, update spatius to 1.0.5

### DIFF
--- a/livekit-plugins/livekit-plugins-spatius/README.md
+++ b/livekit-plugins/livekit-plugins-spatius/README.md
@@ -1,8 +1,8 @@
 # LiveKit Plugins Spatius
 
-Agent Framework plugin for [Spatius](https://www.spatius.ai) avatars.
+Agent Framework plugin for [Spatius](https://www.spatius.ai/?utm_source=livekit) avatars.
 
-See the [Spatius documentation](https://docs.spatius.ai) for Spatius account setup and
+See the [Spatius documentation](https://docs.spatius.ai?utm_source=livekit) for Spatius account setup and
 avatar configuration.
 
 ## Client-side rendering
@@ -13,7 +13,7 @@ otherwise black frames, so a standard LiveKit video renderer will display a blac
 screen. Your frontend must use the Spatius client SDK and LiveKit adapter to decode
 the track and render the avatar.
 
-See the [client integration guide](https://docs.spatius.ai/livekit-agents/client) and
+See the [client integration guide](https://docs.spatius.ai/livekit-agents/client?utm_source=livekit) and
 the [reference frontend](https://github.com/spatius-ai/spatius-avatar-demo/tree/main/platform-integrations/livekit-agents-demo/livekit-agents-reference-demo/frontend)
 for a working implementation.
 
@@ -33,5 +33,4 @@ await avatar.start(session, room=ctx.room)
 ```
 
 The plugin reads `SPATIUS_API_KEY`, `SPATIUS_APP_ID`, and `SPATIUS_AVATAR_ID` from the
-environment when constructor arguments are omitted. It defaults to the `us-west` Spatius
-region and composes the production endpoint URLs automatically.
+environment when constructor arguments are omitted.

--- a/livekit-plugins/livekit-plugins-spatius/livekit/plugins/spatius/avatar.py
+++ b/livekit-plugins/livekit-plugins-spatius/livekit/plugins/spatius/avatar.py
@@ -45,7 +45,9 @@ from spatius import (
 
 from .log import logger
 
-DEFAULT_REGION = "us-west"
+# "auto" resolves the ingress region via the Spatius bootstrap API, falling back
+# to us-west if resolution fails; set region/SPATIUS_REGION to pin a concrete region
+DEFAULT_REGION = "auto"
 DEFAULT_SAMPLE_RATE = 24000
 DEFAULT_AUDIO_FORMAT = AudioFormat.OGG_OPUS
 DEFAULT_OPUS_FRAME_DURATION_MS = 20
@@ -76,6 +78,10 @@ class AvatarSession(BaseAvatarSession):
     to Spatius motion server, it joins the LiveKit room to publish synchronized
     avatar audio and motion data. The worker reports playback started and finished
     back to the agent over LiveKit RPC.
+
+    By default the ingress region is resolved automatically through the Spatius
+    bootstrap API (``region="auto"``). Pass ``region`` or set the ``SPATIUS_REGION``
+    environment variable to pin a concrete region such as ``us-west``.
     """
 
     def __init__(
@@ -95,6 +101,7 @@ class AvatarSession(BaseAvatarSession):
         bitrate: int = 0,
         opus_frame_duration_ms: int = DEFAULT_OPUS_FRAME_DURATION_MS,
         opus_application: str = DEFAULT_OPUS_APPLICATION,
+        extra_params: dict[str, str] | None = None,
     ) -> None:
         super().__init__()
 
@@ -136,6 +143,7 @@ class AvatarSession(BaseAvatarSession):
         self._idle_timeout_seconds = idle_timeout_seconds
         self._sample_rate = int(sample_rate) if utils.is_given(sample_rate) else None
         self._bitrate = bitrate
+        self._extra_params = dict(extra_params or {})
         self._opus_encoder = (
             OggOpusEncoderConfig(
                 frame_duration_ms=opus_frame_duration_ms,
@@ -252,6 +260,7 @@ class AvatarSession(BaseAvatarSession):
                 bitrate=self._bitrate,
                 audio_format=self._audio_format,
                 ogg_opus_encoder=self._opus_encoder,
+                extra_params=self._extra_params,
                 on_error=self._on_spatius_error,
                 on_close=self._on_spatius_close,
             )

--- a/livekit-plugins/livekit-plugins-spatius/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-spatius/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents>=1.6.10",
-    "spatius[opus]>=1.0.4",
+    "spatius[opus]>=1.0.5",
 ]
 
 [project.urls]

--- a/livekit-plugins/livekit-plugins-spatius/tests/test_avatar.py
+++ b/livekit-plugins/livekit-plugins-spatius/tests/test_avatar.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from livekit.plugins.spatius import AvatarSession
+
+pytestmark = pytest.mark.unit
+
+
+def test_extra_params_are_copied() -> None:
+    params = {"server_post_process": "false"}
+
+    with patch.dict(
+        os.environ,
+        {
+            "SPATIUS_API_KEY": "test-key",
+            "SPATIUS_APP_ID": "test-app",
+            "SPATIUS_AVATAR_ID": "test-avatar",
+        },
+    ):
+        session = AvatarSession(extra_params=params)
+
+    params["server_post_process"] = "true"
+
+    assert session._extra_params == {"server_post_process": "false"}
+
+
+async def test_extra_params_are_forwarded_to_sdk() -> None:
+    sdk_session = MagicMock()
+    sdk_session.init = AsyncMock()
+    sdk_session.start = AsyncMock()
+    sdk_session.close = AsyncMock()
+    room = MagicMock()
+    room.name = "test-room"
+    room.local_participant.identity = "test-agent"
+    agent_session = MagicMock()
+    agent_session.output = MagicMock()
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "SPATIUS_API_KEY": "test-key",
+                "SPATIUS_APP_ID": "test-app",
+                "SPATIUS_AVATAR_ID": "test-avatar",
+            },
+        ),
+        patch("livekit.plugins.spatius.avatar.BaseAvatarSession.start", new=AsyncMock()),
+        patch("livekit.plugins.spatius.avatar.QueueAudioOutput") as queue_audio,
+        patch(
+            "livekit.plugins.spatius.avatar.new_avatar_session", return_value=sdk_session
+        ) as create_sdk_session,
+    ):
+        queue_audio.return_value.start = AsyncMock()
+        queue_audio.return_value.aclose = AsyncMock()
+        queue_audio.return_value.on = MagicMock()
+        session = AvatarSession(extra_params={"server_post_process": "false"}, sample_rate=24_000)
+        await session.start(
+            agent_session,
+            room,
+            livekit_url="wss://livekit.example.com",
+            livekit_api_key="test-key-with-at-least-thirty-two-characters",
+            livekit_api_secret="test-secret-with-at-least-thirty-two-characters",
+        )
+
+    assert create_sdk_session.call_args.kwargs["extra_params"] == {"server_post_process": "false"}
+    await session.aclose()

--- a/uv.lock
+++ b/uv.lock
@@ -667,15 +667,15 @@ name = "bithuman"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "av", marker = "python_full_version < '3.14'" },
-    { name = "loguru", marker = "python_full_version < '3.14'" },
-    { name = "networkx", marker = "python_full_version < '3.14'" },
-    { name = "numpy", marker = "python_full_version < '3.14'" },
-    { name = "opencv-python-headless", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "pydantic-settings", marker = "python_full_version < '3.14'" },
-    { name = "pyyaml", marker = "python_full_version < '3.14'" },
-    { name = "soundfile", marker = "python_full_version < '3.14'" },
+    { name = "av" },
+    { name = "loguru" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "opencv-python-headless" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyyaml" },
+    { name = "soundfile" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/f4/9faa8a78e8968f4404e5e47a2852d7a97313a667424a8e6f8bff16a28899/bithuman-2.7.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b399a37e187c17a8874e0eeb8e7e7a0907a4155537fac08185dabdb62491a7aa", size = 27205973, upload-time = "2026-07-17T00:14:45.72Z" },
@@ -3418,7 +3418,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "livekit-agents", editable = "livekit-agents" },
-    { name = "spatius", extras = ["opus"], specifier = ">=1.0.4" },
+    { name = "spatius", extras = ["opus"], specifier = ">=1.0.5" },
 ]
 
 [[package]]
@@ -3572,8 +3572,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -4233,7 +4233,7 @@ name = "opencv-python-headless"
 version = "5.0.0.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/99/76b7c80252aa83c1af16393454aafd125a0287101afe8deb0a6821af0e30/opencv_python_headless-5.0.0.93.tar.gz", hash = "sha256:b82f9831daab90b725c7c1ee1b36cb5732c367096ac76d119e64e14eb70d5f3c", size = 81817738, upload-time = "2026-07-02T07:01:06.039Z" }
 wheels = [
@@ -5701,9 +5701,9 @@ name = "soundfile"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "python_full_version < '3.14'" },
-    { name = "numpy", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "cffi" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d2/db/949331952a6fb1c5b12e9de80fd08747966c2039d1a61db4764fbd3981c2/soundfile-0.14.0.tar.gz", hash = "sha256:ba1c1a2d618bca5c406647c83b89f07cc8810fa506a50622a6993ba130c1de11", size = 47842, upload-time = "2026-06-06T08:58:47.869Z" }
 wheels = [
@@ -5728,17 +5728,20 @@ wheels = [
 
 [[package]]
 name = "spatius"
-version = "1.0.4"
+version = "1.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "nanoid" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "protobuf" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/20/fad918f35d276b26ffe2a4991f59d5a768df3cfc2f737eedfa6ab2e08a58/spatius-1.0.4.tar.gz", hash = "sha256:1f041fe95ba3c7465825ceda03ac3be2e90173c20a11dd45854cf89ab1d86aef", size = 129807, upload-time = "2026-07-23T17:29:34.022Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/10/d1b4b523c0b20e6bea62c3f8497ea12339bc0532804ffe9d9fba7c1b00e9/spatius-1.0.5.tar.gz", hash = "sha256:bc9a2d66156e5eec65f45847d4d19be1b0cbc0bbe91011150a58f931ad681500", size = 152920, upload-time = "2026-08-16T22:13:26.215Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/fc/c0e9176e988dca84321b03fab9b4aa0ab782372555d9245a0a60ed5aa9c0/spatius-1.0.4-py3-none-any.whl", hash = "sha256:3f99be2fba873a5dd798b265852f40f97b624413ea39a9fc14891e578da774de", size = 22903, upload-time = "2026-07-23T17:29:32.879Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c9/4b2ba01d29595f9da903519588bfee8f06982bc5836a61bb81646c1998a0/spatius-1.0.5-py3-none-any.whl", hash = "sha256:114a19897ed96a6f6a7fac7edece0f204f9fe166776d8ca253119c9bf05c8371", size = 31489, upload-time = "2026-08-16T22:13:24.954Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Add `extra_params` to `AvatarSession` and forward it to the Spatius SDK's `new_avatar_session`, letting callers pass server-side session options (e.g. `server_post_process`) through the plugin. The dict is copied at construction to avoid aliasing caller state.
- Bump the `spatius[opus]` dependency from `>=1.0.4` to `>=1.0.5`.
- README link updates (`utm_source=livekit`).

## Region default change

spatius 1.0.5 changes the default ingress region behavior: when no region is specified, it is no longer fixed to `us-west` — the SDK resolves the region automatically via the Spatius global bootstrap API (automatic regional scheduling). If bootstrap resolution fails, it falls back to the last cached region or `us-west`.