### PR TITLE
fix(audio): check AudioArrayBuffer frame size after resampling

### DIFF
--- a/livekit-agents/livekit/agents/utils/audio.py
+++ b/livekit-agents/livekit/agents/utils/audio.py
@@ -292,11 +292,8 @@ class AudioArrayBuffer:
             The number of samples written to the buffer.
 
         Raises:
-            ValueError: If the frame samples are greater than the buffer size.
+            ValueError: If the frame samples, after resampling, are greater than the buffer size.
         """
-        if frame.samples_per_channel > self._buffer_size:
-            raise ValueError("frame samples are greater than the buffer size")
-
         frames: list[rtc.AudioFrame] = []
         if self._resampler is None and frame.sample_rate != self._sample_rate:
             self._resampler = rtc.AudioResampler(
@@ -312,6 +309,21 @@ class AudioArrayBuffer:
             frames.extend(self._resampler.push(frame))
         else:
             frames.append(frame)
+
+        if not frames:
+            # the resampler holds short frames back until it can emit a full output frame
+            return 0
+
+        if (samples := sum(f.samples_per_channel for f in frames)) > self._buffer_size:
+            detail = (
+                f" after resampling {frame.sample_rate}Hz to {self._sample_rate}Hz"
+                if self._resampler
+                else ""
+            )
+            raise ValueError(
+                f"frame samples ({samples}{detail}) are greater than "
+                f"the buffer size ({self._buffer_size})"
+            )
 
         frame = merge_frames(frames)
 

--- a/tests/test_utils/test_audio_array_buffer.py
+++ b/tests/test_utils/test_audio_array_buffer.py
@@ -201,6 +201,26 @@ class TestSampleRates:
         expected = buf_sr * 50 // 1000
         assert abs(len(buf.read()) - expected) <= 10  # QUICK quality resampler may round
 
+    def test_upsampled_too_large_raises(self) -> None:
+        """A frame that only overflows once upsampled blames the resampling, not the caller."""
+        buf = AudioArrayBuffer(buffer_size=1000, sample_rate=16000)
+        with pytest.raises(ValueError, match="after resampling 8000Hz to 16000Hz"):
+            buf.push_frame(_frame(list(range(900)), sr=8000))
+
+    def test_downsampled_fits_buffer(self) -> None:
+        """A frame that only fits once downsampled is accepted."""
+        buf = AudioArrayBuffer(buffer_size=1000, sample_rate=8000)
+        written = buf.push_frame(_frame(list(range(1800)), sr=16000))
+        assert abs(written - 900) <= 10  # QUICK quality resampler may round
+        assert len(buf) == written
+
+    def test_frame_shorter_than_resampler_output(self) -> None:
+        """A frame the resampler holds back writes nothing instead of raising."""
+        buf = AudioArrayBuffer(buffer_size=1000, sample_rate=16000)
+        assert buf.push_frame(_frame([1], sr=8000)) == 0
+        assert len(buf) == 0
+        assert buf.push_frame(_frame([2, 3, 4, 5], sr=8000)) > 0
+
 
 class TestPerformance:
     @pytest.mark.parametrize("sr", [16000, 48000], ids=["16k", "48k"])


### PR DESCRIPTION
**Problem**

`AudioArrayBuffer.push_frame()` checks the frame size before it resamples, but it writes the size after. An 8kHz frame that passes the check overflows a 16kHz buffer, and numpy raises `could not broadcast input array from shape (1796,) into shape (1000,)`. The reverse also fails, because a frame that fits only after downsampling is rejected. A third case crashes as well. The resampler returns no frames until it has enough input, and `merge_frames()` then raises `buffer is empty`.

**Fix**

The size check now runs on the resampled sample count. The caller gets the documented `ValueError`, and a frame that fits only after downsampling is accepted. The message names the rate conversion, because the count in it is not the count the caller pushed: `frame samples (1796 after resampling 8000Hz to 16000Hz) are greater than the buffer size (1000)`. When the resampler has too little input for one output block, `push_frame()` returns 0. The samples stay in the resampler and reach the buffer on the next push.

A frame larger than the whole buffer still raises, which matches the docstring and the existing test.

Closes livekit/agents#6875