### PR TITLE
feat(room-io): listen to several participants through one audio input

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -54,6 +54,7 @@ class _ParticipantInputStream(Generic[T], ABC):
         self._streaming = False
         self._participant_identity: str | None = None
         self._attached = True
+        self._forwarding = True
 
         self._forward_atask: asyncio.Task[None] | None = None
         self._tasks: set[asyncio.Task[Any]] = set()
@@ -88,6 +89,15 @@ class _ParticipantInputStream(Generic[T], ABC):
         self._streaming = streaming
         if self._on_stream_changed:
             self._on_stream_changed()
+
+    def _set_forwarding(self, forwarding: bool) -> None:
+        """Whether frames read off the track are worth forwarding at all.
+
+        Separate from `on_attached`/`on_detached`, which are the session's side of the
+        `AudioInput` contract: this is for an owner that is not reading the stream right
+        now, and would otherwise leave frames piling up in a channel nobody drains.
+        """
+        self._forwarding = forwarding
 
     def _drain(self) -> None:
         """Drop whatever is buffered but not consumed yet."""
@@ -179,8 +189,8 @@ class _ParticipantInputStream(Generic[T], ABC):
         }
         logger.debug("start reading stream", extra=extra)
         async for event in stream:
-            if not self._attached:
-                # drop frames if the stream is detached
+            if not self._attached or not self._forwarding:
+                # drop frames if the stream is detached or nobody is reading it
                 continue
             frame = cast(T, event.frame)
             self._process_frame(frame)
@@ -589,7 +599,8 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
     def _on_track_mute_changed(
         self, participant: rtc.Participant, publication: rtc.TrackPublication
     ) -> None:
-        self._child_stream_changed(participant.identity)
+        if publication.source == rtc.TrackSource.SOURCE_MICROPHONE:
+            self._child_stream_changed(participant.identity)
 
 
 class _MixedParticipantAudioInput(_ParticipantAudioInputGroup):
@@ -630,9 +641,13 @@ class _MixedParticipantAudioInput(_ParticipantAudioInputGroup):
             return
 
         if not stream.streaming:
+            # the mixer is this child's only reader, so an unmixed child has to stop
+            # producing, whether it is leaving the mix or was never in it (a track
+            # subscribed while already muted never reaches _stop_mixing)
+            stream._set_forwarding(False)
             self._stop_mixing(identity, stream)
         elif identity not in self._mixing:
-            stream.on_attached()
+            stream._set_forwarding(True)
             stream._drain()  # start from live audio, not from what piled up while unregistered
             self._mixer.add_stream(stream)
             self._mixing.add(identity)
@@ -643,9 +658,6 @@ class _MixedParticipantAudioInput(_ParticipantAudioInputGroup):
 
         self._mixer.remove_stream(stream)
         self._mixing.discard(identity)
-        # the mixer is this child's only reader, so it has to stop producing rather than
-        # buffer into a channel nobody drains, whatever a muted track keeps delivering
-        stream.on_detached()
 
         if not self._mixing:
             # nothing left to mix: the session needs silence to flush the pending transcript,

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -470,6 +470,11 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
         self._tasks: set[asyncio.Task[Any]] = set()
         self._data_ch = aio.Chan[rtc.AudioFrame]()
 
+        # a muted track is not unpublished and its stream doesn't end, it just stops
+        # delivering, so nothing else tells a group its child went quiet
+        self._room.on("track_muted", self._on_track_mute_changed)
+        self._room.on("track_unmuted", self._on_track_mute_changed)
+
         self._new_stream = functools.partial(
             _ParticipantAudioInputStream,
             room,
@@ -539,6 +544,9 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
 
     @override
     async def aclose(self) -> None:
+        self._room.off("track_muted", self._on_track_mute_changed)
+        self._room.off("track_unmuted", self._on_track_mute_changed)
+
         for stream in self._streams.values():
             await self._close_stream(stream)
         self._streams.clear()
@@ -575,7 +583,12 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
         pass
 
     def _child_stream_changed(self, identity: str) -> None:
-        """A participant's track was subscribed, replaced or lost."""
+        """A participant's track was subscribed, replaced, muted or lost."""
+
+    def _on_track_mute_changed(
+        self, participant: rtc.Participant, publication: rtc.TrackPublication
+    ) -> None:
+        self._child_stream_changed(participant.identity)
         pass
 
 
@@ -583,13 +596,6 @@ class _MixedParticipantAudioInput(_ParticipantAudioInputGroup):
     """Sums every participant's microphone, so overlapping speech is preserved."""
 
     def __init__(self, room: rtc.Room, **kwargs: Any) -> None:
-        # the mixer paces every registered stream at real time, so the pre-connect buffer
-        # would not be caught up on: it would leave that participant seconds behind the rest
-        # of the mix for the whole session
-        if kwargs.get("pre_connect_audio_handler") is not None:
-            logger.warning("pre-connect audio is not supported when mixing participants")
-            kwargs["pre_connect_audio_handler"] = None
-
         super().__init__(room, **kwargs)
         self._mixing: set[str] = set()
         self._mixer = rtc.AudioMixer(
@@ -602,16 +608,8 @@ class _MixedParticipantAudioInput(_ParticipantAudioInputGroup):
         )
         self._forward_atask = asyncio.create_task(self._forward_mixed())
 
-        # a muted track is not unpublished and its stream doesn't end, it just stops
-        # delivering: without these the mixer would keep waiting on it every block
-        self._room.on("track_muted", self._on_track_mute_changed)
-        self._room.on("track_unmuted", self._on_track_mute_changed)
-
     @override
     async def aclose(self) -> None:
-        self._room.off("track_muted", self._on_track_mute_changed)
-        self._room.off("track_unmuted", self._on_track_mute_changed)
-
         await self._mixer.aclose()
         await aio.cancel_and_wait(self._forward_atask)
         self._mixing.clear()
@@ -656,11 +654,6 @@ class _MixedParticipantAudioInput(_ParticipantAudioInputGroup):
     def _close_turn(self) -> None:
         if not self._mixing:
             self._send(audio.silence_frame(_TURN_GAP, self._sample_rate, self._num_channels))
-
-    def _on_track_mute_changed(
-        self, participant: rtc.Participant, publication: rtc.TrackPublication
-    ) -> None:
-        self._child_stream_changed(participant.identity)
 
     @log_exceptions(logger=logger)
     async def _forward_mixed(self) -> None:
@@ -723,9 +716,24 @@ class _ActiveSpeakerAudioInput(_ParticipantAudioInputGroup):
 
         self._select_reported()
 
+    @override
+    def _child_stream_changed(self, identity: str) -> None:
+        stream = self._streams.get(identity)
+        if self._speaking == identity and (stream is None or not stream.streaming):
+            # a muted speaker the server still reports would otherwise hold the floor
+            # while delivering nothing, and nobody else could be selected
+            self._release()
+        self._select_reported()
+
     def _select_reported(self) -> None:
-        if self._speaking is None and self._reported:
-            self._select(self._reported[0])
+        if self._speaking is not None:
+            return
+
+        for identity in self._reported:
+            stream = self._streams.get(identity)
+            if stream is not None and stream.streaming:
+                self._select(identity)
+                return
 
     def _select(self, identity: str) -> None:
         self._speaking = identity

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -461,6 +461,9 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
         frame_size_ms: int = 50,
     ) -> None:
         super().__init__(label="RoomIO")
+        if frame_size_ms <= 0:
+            raise ValueError("frame_size_ms must be greater than 0")
+
         self._room = room
         self._sample_rate = sample_rate
         self._num_channels = num_channels
@@ -547,7 +550,7 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
         self._room.off("track_muted", self._on_track_mute_changed)
         self._room.off("track_unmuted", self._on_track_mute_changed)
 
-        for stream in self._streams.values():
+        for stream in list(self._streams.values()):
             await self._close_stream(stream)
         self._streams.clear()
 
@@ -629,6 +632,7 @@ class _MixedParticipantAudioInput(_ParticipantAudioInputGroup):
         if not stream.streaming:
             self._stop_mixing(identity, stream)
         elif identity not in self._mixing:
+            stream.on_attached()
             stream._drain()  # start from live audio, not from what piled up while unregistered
             self._mixer.add_stream(stream)
             self._mixing.add(identity)
@@ -639,6 +643,9 @@ class _MixedParticipantAudioInput(_ParticipantAudioInputGroup):
 
         self._mixer.remove_stream(stream)
         self._mixing.discard(identity)
+        # the mixer is this child's only reader, so it has to stop producing rather than
+        # buffer into a channel nobody drains, whatever a muted track keeps delivering
+        stream.on_detached()
 
         if not self._mixing:
             # nothing left to mix: the session needs silence to flush the pending transcript,
@@ -705,8 +712,10 @@ class _ActiveSpeakerAudioInput(_ParticipantAudioInputGroup):
         # until one arrives, and a speaker keeps the floor until the server drops them, so a
         # louder participant never cuts into the middle of a turn. if sparse updates turn out
         # to lose turns in practice, the fallback is to pick the loudest pre-roll by RMS
-        # the server sends the loudest first; identities we don't listen to are not candidates
-        self._reported = [p.identity for p in speakers if p.identity in self._streams]
+        # the server sends the loudest first. kept unfiltered: a participant added after this
+        # update takes the floor as soon as their stream is live, rather than staying unheard
+        # until the server happens to send another one
+        self._reported = [p.identity for p in speakers]
 
         if self._speaking is not None and self._speaking not in self._reported:
             self._release()

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Iterable
+from collections import deque
+from collections.abc import AsyncIterator, Callable, Iterable
 from typing import Any, Generic, TypeVar, cast
 
 from typing_extensions import override
@@ -11,12 +13,17 @@ import livekit.rtc as rtc
 from livekit.rtc._proto.track_pb2 import AudioTrackFeature
 
 from ...log import logger
-from ...utils import aio, log_exceptions
+from ...utils import aio, audio, log_exceptions
 from ..io import AudioInput, VideoInput
 from ._pre_connect_audio import PreConnectAudioHandler
-from .types import NoiseCancellationParams, NoiseCancellationSelector
+from .types import NoiseCancellationParams, NoiseCancellationSelector, ParticipantsMode
 
 T = TypeVar("T", bound=rtc.AudioFrame | rtc.VideoFrame)
+
+_TURN_GAP = 0.5
+"""Silence pushed to the session to close a turn, so the STT flushes what it has."""
+_PREROLL = 2.0
+"""Audio held per participant before they are selected as the active speaker."""
 
 
 class _ParticipantInputStream(Generic[T], ABC):
@@ -31,8 +38,10 @@ class _ParticipantInputStream(Generic[T], ABC):
         *,
         track_source: rtc.TrackSource.ValueType | list[rtc.TrackSource.ValueType],
         processor: rtc.FrameProcessor[T] | None = None,
+        on_stream_changed: Callable[[], None] | None = None,
     ) -> None:
         self._room = room
+        self._on_stream_changed = on_stream_changed
         self._accepted_sources = (
             {track_source}
             if isinstance(track_source, rtc.TrackSource.ValueType)
@@ -42,6 +51,7 @@ class _ParticipantInputStream(Generic[T], ABC):
         self._data_ch = aio.Chan[T]()
         self._publication: rtc.RemoteTrackPublication | None = None
         self._stream: rtc.VideoStream | rtc.AudioStream | None = None
+        self._streaming = False
         self._participant_identity: str | None = None
         self._attached = True
 
@@ -65,6 +75,24 @@ class _ParticipantInputStream(Generic[T], ABC):
         if not self._publication:
             return rtc.TrackSource.SOURCE_UNKNOWN
         return self._publication.source
+
+    @property
+    def streaming(self) -> bool:
+        """Whether a live, unmuted track is currently being read."""
+        return self._streaming and not (self._publication and self._publication.muted)
+
+    def _set_streaming(self, streaming: bool) -> None:
+        if streaming == self._streaming:
+            return
+
+        self._streaming = streaming
+        if self._on_stream_changed:
+            self._on_stream_changed()
+
+    def _drain(self) -> None:
+        """Drop whatever is buffered but not consumed yet."""
+        while not self._data_ch.empty():
+            self._data_ch.recv_nowait()
 
     def on_attached(self) -> None:
         logger.debug(
@@ -156,6 +184,8 @@ class _ParticipantInputStream(Generic[T], ABC):
             self._process_frame(frame)
             await self._data_ch.send(frame)
 
+        # a track can stop delivering without being unpublished, e.g. the publisher closing it
+        self._set_streaming(False)
         logger.debug("stream closed", extra=extra)
 
     def _process_frame(self, frame: T) -> None:
@@ -184,6 +214,7 @@ class _ParticipantInputStream(Generic[T], ABC):
             self._tasks.add(task)
             self._stream = None
             self._publication = None
+            self._set_streaming(False)
         self._update_processor(None)
 
     def _on_track_available(
@@ -205,6 +236,7 @@ class _ParticipantInputStream(Generic[T], ABC):
         self._forward_atask = asyncio.create_task(
             self._forward_task(self._forward_atask, self._stream, publication, participant)
         )
+        self._set_streaming(True)
         return True
 
     def _on_track_unavailable(
@@ -227,7 +259,34 @@ class _ParticipantInputStream(Generic[T], ABC):
                 return
 
 
-class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], AudioInput):
+class _RoomAudioInput(AudioInput, ABC):
+    """The audio input `RoomIO` drives.
+
+    `RoomIO` owns the participant lifecycle and routes it here: `add_participant` and
+    `remove_participant` are called for every accepted participant, `set_participant` for
+    the linked one. An input that only listens to the linked participant ignores the former.
+    """
+
+    @abstractmethod
+    def set_participant(self, participant: rtc.RemoteParticipant | str | None) -> None: ...
+
+    @abstractmethod
+    async def aclose(self) -> None: ...
+
+    def add_participant(self, participant: rtc.RemoteParticipant) -> None:
+        """Called for every accepted participant.
+
+        Does nothing by default: an input that only listens to the linked participant has
+        nothing to do with the others, and `set_participant` already tells it who that is.
+        """
+        pass
+
+    def remove_participant(self, identity: str) -> None:
+        """Called when a participant leaves. Does nothing by default, see `add_participant`."""
+        pass
+
+
+class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], _RoomAudioInput):
     def __init__(
         self,
         room: rtc.Room,
@@ -241,6 +300,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         auto_gain_control: bool = True,
         pre_connect_audio_handler: PreConnectAudioHandler | None,
         frame_size_ms: int = 50,
+        on_stream_changed: Callable[[], None] | None = None,
     ) -> None:
         _ParticipantInputStream.__init__(
             self,
@@ -249,8 +309,9 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             processor=(
                 noise_cancellation if isinstance(noise_cancellation, rtc.FrameProcessor) else None
             ),
+            on_stream_changed=on_stream_changed,
         )
-        AudioInput.__init__(self, label="RoomIO")
+        _RoomAudioInput.__init__(self, label="RoomIO")
         if frame_size_ms <= 0:
             raise ValueError("frame_size_ms must be greater than 0")
 
@@ -334,14 +395,8 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         await super()._forward_task(old_task, stream, publication, participant)
 
         # push a silent frame to flush the stt final result if any
-        silent_samples = int(self._sample_rate * 0.5)
         await self._data_ch.send(
-            rtc.AudioFrame(
-                b"\x00\x00" * silent_samples,
-                sample_rate=self._sample_rate,
-                num_channels=self._num_channels,
-                samples_per_channel=silent_samples,
-            )
+            audio.silence_frame(_TURN_GAP, self._sample_rate, self._num_channels)
         )
 
     def _resample_frames(self, frames: Iterable[rtc.AudioFrame]) -> Iterable[rtc.AudioFrame]:
@@ -377,6 +432,288 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                     yield frame
             else:
                 yield frame
+
+
+class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
+    """Several participants behind a single audio input.
+
+    Owns one unchanged :class:`_ParticipantAudioInputStream` per participant; subclasses
+    decide how those are combined into the frames the session reads.
+    """
+
+    def __init__(
+        self,
+        room: rtc.Room,
+        *,
+        sample_rate: int,
+        num_channels: int,
+        noise_cancellation: rtc.NoiseCancellationOptions
+        | NoiseCancellationSelector
+        | rtc.FrameProcessor[rtc.AudioFrame]
+        | None,
+        auto_gain_control: bool = True,
+        pre_connect_audio_handler: PreConnectAudioHandler | None,
+        frame_size_ms: int = 50,
+    ) -> None:
+        super().__init__(label="RoomIO")
+        self._room = room
+        self._sample_rate = sample_rate
+        self._num_channels = num_channels
+        self._frame_size_ms = frame_size_ms
+        self._attached = True
+        self._streams: dict[str, _ParticipantAudioInputStream] = {}
+        self._tasks: set[asyncio.Task[Any]] = set()
+        self._data_ch = aio.Chan[rtc.AudioFrame]()
+
+        self._new_stream = functools.partial(
+            _ParticipantAudioInputStream,
+            room,
+            sample_rate=sample_rate,
+            num_channels=num_channels,
+            noise_cancellation=noise_cancellation,
+            auto_gain_control=auto_gain_control,
+            pre_connect_audio_handler=pre_connect_audio_handler,
+            frame_size_ms=frame_size_ms,
+        )
+
+        if isinstance(noise_cancellation, rtc.FrameProcessor):
+            logger.warning(
+                "a single noise cancellation processor is shared by every participant, which "
+                "interleaves speakers through one stateful filter. pass a callable returning "
+                "a new processor per participant instead",
+                extra={"processor": type(noise_cancellation).__name__},
+            )
+
+    @override
+    def add_participant(self, participant: rtc.RemoteParticipant | str) -> None:
+        identity = (
+            participant.identity if isinstance(participant, rtc.RemoteParticipant) else participant
+        )
+        if identity in self._streams:
+            return
+
+        stream = self._new_stream(
+            on_stream_changed=functools.partial(self._child_stream_changed, identity)
+        )
+        self._streams[identity] = stream
+        self._child_added(identity, stream)
+        # last: subscribing to a published track calls back into _child_stream_changed
+        stream.set_participant(participant)
+
+    @override
+    def remove_participant(self, identity: str) -> None:
+        if (stream := self._streams.pop(identity, None)) is None:
+            return
+
+        self._child_removed(identity, stream)
+        task = asyncio.create_task(stream.aclose())
+        task.add_done_callback(self._tasks.discard)
+        self._tasks.add(task)
+
+    @override
+    def set_participant(self, participant: rtc.RemoteParticipant | str | None) -> None:
+        """Ignored: every accepted participant is listened to, linking only drives the outputs."""
+
+    @override
+    async def __anext__(self) -> rtc.AudioFrame:
+        return await self._data_ch.__anext__()
+
+    @override
+    def on_attached(self) -> None:
+        # not forwarded to the participant streams on purpose, see _send()
+        self._attached = True
+
+    @override
+    def on_detached(self) -> None:
+        self._attached = False
+
+    @override
+    async def aclose(self) -> None:
+        for stream in self._streams.values():
+            await stream.aclose()
+        self._streams.clear()
+
+        self._data_ch.close()
+        await aio.cancel_and_wait(*self._tasks)
+        self._tasks.clear()
+
+    def _send(self, frame: rtc.AudioFrame) -> None:
+        """Hand a frame to the session, dropping it while the input is detached.
+
+        Dropping here rather than in the participant streams keeps them reading: a stream
+        that stops delivering stalls the mixer and starves the active speaker detection.
+        """
+        if self._attached and not self._data_ch.closed:
+            self._data_ch.send_nowait(frame)
+
+    # the hooks below are how a subclass combines its children; each is a no-op here because
+    # the group itself only owns their lifetime, not what the session ends up hearing
+
+    def _child_added(self, identity: str, stream: _ParticipantAudioInputStream) -> None:
+        """A participant's stream was created, before it subscribes to anything."""
+        pass
+
+    def _child_removed(self, identity: str, stream: _ParticipantAudioInputStream) -> None:
+        """A participant's stream is about to be closed."""
+        pass
+
+    def _child_stream_changed(self, identity: str) -> None:
+        """A participant's track was subscribed, replaced or lost."""
+        pass
+
+
+class _MixedParticipantAudioInput(_ParticipantAudioInputGroup):
+    """Sums every participant's microphone, so overlapping speech is preserved."""
+
+    def __init__(self, room: rtc.Room, **kwargs: Any) -> None:
+        super().__init__(room, **kwargs)
+        self._mixing: set[str] = set()
+        self._mixer = rtc.AudioMixer(
+            self._sample_rate,
+            self._num_channels,
+            blocksize=int(self._sample_rate * self._frame_size_ms / 1000),
+            # must stay above the frame interval: the mixer pads a stream that misses this
+            # deadline, so a live stream would get chopped by a tighter timeout
+            stream_timeout_ms=max(100, self._frame_size_ms * 2),
+        )
+        self._forward_atask = asyncio.create_task(self._forward_mixed())
+
+        # a muted track is not unpublished and its stream doesn't end, it just stops
+        # delivering: without these the mixer would keep waiting on it every block
+        self._room.on("track_muted", self._on_track_mute_changed)
+        self._room.on("track_unmuted", self._on_track_mute_changed)
+
+    @override
+    async def aclose(self) -> None:
+        self._room.off("track_muted", self._on_track_mute_changed)
+        self._room.off("track_unmuted", self._on_track_mute_changed)
+
+        await self._mixer.aclose()
+        await aio.cancel_and_wait(self._forward_atask)
+        self._mixing.clear()
+        await super().aclose()
+
+    @override
+    def _child_removed(self, identity: str, stream: _ParticipantAudioInputStream) -> None:
+        self._stop_mixing(identity, stream)
+
+    @override
+    def _child_stream_changed(self, identity: str) -> None:
+        """Register a participant with the mixer only while it has audio to give.
+
+        The mixer waits `stream_timeout_ms` on every registered stream for every block, so an
+        idle one paces the whole mix below real time and warns on every block.
+        """
+        if (stream := self._streams.get(identity)) is None:
+            return
+
+        if not stream.streaming:
+            self._stop_mixing(identity, stream)
+        elif identity not in self._mixing:
+            stream._drain()  # start from live audio, not from what piled up while unregistered
+            self._mixer.add_stream(stream)
+            self._mixing.add(identity)
+
+    def _stop_mixing(self, identity: str, stream: _ParticipantAudioInputStream) -> None:
+        if identity not in self._mixing:
+            return
+
+        self._mixer.remove_stream(stream)
+        self._mixing.discard(identity)
+
+        if not self._mixing:
+            # nothing left to mix: the session needs silence to flush the pending transcript.
+            # while others are still talking the mix carries on and injecting it would punch
+            # a hole in their audio
+            self._send(audio.silence_frame(_TURN_GAP, self._sample_rate, self._num_channels))
+
+    def _on_track_mute_changed(
+        self, participant: rtc.Participant, publication: rtc.TrackPublication
+    ) -> None:
+        self._child_stream_changed(participant.identity)
+
+    @log_exceptions(logger=logger)
+    async def _forward_mixed(self) -> None:
+        async for frame in self._mixer:
+            self._send(frame)
+
+
+class _ActiveSpeakerAudioInput(_ParticipantAudioInputGroup):
+    """Forwards one participant at a time, the one the server reports as speaking.
+
+    Overlapping speech is dropped rather than summed, which keeps the audio the STT sees
+    clean at the cost of losing whatever the other participants said meanwhile.
+    """
+
+    def __init__(self, room: rtc.Room, **kwargs: Any) -> None:
+        super().__init__(room, **kwargs)
+        self._speaking: str | None = None
+        # `active_speakers_changed` lags the onset of speech, so a participant's audio is held
+        # until they are selected and flushed as pre-roll: without it every turn loses its
+        # first syllables. it doubles as the overlap window, so keep it short
+        self._preroll: dict[str, deque[rtc.AudioFrame]] = {}
+        self._preroll_len = max(1, int(_PREROLL / (self._frame_size_ms / 1000)))
+        self._room.on("active_speakers_changed", self._on_active_speakers_changed)
+
+    @override
+    async def aclose(self) -> None:
+        self._room.off("active_speakers_changed", self._on_active_speakers_changed)
+        await super().aclose()
+        self._preroll.clear()
+
+    @override
+    def _child_added(self, identity: str, stream: _ParticipantAudioInputStream) -> None:
+        self._preroll[identity] = deque(maxlen=self._preroll_len)
+        task = asyncio.create_task(self._forward_speaker(identity, stream))
+        task.add_done_callback(self._tasks.discard)
+        self._tasks.add(task)
+
+    @override
+    def _child_removed(self, identity: str, stream: _ParticipantAudioInputStream) -> None:
+        self._preroll.pop(identity, None)
+        if self._speaking == identity:
+            self._release()
+
+    def _on_active_speakers_changed(self, speakers: list[rtc.Participant]) -> None:
+        # ponytail: selection is driven entirely by the server's speaker updates, so nothing is
+        # forwarded if they never arrive. fall back to picking the loudest pre-roll by RMS if
+        # that ever shows up in practice
+        # the server sends the loudest first; identities we don't listen to are not candidates
+        speaking = [p.identity for p in speakers if p.identity in self._streams]
+
+        if self._speaking is not None and self._speaking not in speaking:
+            self._release()
+
+        if self._speaking is None and speaking:
+            self._select(speaking[0])
+
+    def _select(self, identity: str) -> None:
+        self._speaking = identity
+        for frame in self._preroll.get(identity, ()):
+            self._send(frame)
+        for preroll in self._preroll.values():
+            preroll.clear()
+
+    def _release(self) -> None:
+        self._speaking = None
+        # segment the turn: without a gap this speaker's tail and the next one's opening
+        # reach the STT as a single utterance and end up merged in the transcript
+        self._send(audio.silence_frame(_TURN_GAP, self._sample_rate, self._num_channels))
+
+    @log_exceptions(logger=logger)
+    async def _forward_speaker(self, identity: str, stream: _ParticipantAudioInputStream) -> None:
+        async for frame in stream:
+            if identity == self._speaking:
+                self._send(frame)
+            elif (preroll := self._preroll.get(identity)) is not None:
+                preroll.append(frame)  # bounded: the oldest frame falls off
+
+
+ROOM_AUDIO_INPUTS: dict[ParticipantsMode, Callable[..., _RoomAudioInput]] = {
+    "linked": _ParticipantAudioInputStream,
+    "mix": _MixedParticipantAudioInput,
+    "pick": _ActiveSpeakerAudioInput,
+}
 
 
 class _ParticipantVideoInputStream(_ParticipantInputStream[rtc.VideoFrame], VideoInput):

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -145,13 +145,15 @@ class _ParticipantInputStream(Generic[T], ABC):
                     continue
                 self._on_track_available(publication.track, publication, participant)
 
-    async def aclose(self) -> None:
+    async def aclose(self, *, close_processor: bool = True) -> None:
         if self._stream:
             await self._stream.aclose()
             self._stream = None
         self._publication = None
         if self._processor:
-            self._processor._close()
+            # a processor shared between streams is closed by whoever owns it, once
+            if close_processor or self._processor_owned:
+                self._processor._close()
             self._processor = None
         if self._forward_atask:
             await aio.cancel_and_wait(self._forward_atask)
@@ -184,8 +186,11 @@ class _ParticipantInputStream(Generic[T], ABC):
             self._process_frame(frame)
             await self._data_ch.send(frame)
 
-        # a track can stop delivering without being unpublished, e.g. the publisher closing it
-        self._set_streaming(False)
+        # a track can stop delivering without being unpublished, e.g. the publisher closing it.
+        # guarded so a task winding down after a track swap cannot clear the flag its
+        # replacement just set, whatever order the two get scheduled in
+        if self._publication is publication:
+            self._set_streaming(False)
         logger.debug("stream closed", extra=extra)
 
     def _process_frame(self, frame: T) -> None:
@@ -476,7 +481,12 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
             frame_size_ms=frame_size_ms,
         )
 
-        if isinstance(noise_cancellation, rtc.FrameProcessor):
+        # every child is handed the same instance, so the group closes it rather than
+        # letting each of them close it in turn
+        self._shared_processor = (
+            noise_cancellation if isinstance(noise_cancellation, rtc.FrameProcessor) else None
+        )
+        if self._shared_processor is not None:
             logger.warning(
                 "a single noise cancellation processor is shared by every participant, which "
                 "interleaves speakers through one stateful filter. pass a callable returning "
@@ -506,7 +516,7 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
             return
 
         self._child_removed(identity, stream)
-        task = asyncio.create_task(stream.aclose())
+        task = asyncio.create_task(self._close_stream(stream))
         task.add_done_callback(self._tasks.discard)
         self._tasks.add(task)
 
@@ -530,12 +540,19 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
     @override
     async def aclose(self) -> None:
         for stream in self._streams.values():
-            await stream.aclose()
+            await self._close_stream(stream)
         self._streams.clear()
+
+        if self._shared_processor is not None:
+            self._shared_processor._close()
+            self._shared_processor = None
 
         self._data_ch.close()
         await aio.cancel_and_wait(*self._tasks)
         self._tasks.clear()
+
+    async def _close_stream(self, stream: _ParticipantAudioInputStream) -> None:
+        await stream.aclose(close_processor=self._shared_processor is None)
 
     def _send(self, frame: rtc.AudioFrame) -> None:
         """Hand a frame to the session, dropping it while the input is detached.
@@ -566,6 +583,13 @@ class _MixedParticipantAudioInput(_ParticipantAudioInputGroup):
     """Sums every participant's microphone, so overlapping speech is preserved."""
 
     def __init__(self, room: rtc.Room, **kwargs: Any) -> None:
+        # the mixer paces every registered stream at real time, so the pre-connect buffer
+        # would not be caught up on: it would leave that participant seconds behind the rest
+        # of the mix for the whole session
+        if kwargs.get("pre_connect_audio_handler") is not None:
+            logger.warning("pre-connect audio is not supported when mixing participants")
+            kwargs["pre_connect_audio_handler"] = None
+
         super().__init__(room, **kwargs)
         self._mixing: set[str] = set()
         self._mixer = rtc.AudioMixer(
@@ -622,9 +646,15 @@ class _MixedParticipantAudioInput(_ParticipantAudioInputGroup):
         self._mixing.discard(identity)
 
         if not self._mixing:
-            # nothing left to mix: the session needs silence to flush the pending transcript.
+            # nothing left to mix: the session needs silence to flush the pending transcript,
+            # but only once the room has settled. a track being replaced empties the mix for
+            # the rest of the tick and re-registers, and that is not the end of a turn.
             # while others are still talking the mix carries on and injecting it would punch
             # a hole in their audio
+            asyncio.get_running_loop().call_soon(self._close_turn)
+
+    def _close_turn(self) -> None:
+        if not self._mixing:
             self._send(audio.silence_frame(_TURN_GAP, self._sample_rate, self._num_channels))
 
     def _on_track_mute_changed(
@@ -653,6 +683,7 @@ class _ActiveSpeakerAudioInput(_ParticipantAudioInputGroup):
         # first syllables. it doubles as the overlap window, so keep it short
         self._preroll: dict[str, deque[rtc.AudioFrame]] = {}
         self._preroll_len = max(1, int(_PREROLL / (self._frame_size_ms / 1000)))
+        self._reported: list[str] = []  # last speakers the server reported, loudest first
         self._room.on("active_speakers_changed", self._on_active_speakers_changed)
 
     @override
@@ -671,21 +702,30 @@ class _ActiveSpeakerAudioInput(_ParticipantAudioInputGroup):
     @override
     def _child_removed(self, identity: str, stream: _ParticipantAudioInputStream) -> None:
         self._preroll.pop(identity, None)
+        if identity in self._reported:
+            self._reported.remove(identity)
         if self._speaking == identity:
+            # whoever else the server last reported keeps the floor: waiting for the next
+            # update would drop their turn
             self._release()
+            self._select_reported()
 
     def _on_active_speakers_changed(self, speakers: list[rtc.Participant]) -> None:
-        # ponytail: selection is driven entirely by the server's speaker updates, so nothing is
-        # forwarded if they never arrive. fall back to picking the loudest pre-roll by RMS if
-        # that ever shows up in practice
+        # selection is driven entirely by the server's speaker updates: nothing is forwarded
+        # until one arrives, and a speaker keeps the floor until the server drops them, so a
+        # louder participant never cuts into the middle of a turn. if sparse updates turn out
+        # to lose turns in practice, the fallback is to pick the loudest pre-roll by RMS
         # the server sends the loudest first; identities we don't listen to are not candidates
-        speaking = [p.identity for p in speakers if p.identity in self._streams]
+        self._reported = [p.identity for p in speakers if p.identity in self._streams]
 
-        if self._speaking is not None and self._speaking not in speaking:
+        if self._speaking is not None and self._speaking not in self._reported:
             self._release()
 
-        if self._speaking is None and speaking:
-            self._select(speaking[0])
+        self._select_reported()
+
+    def _select_reported(self) -> None:
+        if self._speaking is None and self._reported:
+            self._select(self._reported[0])
 
     def _select(self, identity: str) -> None:
         self._speaking = identity

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -22,8 +22,13 @@ T = TypeVar("T", bound=rtc.AudioFrame | rtc.VideoFrame)
 
 _TURN_GAP = 0.5
 """Silence pushed to the session to close a turn, so the STT flushes what it has."""
-_PREROLL = 2.0
-"""Audio held per participant before they are selected as the active speaker."""
+_PREROLL = 0.5
+"""Audio held per participant before they are selected as the active speaker.
+
+Sized against how late `active_speakers_changed` is rather than how much audio could be
+kept: it doubles as the overlap window, so everything held is replayed to the session on
+selection, including whatever the previous speaker was talking over.
+"""
 
 
 class _ParticipantInputStream(Generic[T], ABC):

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -101,6 +101,10 @@ class _ParticipantInputStream(Generic[T], ABC):
         Separate from `on_attached`/`on_detached`, which are the session's side of the
         `AudioInput` contract: this is for an owner that is not reading the stream right
         now, and would otherwise leave frames piling up in a channel nobody drains.
+
+        The owner must keep "not forwarding" and "not being read" the same thing. A stream
+        left registered with a reader that paces itself, `rtc.AudioMixer` in particular,
+        stalls that reader on every block once it stops delivering.
         """
         self._forwarding = forwarding
 
@@ -321,6 +325,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], _Roo
         pre_connect_audio_handler: PreConnectAudioHandler | None,
         frame_size_ms: int = 50,
         on_stream_changed: Callable[[], None] | None = None,
+        flush_on_track_end: bool = True,
     ) -> None:
         _ParticipantInputStream.__init__(
             self,
@@ -340,6 +345,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], _Roo
         self._frame_size_ms = frame_size_ms
         self._noise_cancellation = noise_cancellation
         self._pre_connect_audio_handler = pre_connect_audio_handler
+        self._flush_on_track_end = flush_on_track_end
         self._apm: rtc.AudioProcessingModule | None = None
         if auto_gain_control:
             self._apm = rtc.AudioProcessingModule(auto_gain_control=True)
@@ -414,10 +420,13 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], _Roo
 
         await super()._forward_task(old_task, stream, publication, participant)
 
-        # push a silent frame to flush the stt final result if any
-        await self._data_ch.send(
-            audio.silence_frame(_TURN_GAP, self._sample_rate, self._num_channels)
-        )
+        # push a silent frame to flush the stt final result if any. an owner combining
+        # several participants segments turns itself, and this frame would land in a buffer
+        # nobody is reading or in the pre-roll of somebody who is not speaking
+        if self._flush_on_track_end:
+            await self._data_ch.send(
+                audio.silence_frame(_TURN_GAP, self._sample_rate, self._num_channels)
+            )
 
     def _resample_frames(self, frames: Iterable[rtc.AudioFrame]) -> Iterable[rtc.AudioFrame]:
         resampler: rtc.AudioResampler | None = None
@@ -484,6 +493,7 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
         self._num_channels = num_channels
         self._frame_size_ms = frame_size_ms
         self._attached = True
+        self._closed = False
         self._streams: dict[str, _ParticipantAudioInputStream] = {}
         self._tasks: set[asyncio.Task[Any]] = set()
         self._data_ch = aio.Chan[rtc.AudioFrame]()
@@ -502,6 +512,7 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
             auto_gain_control=auto_gain_control,
             pre_connect_audio_handler=pre_connect_audio_handler,
             frame_size_ms=frame_size_ms,
+            flush_on_track_end=False,
         )
 
         # every child is handed the same instance, so the group closes it rather than
@@ -522,7 +533,7 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
         identity = (
             participant.identity if isinstance(participant, rtc.RemoteParticipant) else participant
         )
-        if identity in self._streams:
+        if self._closed or identity in self._streams:
             return
 
         stream = self._new_stream(
@@ -562,6 +573,7 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
 
     @override
     async def aclose(self) -> None:
+        self._closed = True
         self._room.off("track_muted", self._on_track_mute_changed)
         self._room.off("track_unmuted", self._on_track_mute_changed)
 
@@ -626,10 +638,13 @@ class _MixedParticipantAudioInput(_ParticipantAudioInputGroup):
 
     @override
     async def aclose(self) -> None:
+        # children first: each keeps its own `track_subscribed` handler until it is closed,
+        # and closing the mixer under a live one turns a subscription landing mid-teardown
+        # into a RuntimeError raised inside the room's event dispatch
+        await super().aclose()
         await self._mixer.aclose()
         await aio.cancel_and_wait(self._forward_atask)
         self._mixing.clear()
-        await super().aclose()
 
     @override
     def _child_removed(self, identity: str, stream: _ParticipantAudioInputStream) -> None:
@@ -642,7 +657,7 @@ class _MixedParticipantAudioInput(_ParticipantAudioInputGroup):
         The mixer waits `stream_timeout_ms` on every registered stream for every block, so an
         idle one paces the whole mix below real time and warns on every block.
         """
-        if (stream := self._streams.get(identity)) is None:
+        if self._closed or (stream := self._streams.get(identity)) is None:
             return
 
         if not stream.streaming:
@@ -687,6 +702,10 @@ class _ActiveSpeakerAudioInput(_ParticipantAudioInputGroup):
 
     Overlapping speech is dropped rather than summed, which keeps the audio the STT sees
     clean at the cost of losing whatever the other participants said meanwhile.
+
+    A speaker holds the floor until the server drops them, so nobody cuts into the middle
+    of a turn. The cost is that somebody who goes quiet and comes back while another
+    participant holds the floor is not heard again until the next `active_speakers_changed`.
     """
 
     def __init__(self, room: rtc.Room, **kwargs: Any) -> None:

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -576,11 +576,9 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
 
     def _child_added(self, identity: str, stream: _ParticipantAudioInputStream) -> None:
         """A participant's stream was created, before it subscribes to anything."""
-        pass
 
     def _child_removed(self, identity: str, stream: _ParticipantAudioInputStream) -> None:
         """A participant's stream is about to be closed."""
-        pass
 
     def _child_stream_changed(self, identity: str) -> None:
         """A participant's track was subscribed, replaced, muted or lost."""
@@ -589,7 +587,6 @@ class _ParticipantAudioInputGroup(_RoomAudioInput, ABC):
         self, participant: rtc.Participant, publication: rtc.TrackPublication
     ) -> None:
         self._child_stream_changed(participant.identity)
-        pass
 
 
 class _MixedParticipantAudioInput(_ParticipantAudioInputGroup):
@@ -718,6 +715,11 @@ class _ActiveSpeakerAudioInput(_ParticipantAudioInputGroup):
 
     @override
     def _child_stream_changed(self, identity: str) -> None:
+        # a replaced track closes the old stream and opens its replacement in the same tick.
+        # that is not the speaker stopping, so let the room settle before handing the floor on
+        asyncio.get_running_loop().call_soon(self._update_floor, identity)
+
+    def _update_floor(self, identity: str) -> None:
         stream = self._streams.get(identity)
         if self._speaking == identity and (stream is None or not stream.streaming):
             # a muted speaker the server still reports would otherwise hold the floor

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -104,11 +104,21 @@ class RoomIO:
         # -- create inputs --
         input_audio_options = self._options.get_audio_input_options()
         if input_audio_options and input_audio_options.pre_connect_audio:
-            self._pre_connect_audio_handler = PreConnectAudioHandler(
-                room=self._room,
-                timeout=input_audio_options.pre_connect_audio_timeout,
-            )
-            self._pre_connect_audio_handler.register()
+            if input_audio_options.participants != "linked":
+                # the buffer is audio from before the participant joined, so it is not
+                # concurrent with anyone: replaying it into a stream that is combined with
+                # other participants either paces it behind the rest of the mix or lands it
+                # in the pre-roll of somebody who is not speaking yet
+                logger.warning(
+                    "pre-connect audio is only supported with participants='linked', ignoring",
+                    extra={"participants": input_audio_options.participants},
+                )
+            else:
+                self._pre_connect_audio_handler = PreConnectAudioHandler(
+                    room=self._room,
+                    timeout=input_audio_options.pre_connect_audio_timeout,
+                )
+                self._pre_connect_audio_handler.register()
 
         input_video_options = self._options.get_video_input_options()
         if input_video_options:

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -109,7 +109,9 @@ class RoomIO:
                 # concurrent with anyone: replaying it into a stream that is combined with
                 # other participants either paces it behind the rest of the mix or lands it
                 # in the pre-roll of somebody who is not speaking yet
-                logger.warning(
+                # info, not a warning: pre_connect_audio is on by default, so every mix/pick
+                # session would log it without anyone having asked for it
+                logger.info(
                     "pre-connect audio is only supported with participants='linked', ignoring",
                     extra={"participants": input_audio_options.participants},
                 )

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
 
 from ...job import DEFAULT_PARTICIPANT_KINDS
-from ._input import _ParticipantAudioInputStream, _ParticipantVideoInputStream
+from ._input import ROOM_AUDIO_INPUTS, _ParticipantVideoInputStream, _RoomAudioInput
 from ._output import _ParticipantAudioOutput, _ParticipantTranscriptionOutput
 from .types import (
     DEFAULT_CLOSE_ON_DISCONNECT_REASONS,
@@ -65,7 +65,7 @@ class RoomIO:
         ):
             self._participant_identity = self._options.participant_identity
 
-        self._audio_input: _ParticipantAudioInputStream | None = None
+        self._audio_input: _RoomAudioInput | None = None
         self._video_input: _ParticipantVideoInputStream | None = None
         self._audio_output: _ParticipantAudioOutput | None = None
         self._user_tr_output: _ParticipantTranscriptionOutput | None = None
@@ -115,7 +115,7 @@ class RoomIO:
             self._video_input = _ParticipantVideoInputStream(self._room)
 
         if input_audio_options:
-            self._audio_input = _ParticipantAudioInputStream(
+            self._audio_input = ROOM_AUDIO_INPUTS[input_audio_options.participants](
                 self._room,
                 sample_rate=input_audio_options.sample_rate,
                 num_channels=input_audio_options.num_channels,
@@ -375,6 +375,19 @@ class RoomIO:
             self._room_connected_fut.set_result(None)
 
     def _on_participant_connected(self, participant: rtc.RemoteParticipant) -> None:
+        accepted_kinds = self._options.participant_kinds or DEFAULT_PARTICIPANT_KINDS
+        if participant.kind not in accepted_kinds:
+            # not an accepted participant kind, skip
+            return
+
+        publishing_for_agent = (
+            participant.attributes.get(ATTRIBUTE_PUBLISH_ON_BEHALF)
+            == self._room.local_participant.identity
+        )
+        if self._audio_input and not publishing_for_agent:
+            # ignored unless the audio input listens to more than the linked participant
+            self._audio_input.add_participant(participant)
+
         if self._participant_available_fut.done():
             return
 
@@ -382,21 +395,16 @@ class RoomIO:
             if participant.identity != self._participant_identity:
                 return
         # otherwise, skip participants that are marked as publishing for this agent
-        elif (
-            participant.attributes.get(ATTRIBUTE_PUBLISH_ON_BEHALF)
-            == self._room.local_participant.identity
-        ):
-            return
-
-        accepted_kinds = self._options.participant_kinds or DEFAULT_PARTICIPANT_KINDS
-        if participant.kind not in accepted_kinds:
-            # not an accepted participant kind, skip
+        elif publishing_for_agent:
             return
 
         self._participant_available_fut.set_result(participant)
         self._agent_session._on_room_io_participant_linked(participant)
 
     def _on_participant_disconnected(self, participant: rtc.RemoteParticipant) -> None:
+        if self._audio_input:
+            self._audio_input.remove_participant(participant.identity)
+
         if not (linked := self.linked_participant) or participant.identity != linked.identity:
             return
         self._participant_available_fut = asyncio.Future[rtc.RemoteParticipant]()

--- a/livekit-agents/livekit/agents/voice/room_io/types.py
+++ b/livekit-agents/livekit/agents/voice/room_io/types.py
@@ -139,7 +139,9 @@ class RoomOptions:
     participant: the agent still listens to every accepted one."""
     close_on_disconnect: bool = True
     """Close the AgentSession if the linked participant disconnects with reasons in
-    CLIENT_INITIATED, ROOM_DELETED, or USER_REJECTED."""
+    CLIENT_INITIATED, ROOM_DELETED, or USER_REJECTED. Only the linked participant is
+    watched, so with `AudioInputOptions.participants` set to "mix" or "pick" the session
+    still closes when they leave, even if the agent is listening to others who stayed."""
     delete_room_on_close: bool = False
     """Delete the room when the AgentSession is closed, default to False"""
 
@@ -278,7 +280,9 @@ class RoomInputOptions:
     """The pre-connect audio will be ignored if it doesn't arrive within this time."""
     close_on_disconnect: bool = True
     """Close the AgentSession if the linked participant disconnects with reasons in
-    CLIENT_INITIATED, ROOM_DELETED, or USER_REJECTED."""
+    CLIENT_INITIATED, ROOM_DELETED, or USER_REJECTED. Only the linked participant is
+    watched, so with `AudioInputOptions.participants` set to "mix" or "pick" the session
+    still closes when they leave, even if the agent is listening to others who stayed."""
     delete_room_on_close: bool = False
     """Delete the room when the AgentSession is closed, default to False"""
 

--- a/livekit-agents/livekit/agents/voice/room_io/types.py
+++ b/livekit-agents/livekit/agents/voice/room_io/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Literal, TypeAlias
 
 from livekit import rtc
 
@@ -37,6 +37,8 @@ class NoiseCancellationParams:
     track: rtc.Track
 
 
+ParticipantsMode: TypeAlias = Literal["linked", "mix", "pick"]
+
 NoiseCancellationSelector: TypeAlias = Callable[
     [NoiseCancellationParams],
     rtc.NoiseCancellationOptions | rtc.FrameProcessor[rtc.AudioFrame] | None,
@@ -68,6 +70,16 @@ class AudioInputOptions:
     ) = None
     auto_gain_control: bool = True
     """Enable automatic gain control (AGC) on the input audio. Enabled by default."""
+    participants: ParticipantsMode = "linked"
+    """Which participants the agent listens to. Every speaker lands in the same chat context,
+    transcribed as if they were the linked participant. Only "linked" is affected by
+    `RoomOptions.participant_identity` and `RoomIO.set_participant`.
+
+    - ``"linked"``: only the linked participant (default).
+    - ``"mix"``: every accepted participant, summed together. Keeps overlapping speech.
+    - ``"pick"``: the participant the server reports as speaking, one at a time. Cleaner audio
+      for the STT, but whatever the others say meanwhile is dropped.
+    """
     pre_connect_audio: bool = True
     """Pre-connect audio enabled or not."""
     pre_connect_audio_timeout: float = 3.0
@@ -122,7 +134,9 @@ class RoomOptions:
     accept `DEFAULT_PARTICIPANT_KINDS`."""
     participant_identity: NotGivenOr[str] = NOT_GIVEN
     """The participant to link to. If not provided, link to the first participant.
-    Can be overridden by the `participant` argument of RoomIO constructor or `set_participant`."""
+    Can be overridden by the `participant` argument of RoomIO constructor or `set_participant`.
+    When `AudioInputOptions.participants` is not "linked", this only picks the linked
+    participant: the agent still listens to every accepted one."""
     close_on_disconnect: bool = True
     """Close the AgentSession if the linked participant disconnects with reasons in
     CLIENT_INITIATED, ROOM_DELETED, or USER_REJECTED."""

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -986,6 +986,7 @@ async def test_active_speaker_audio_input_releases_a_muted_speaker() -> None:
         assert audio_input._speaking == "alice"
 
         _mute_track(room, audio_input, "alice", True)
+        await asyncio.sleep(0)  # the floor settles on the next tick
         assert audio_input._speaking == "bob"
         assert 200 in await _amplitudes(audio_input, 10)
     finally:
@@ -1009,3 +1010,24 @@ async def test_roomio_skips_pre_connect_audio_for_group_inputs() -> None:
     finally:
         for room_io in (linked, mixed):
             await room_io.aclose()
+
+
+@pytest.mark.asyncio
+async def test_active_speaker_audio_input_republishing_keeps_the_floor() -> None:
+    """Swapping a track is not the speaker stopping, they keep talking through it."""
+    room = _FakeRoom()
+    audio_input = _make_room_audio_input(room, _ActiveSpeakerAudioInput)
+
+    try:
+        _publish(audio_input, "alice", 100)
+        _publish(audio_input, "bob", 200)
+
+        _report_speakers(room, "alice", "bob")
+        assert set(await _amplitudes(audio_input, 3)) == {100}
+
+        _start_track(audio_input._streams["alice"], "alice", 100, sid="TR_alice_2")
+        await asyncio.sleep(0)
+        assert audio_input._speaking == "alice"
+        assert set(await _amplitudes(audio_input, 5)) == {100}, "no gap, no handover to bob"
+    finally:
+        await audio_input.aclose()

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -5,12 +5,16 @@ from collections import defaultdict
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import numpy as np
 import pytest
 
 from livekit import rtc
 from livekit.agents import utils
+from livekit.agents.types import ATTRIBUTE_PUBLISH_ON_BEHALF
 from livekit.agents.voice.io import PlaybackFinishedEvent
 from livekit.agents.voice.room_io._input import (
+    _ActiveSpeakerAudioInput,
+    _MixedParticipantAudioInput,
     _ParticipantAudioInputStream,
     _ParticipantInputStream,
 )
@@ -20,7 +24,7 @@ from livekit.agents.voice.room_io._output import (
     _ParticipantTranscriptionOutput,
 )
 from livekit.agents.voice.room_io.room_io import RoomIO
-from livekit.agents.voice.room_io.types import NoiseCancellationParams
+from livekit.agents.voice.room_io.types import NoiseCancellationParams, RoomOptions
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
@@ -680,3 +684,225 @@ async def test_audio_output_waits_for_active_submission_and_source_playout() -> 
 
     assert not finished.interrupted
     assert finished.playback_position == pytest.approx(frame.duration)
+
+
+# -- multi participant inputs -------------------------------------------------
+
+
+class _ConstantAudioStream:
+    """AudioStream stand-in delivering frames of a constant amplitude, paced like a track."""
+
+    def __init__(self, value: int, *, samples: int = 1200, count: int = 200) -> None:
+        self._frame = rtc.AudioFrame(
+            data=np.full(samples, value, dtype=np.int16).tobytes(),
+            sample_rate=24000,
+            num_channels=1,
+            samples_per_channel=samples,
+        )
+        self._left = count
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._left <= 0:
+            raise StopAsyncIteration
+        self._left -= 1
+        await asyncio.sleep(self._frame.duration)
+        return SimpleNamespace(frame=self._frame)
+
+    async def aclose(self) -> None:
+        pass
+
+
+def _make_room_audio_input(room: _FakeRoom, cls):
+    return cls(
+        room,
+        sample_rate=24000,
+        num_channels=1,
+        noise_cancellation=None,
+        auto_gain_control=False,
+        pre_connect_audio_handler=None,
+    )
+
+
+def _start_track(stream, identity: str, value: int) -> None:
+    """Publish a microphone track of a constant amplitude for this participant."""
+    track, publication, participant = _make_track_available_args(identity, sid=f"TR_{identity}")
+    publication.muted = False
+    with patch(
+        "livekit.rtc.AudioStream.from_track",
+        side_effect=lambda **kw: _ConstantAudioStream(value),
+    ):
+        stream._on_track_available(track, publication, participant)
+
+
+def _publish(audio_input, identity: str, value: int) -> None:
+    """Add a participant to a group input and start their microphone."""
+    audio_input.add_participant(identity)
+    _start_track(audio_input._streams[identity], identity, value)
+
+
+async def _amplitudes(audio_input, count: int) -> list[int]:
+    """Amplitude of the next `count` frames the session would read."""
+    frames = [await asyncio.wait_for(audio_input.__anext__(), timeout=5.0) for _ in range(count)]
+    return [int(np.frombuffer(frame.data, dtype=np.int16)[0]) for frame in frames]
+
+
+@pytest.mark.asyncio
+async def test_linked_audio_input_only_hears_the_linked_participant() -> None:
+    """The default input follows `set_participant` and ignores the rest of the room."""
+    room = _FakeRoom()
+    audio_input = _make_room_audio_input(room, _ParticipantAudioInputStream)
+
+    try:
+        audio_input.set_participant("alice")
+        audio_input.add_participant("bob")  # RoomIO calls this for everyone, it is a no-op here
+        _start_track(audio_input, "alice", 100)
+        _start_track(audio_input, "bob", 200)
+
+        assert set(await _amplitudes(audio_input, 5)) == {100}
+
+        audio_input.remove_participant("bob")
+        assert set(await _amplitudes(audio_input, 3)) == {100}
+    finally:
+        await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mixed_audio_input_sums_every_participant() -> None:
+    """Participants are summed while they stream, and dropped from the mix once removed."""
+    room = _FakeRoom()
+    audio_input = _make_room_audio_input(room, _MixedParticipantAudioInput)
+
+    try:
+        _publish(audio_input, "alice", 100)
+        _publish(audio_input, "bob", 200)
+        assert audio_input._mixing == {"alice", "bob"}
+        assert 300 in await _amplitudes(audio_input, 3)
+
+        audio_input.remove_participant("bob")
+        assert audio_input._mixing == {"alice"}
+        assert 100 in await _amplitudes(audio_input, 5)
+    finally:
+        await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_active_speaker_audio_input_forwards_one_participant_at_a_time() -> None:
+    """Only the reported speaker is forwarded, preceded by their pre-roll and a turn gap."""
+    room = _FakeRoom()
+    audio_input = _make_room_audio_input(room, _ActiveSpeakerAudioInput)
+
+    def _speaking(*identities: str) -> None:
+        for callback in list(room._events["active_speakers_changed"]):
+            callback([SimpleNamespace(identity=identity) for identity in identities])
+
+    try:
+        _publish(audio_input, "alice", 100)
+        _publish(audio_input, "bob", 200)
+
+        # a second of alice speaking, which is also a second of bob held as pre-roll
+        _speaking("alice")
+        assert set(await _amplitudes(audio_input, 20)) == {100}
+
+        _speaking("bob")
+        started = asyncio.get_running_loop().time()
+        heard = await _amplitudes(audio_input, 15)
+        gap = heard.index(0)  # the turn boundary, so the stt doesn't merge both speakers
+        assert set(heard[gap + 1 :]) == {200}
+        # bob's pre-roll arrives at once: read live, those 15 frames would take 15 * 50ms
+        assert asyncio.get_running_loop().time() - started < 0.5
+    finally:
+        await audio_input.aclose()
+
+
+# -- participant linking ------------------------------------------------------
+
+
+class _RecordingAudioInput:
+    """Stands in for the audio input to record the lifecycle RoomIO drives."""
+
+    def __init__(self) -> None:
+        self.added: list[str] = []
+        self.removed: list[str] = []
+
+    def add_participant(self, participant) -> None:
+        self.added.append(participant.identity)
+
+    def remove_participant(self, identity: str) -> None:
+        self.removed.append(identity)
+
+
+def _remote_participant(
+    identity: str,
+    *,
+    kind=rtc.ParticipantKind.PARTICIPANT_KIND_STANDARD,
+    attributes: dict[str, str] | None = None,
+):
+    participant = MagicMock()
+    participant.identity = identity
+    participant.kind = kind
+    participant.attributes = attributes or {}
+    return participant
+
+
+def _make_room_io(room: _FakeRoom, **options) -> RoomIO:
+    agent_session = SimpleNamespace(_on_room_io_participant_linked=MagicMock())
+    return RoomIO(agent_session, room, options=RoomOptions(**options))
+
+
+@pytest.mark.asyncio
+async def test_roomio_links_only_the_configured_participant() -> None:
+    """`participant_identity` still decides who is linked, whatever else joins."""
+    room = _FakeRoom()
+    room_io = _make_room_io(room, participant_identity="alice")
+
+    room_io._on_participant_connected(_remote_participant("bob"))
+    assert room_io.linked_participant is None
+
+    alice = _remote_participant("alice")
+    room_io._on_participant_connected(alice)
+    assert room_io.linked_participant is alice
+
+
+@pytest.mark.asyncio
+async def test_roomio_skips_agent_publishers_and_unaccepted_kinds() -> None:
+    room = _FakeRoom()
+    room_io = _make_room_io(room)
+
+    # an avatar worker publishing on the agent's behalf is not the user
+    room_io._on_participant_connected(
+        _remote_participant("avatar", attributes={ATTRIBUTE_PUBLISH_ON_BEHALF: "local"})
+    )
+    room_io._on_participant_connected(
+        _remote_participant("egress", kind=rtc.ParticipantKind.PARTICIPANT_KIND_EGRESS)
+    )
+    assert room_io.linked_participant is None
+
+    user = _remote_participant("user")
+    room_io._on_participant_connected(user)
+    assert room_io.linked_participant is user
+
+
+@pytest.mark.asyncio
+async def test_roomio_routes_every_participant_to_the_audio_input() -> None:
+    """Listening and linking are separate: `participant_identity` only picks the linked one."""
+    room = _FakeRoom()
+    room_io = _make_room_io(room, participant_identity="alice")
+    audio_input = _RecordingAudioInput()
+    room_io._audio_input = audio_input  # type: ignore[assignment]
+
+    bob = _remote_participant("bob")
+    alice = _remote_participant("alice")
+    room_io._on_participant_connected(bob)
+    room_io._on_participant_connected(alice)
+    room_io._on_participant_connected(
+        _remote_participant("avatar", attributes={ATTRIBUTE_PUBLISH_ON_BEHALF: "local"})
+    )
+
+    assert audio_input.added == ["bob", "alice"]
+    assert room_io.linked_participant is alice
+
+    room_io._on_participant_disconnected(bob)
+    assert audio_input.removed == ["bob"]

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -24,7 +24,11 @@ from livekit.agents.voice.room_io._output import (
     _ParticipantTranscriptionOutput,
 )
 from livekit.agents.voice.room_io.room_io import RoomIO
-from livekit.agents.voice.room_io.types import NoiseCancellationParams, RoomOptions
+from livekit.agents.voice.room_io.types import (
+    AudioInputOptions,
+    NoiseCancellationParams,
+    RoomOptions,
+)
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
@@ -60,6 +64,12 @@ class _FakeRoom:
 
     def unregister_text_stream_handler(self, topic: str) -> None:
         self._events.pop(f"text:{topic}", None)
+
+    def register_byte_stream_handler(self, topic: str, callback: object) -> None:
+        self.on(f"bytes:{topic}", callback)
+
+    def unregister_byte_stream_handler(self, topic: str) -> None:
+        self._events.pop(f"bytes:{topic}", None)
 
 
 class _MockAudioStream:
@@ -745,6 +755,14 @@ def _publish(audio_input, identity: str, value: int) -> None:
     _start_track(audio_input._streams[identity], identity, value)
 
 
+def _mute_track(room: _FakeRoom, audio_input, identity: str, muted: bool) -> None:
+    """Mute or unmute a participant's published track and deliver the room event."""
+    audio_input._streams[identity]._publication.muted = muted
+    event = "track_muted" if muted else "track_unmuted"
+    for callback in list(room._events[event]):
+        callback(SimpleNamespace(identity=identity), MagicMock())
+
+
 def _report_speakers(room: _FakeRoom, *identities: str) -> None:
     """Deliver an `active_speakers_changed` update, loudest first."""
     for callback in list(room._events["active_speakers_changed"]):
@@ -852,7 +870,13 @@ def _remote_participant(
 
 
 def _make_room_io(room: _FakeRoom, **options) -> RoomIO:
-    agent_session = SimpleNamespace(_on_room_io_participant_linked=MagicMock())
+    agent_session = SimpleNamespace(
+        _on_room_io_participant_linked=MagicMock(),
+        on=MagicMock(),
+        off=MagicMock(),
+        input=SimpleNamespace(audio=None, video=None),
+        output=SimpleNamespace(audio=None, transcription=None),
+    )
     return RoomIO(agent_session, room, options=RoomOptions(**options))
 
 
@@ -946,3 +970,42 @@ async def test_active_speaker_audio_input_reselects_when_the_speaker_leaves() ->
         assert 200 in await _amplitudes(audio_input, 10)
     finally:
         await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_active_speaker_audio_input_releases_a_muted_speaker() -> None:
+    """A muted speaker the server still reports must not hold the floor."""
+    room = _FakeRoom()
+    audio_input = _make_room_audio_input(room, _ActiveSpeakerAudioInput)
+
+    try:
+        _publish(audio_input, "alice", 100)
+        _publish(audio_input, "bob", 200)
+
+        _report_speakers(room, "alice", "bob")
+        assert audio_input._speaking == "alice"
+
+        _mute_track(room, audio_input, "alice", True)
+        assert audio_input._speaking == "bob"
+        assert 200 in await _amplitudes(audio_input, 10)
+    finally:
+        await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_roomio_skips_pre_connect_audio_for_group_inputs() -> None:
+    """The buffer predates the participant, so it has nowhere to go in a combined stream."""
+    room = _FakeRoom()
+
+    outputs_off = {"audio_output": False, "text_output": False, "text_input": False}
+    linked = _make_room_io(room, audio_input=AudioInputOptions(), **outputs_off)
+    mixed = _make_room_io(room, audio_input=AudioInputOptions(participants="mix"), **outputs_off)
+    for room_io in (linked, mixed):
+        await room_io.start()
+
+    try:
+        assert linked._pre_connect_audio_handler is not None
+        assert mixed._pre_connect_audio_handler is None
+    finally:
+        for room_io in (linked, mixed):
+            await room_io.aclose()

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -726,9 +726,11 @@ def _make_room_audio_input(room: _FakeRoom, cls):
     )
 
 
-def _start_track(stream, identity: str, value: int) -> None:
+def _start_track(stream, identity: str, value: int, sid: str | None = None) -> None:
     """Publish a microphone track of a constant amplitude for this participant."""
-    track, publication, participant = _make_track_available_args(identity, sid=f"TR_{identity}")
+    track, publication, participant = _make_track_available_args(
+        identity, sid=sid or f"TR_{identity}"
+    )
     publication.muted = False
     with patch(
         "livekit.rtc.AudioStream.from_track",
@@ -741,6 +743,12 @@ def _publish(audio_input, identity: str, value: int) -> None:
     """Add a participant to a group input and start their microphone."""
     audio_input.add_participant(identity)
     _start_track(audio_input._streams[identity], identity, value)
+
+
+def _report_speakers(room: _FakeRoom, *identities: str) -> None:
+    """Deliver an `active_speakers_changed` update, loudest first."""
+    for callback in list(room._events["active_speakers_changed"]):
+        callback([SimpleNamespace(identity=identity) for identity in identities])
 
 
 async def _amplitudes(audio_input, count: int) -> list[int]:
@@ -794,19 +802,15 @@ async def test_active_speaker_audio_input_forwards_one_participant_at_a_time() -
     room = _FakeRoom()
     audio_input = _make_room_audio_input(room, _ActiveSpeakerAudioInput)
 
-    def _speaking(*identities: str) -> None:
-        for callback in list(room._events["active_speakers_changed"]):
-            callback([SimpleNamespace(identity=identity) for identity in identities])
-
     try:
         _publish(audio_input, "alice", 100)
         _publish(audio_input, "bob", 200)
 
         # a second of alice speaking, which is also a second of bob held as pre-roll
-        _speaking("alice")
+        _report_speakers(room, "alice")
         assert set(await _amplitudes(audio_input, 20)) == {100}
 
-        _speaking("bob")
+        _report_speakers(room, "bob")
         started = asyncio.get_running_loop().time()
         heard = await _amplitudes(audio_input, 15)
         gap = heard.index(0)  # the turn boundary, so the stt doesn't merge both speakers
@@ -906,3 +910,39 @@ async def test_roomio_routes_every_participant_to_the_audio_input() -> None:
 
     room_io._on_participant_disconnected(bob)
     assert audio_input.removed == ["bob"]
+
+
+@pytest.mark.asyncio
+async def test_mixed_audio_input_republishing_does_not_close_the_turn() -> None:
+    """Swapping a track empties the mix for an instant, which is not the end of a turn."""
+    room = _FakeRoom()
+    audio_input = _make_room_audio_input(room, _MixedParticipantAudioInput)
+
+    try:
+        _publish(audio_input, "alice", 100)
+        assert 100 in await _amplitudes(audio_input, 2)
+
+        _start_track(audio_input._streams["alice"], "alice", 100, sid="TR_alice_2")
+        assert audio_input._mixing == {"alice"}
+        assert 0 not in await _amplitudes(audio_input, 5), "no silence gap on a republish"
+    finally:
+        await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_active_speaker_audio_input_reselects_when_the_speaker_leaves() -> None:
+    """The floor goes to whoever else the server reported, not to nobody."""
+    room = _FakeRoom()
+    audio_input = _make_room_audio_input(room, _ActiveSpeakerAudioInput)
+
+    try:
+        _publish(audio_input, "alice", 100)
+        _publish(audio_input, "bob", 200)
+
+        _report_speakers(room, "alice", "bob")
+        assert set(await _amplitudes(audio_input, 3)) == {100}
+
+        audio_input.remove_participant("alice")
+        assert 200 in await _amplitudes(audio_input, 10)
+    finally:
+        await audio_input.aclose()

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -737,7 +737,12 @@ def _make_room_audio_input(room: _FakeRoom, cls):
 
 
 def _start_track(
-    stream, identity: str, value: int, sid: str | None = None, muted: bool = False
+    stream,
+    identity: str,
+    value: int,
+    sid: str | None = None,
+    muted: bool = False,
+    count: int = 200,
 ) -> None:
     """Publish a microphone track of a constant amplitude for this participant."""
     track, publication, participant = _make_track_available_args(
@@ -746,7 +751,7 @@ def _start_track(
     publication.muted = muted
     with patch(
         "livekit.rtc.AudioStream.from_track",
-        side_effect=lambda **kw: _ConstantAudioStream(value),
+        side_effect=lambda **kw: _ConstantAudioStream(value, count=count),
     ):
         stream._on_track_available(track, publication, participant)
 
@@ -1094,3 +1099,53 @@ async def test_mixed_audio_input_does_not_buffer_a_participant_muted_on_arrival(
         assert 100 in await _amplitudes(audio_input, 3)
     finally:
         await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_active_speaker_audio_input_keeps_pre_roll_free_of_flush_silence() -> None:
+    """A group segments its own turns, so a child's end-of-track gap must not fill a pre-roll."""
+    room = _FakeRoom()
+    audio_input = _make_room_audio_input(room, _ActiveSpeakerAudioInput)
+
+    try:
+        _publish(audio_input, "alice", 100)
+        audio_input.add_participant("bob")
+        _start_track(audio_input._streams["bob"], "bob", 200, count=4)  # ends while alice talks
+
+        _report_speakers(room, "alice")
+        await asyncio.sleep(1.0)
+
+        held = [int(np.frombuffer(f.data, dtype=np.int16)[0]) for f in audio_input._preroll["bob"]]
+        assert held and 0 not in held
+    finally:
+        await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mixed_audio_input_closes_children_before_the_mixer() -> None:
+    """A child still holds a `track_subscribed` handler, and it registers with the mixer."""
+    room = _FakeRoom()
+    audio_input = _make_room_audio_input(room, _MixedParticipantAudioInput)
+    _publish(audio_input, "alice", 100)
+
+    closed: list[str] = []
+    child, mixer = audio_input._streams["alice"], audio_input._mixer
+    child_aclose, mixer_aclose = child.aclose, mixer.aclose
+
+    async def _closing_child(**kwargs):
+        closed.append("child")
+        await child_aclose(**kwargs)
+
+    async def _closing_mixer():
+        closed.append("mixer")
+        await mixer_aclose()
+
+    child.aclose, mixer.aclose = _closing_child, _closing_mixer
+    await audio_input.aclose()
+
+    assert closed == ["child", "mixer"], "the mixer must outlive the streams that register"
+
+    # and once closed, whatever the room still dispatches reaches nothing
+    audio_input._child_stream_changed("alice")
+    audio_input.add_participant("bob")
+    assert audio_input._streams == {}

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -736,12 +736,14 @@ def _make_room_audio_input(room: _FakeRoom, cls):
     )
 
 
-def _start_track(stream, identity: str, value: int, sid: str | None = None) -> None:
+def _start_track(
+    stream, identity: str, value: int, sid: str | None = None, muted: bool = False
+) -> None:
     """Publish a microphone track of a constant amplitude for this participant."""
     track, publication, participant = _make_track_available_args(
         identity, sid=sid or f"TR_{identity}"
     )
-    publication.muted = False
+    publication.muted = muted
     with patch(
         "livekit.rtc.AudioStream.from_track",
         side_effect=lambda **kw: _ConstantAudioStream(value),
@@ -759,8 +761,10 @@ def _mute_track(room: _FakeRoom, audio_input, identity: str, muted: bool) -> Non
     """Mute or unmute a participant's published track and deliver the room event."""
     audio_input._streams[identity]._publication.muted = muted
     event = "track_muted" if muted else "track_unmuted"
+    publication = MagicMock()
+    publication.source = rtc.TrackSource.SOURCE_MICROPHONE
     for callback in list(room._events[event]):
-        callback(SimpleNamespace(identity=identity), MagicMock())
+        callback(SimpleNamespace(identity=identity), publication)
 
 
 def _report_speakers(room: _FakeRoom, *identities: str) -> None:
@@ -1066,6 +1070,27 @@ async def test_active_speaker_audio_input_selects_a_participant_reported_before_
 
         await asyncio.sleep(0)
         assert audio_input._speaking == "alice"
+        assert 100 in await _amplitudes(audio_input, 3)
+    finally:
+        await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mixed_audio_input_does_not_buffer_a_participant_muted_on_arrival() -> None:
+    """A track subscribed while already muted never joins the mix, so it must not produce."""
+    room = _FakeRoom()
+    audio_input = _make_room_audio_input(room, _MixedParticipantAudioInput)
+
+    try:
+        audio_input.add_participant("alice")
+        _start_track(audio_input._streams["alice"], "alice", 100, muted=True)
+        assert audio_input._mixing == set()
+
+        await asyncio.sleep(1.0)  # 20 frames' worth of audio nobody is reading
+        assert audio_input._streams["alice"]._data_ch.qsize() == 0
+
+        _mute_track(room, audio_input, "alice", False)
+        assert audio_input._mixing == {"alice"}
         assert 100 in await _amplitudes(audio_input, 3)
     finally:
         await audio_input.aclose()

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -1031,3 +1031,41 @@ async def test_active_speaker_audio_input_republishing_keeps_the_floor() -> None
         assert set(await _amplitudes(audio_input, 5)) == {100}, "no gap, no handover to bob"
     finally:
         await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_mixed_audio_input_does_not_buffer_an_unmixed_participant() -> None:
+    """The mixer is a child's only reader, so a child it dropped must stop producing."""
+    room = _FakeRoom()
+    audio_input = _make_room_audio_input(room, _MixedParticipantAudioInput)
+
+    try:
+        _publish(audio_input, "alice", 100)
+        _publish(audio_input, "bob", 200)
+        assert 300 in await _amplitudes(audio_input, 2)
+
+        # a muted track that keeps delivering is exactly the case that used to pile up
+        _mute_track(room, audio_input, "alice", True)
+        assert audio_input._mixing == {"bob"}
+
+        await asyncio.sleep(1.0)  # 20 frames' worth of audio nobody is reading
+        assert audio_input._streams["alice"]._data_ch.qsize() == 0
+    finally:
+        await audio_input.aclose()
+
+
+@pytest.mark.asyncio
+async def test_active_speaker_audio_input_selects_a_participant_reported_before_joining() -> None:
+    """Someone already talking when the agent arrives must not wait for the next update."""
+    room = _FakeRoom()
+    audio_input = _make_room_audio_input(room, _ActiveSpeakerAudioInput)
+
+    try:
+        _report_speakers(room, "alice")  # dispatched before the stream exists
+        _publish(audio_input, "alice", 100)
+
+        await asyncio.sleep(0)
+        assert audio_input._speaking == "alice"
+        assert 100 in await _amplitudes(audio_input, 3)
+    finally:
+        await audio_input.aclose()


### PR DESCRIPTION
A single AgentSession could only ever hear the linked participant, so a room with two humans in it produced a one-sided chat context.

The composition point is an AudioInput rather than RoomIO: `_RoomAudioInput` is what RoomIO drives, and `_ParticipantAudioInputGroup` holds one unchanged `_ParticipantAudioInputStream` per participant. `AudioInputOptions.participants` selects how they are combined:

- "linked" (default): unchanged, a single participant stream.
- "mix":    summed by `rtc.AudioMixer`, keeps overlapping speech.
- "pick":   only the participant the server reports as speaking, preceded by
            their held pre-roll and separated by a silence gap.

RoomIO keeps owning the participant lifecycle and routes it through `add_participant`/`remove_participant`, which do nothing for an input that only listens to the linked participant. `participant_identity` and `set_participant` still choose the linked participant, which now only drives the outputs.

Mixing an idle stream would pace the mix below real time and warn on every block, so a participant is registered with the mixer only while a live, unmuted track is being read: `_ParticipantInputStream` now reports when that changes, including a track that stops delivering without being unpublished.