### PR TITLE
fix(tests): settle genai client finalizers in the test that owns them

### DIFF
--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -5,6 +5,7 @@ import gc
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Any
 
 import pytest
 from google.genai import types
@@ -17,6 +18,21 @@ from livekit.plugins.google.utils import create_function_response
 pytestmark = pytest.mark.unit
 
 
+def _is_genai_client_teardown(task: asyncio.Task[Any]) -> bool:
+    """Whether this task is a genai client's ``aclose()`` left behind by a finalizer.
+
+    Keyed on the coroutine's defining module, not its name alone -- ``aclose``
+    is a common method name and this must not touch unrelated tasks. Coroutine
+    objects carry no ``__module__``, hence the walk through ``cr_frame``.
+    """
+    coro = task.get_coro()
+    if not (getattr(coro, "__qualname__", "") or "").endswith(".aclose"):
+        return False
+    frame = getattr(coro, "cr_frame", None)
+    module = frame.f_globals.get("__name__", "") if frame else ""
+    return module.startswith("google.genai")
+
+
 @pytest.fixture(autouse=True)
 async def _settle_genai_finalizers() -> AsyncIterator[None]:
     """Finish the genai client teardown this test started, before the next one.
@@ -24,18 +40,14 @@ async def _settle_genai_finalizers() -> AsyncIterator[None]:
     ``AsyncClient.__del__`` schedules ``aclose()`` on whatever event loop is
     running when the collector reaches it, with no check for a client that was
     already closed explicitly -- so even the sessions this module closes
-    properly leave a finalizer behind. Collected here, while this test still
-    owns the loop, those tasks would otherwise surface as leaked tasks in an
+    properly leave a finalizer behind. Settled here, while this test still owns
+    the loop, those tasks would otherwise surface as leaked tasks in an
     unrelated test in a later module.
     """
     yield
-    # gc.collect() runs the finalizers synchronously, so anything they schedule
-    # is already registered by the time it returns.
     gc.collect()
     if pending := [
-        task
-        for task in asyncio.all_tasks()
-        if not task.done() and "aclose" in (getattr(task.get_coro(), "__qualname__", "") or "")
+        task for task in asyncio.all_tasks() if not task.done() and _is_genai_client_teardown(task)
     ]:
         await asyncio.gather(*pending, return_exceptions=True)
 

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import gc
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -13,6 +15,30 @@ from livekit.plugins.google.realtime.realtime_api import RealtimeModel, Realtime
 from livekit.plugins.google.utils import create_function_response
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+async def _settle_genai_finalizers() -> AsyncIterator[None]:
+    """Finish the genai client teardown this test started, before the next one.
+
+    ``AsyncClient.__del__`` schedules ``aclose()`` on whatever event loop is
+    running when the collector reaches it, with no check for a client that was
+    already closed explicitly -- so even the sessions this module closes
+    properly leave a finalizer behind. Collected here, while this test still
+    owns the loop, those tasks would otherwise surface as leaked tasks in an
+    unrelated test in a later module.
+    """
+    yield
+    # gc.collect() runs the finalizers synchronously, so anything they schedule
+    # is already registered by the time it returns.
+    gc.collect()
+    if pending := [
+        task
+        for task in asyncio.all_tasks()
+        if not task.done() and "aclose" in (getattr(task.get_coro(), "__qualname__", "") or "")
+    ]:
+        await asyncio.gather(*pending, return_exceptions=True)
+
 
 # 10ms of silence at the output sample rate (24kHz mono, 16-bit)
 _PCM_FRAME = b"\x00\x01" * 240


### PR DESCRIPTION
Fixes the flaky `Test leaked tasks` failure described in #6881.

`AsyncClient.__del__` schedules `aclose()` on whatever event loop is running when the collector reaches it, even for a client the test already closed. Collected late, those tasks surface as leaked tasks in an unrelated test in a later module — usually `tests/test_plugin_openai_stt_context.py`, which never touches google.

This adds an autouse fixture to the one module that builds genai clients, so the finalizers run and finish while that test still owns the loop.

Verified on the CPython build CI uses (3.12.13), full unit suite:

| | `unit-tests` |
| --- | --- |
| before | fails, every run |
| after | passes, every run |

Reverting the fixture brings the failure straight back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
