### PR TITLE
feat(expressive): allow dynamic updates via Agent and update_options

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -291,10 +291,6 @@ class Agent:
         if isinstance(tts, str):
             tts = inference.TTS.from_model_string(tts)
 
-        if is_given(expressive):
-            # resolved per turn (agent value over session), no live plumbing needed
-            self._expressive = expressive
-
         if self._activity is None:
             # not running: replace stored config, applied on the next start
             if is_given(stt):
@@ -305,9 +301,15 @@ class Agent:
                 self._llm = llm
             if is_given(tts):
                 self._tts = tts
+            if is_given(expressive):
+                self._expressive = expressive
             return
 
         self._activity._update_models(new_stt=stt, new_vad=vad, new_llm=llm, new_tts=tts)
+        if is_given(expressive):
+            # after _update_models so a rejected model swap leaves expressive untouched;
+            # resolved per turn (agent value over session), no live plumbing needed
+            self._expressive = expressive
 
     # -- Pipeline nodes --
     # They can all be overriden by subclasses, by default they use the STT/LLM/TTS specified in the

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from ..inference import LLMModels, STTModels, TTSModels
     from ..llm import mcp
     from .agent_activity import AgentActivity
-    from .agent_session import AgentSession
+    from .agent_session import AgentSession, ExpressiveOptions
     from .audio_recognition import AudioRecognition
     from .io import TimedString
     from .turn import TurnDetectionMode
@@ -50,6 +50,7 @@ class Agent:
         tool_handling: NotGivenOr[ToolHandlingOptions] = NOT_GIVEN,
         llm: NotGivenOr[llm.LLM | llm.RealtimeModel | LLMModels | str | None] = NOT_GIVEN,
         tts: NotGivenOr[tts.TTS | TTSModels | str | None] = NOT_GIVEN,
+        expressive: NotGivenOr[bool | ExpressiveOptions] = NOT_GIVEN,
         min_consecutive_speech_delay: NotGivenOr[float] = NOT_GIVEN,
         use_tts_aligned_transcript: NotGivenOr[bool] = NOT_GIVEN,
         # deprecated
@@ -94,6 +95,7 @@ class Agent:
         self._llm = llm
         self._tts = tts
         self._vad = vad
+        self._expressive: NotGivenOr[bool | ExpressiveOptions] = expressive
 
         self._allow_interruptions: NotGivenOr[bool] = NOT_GIVEN
         self._interruption_detection: NotGivenOr[Literal["adaptive", "vad"]] = NOT_GIVEN
@@ -267,13 +269,16 @@ class Agent:
         vad: NotGivenOr[vad.VAD | None] = NOT_GIVEN,
         llm: NotGivenOr[llm.LLM | llm.RealtimeModel | LLMModels | str | None] = NOT_GIVEN,
         tts: NotGivenOr[tts.TTS | TTSModels | str | None] = NOT_GIVEN,
+        expressive: NotGivenOr[bool | ExpressiveOptions] = NOT_GIVEN,
     ) -> None:
-        """Swap the STT, VAD, LLM, or TTS on this agent. Only the models passed are changed.
+        """Swap the STT, VAD, LLM, or TTS on this agent, or change its expressive setting.
+        Only the options passed are changed.
 
         Useful for switching a component mid-call (e.g. a different STT language or TTS voice).
         Strings resolve to inference models like the constructor. Pass ``None`` to disable a
         model (overriding the session), matching ``Agent(stt=None)``. If the agent is running,
-        the swap applies to the live pipeline.
+        the swap applies to the live pipeline. ``expressive`` overrides the session value and
+        takes effect on the next reply; pass ``False`` to force it off for this agent.
 
         Raises:
             RuntimeError: When swapping to or from a ``RealtimeModel`` while the agent is
@@ -285,6 +290,10 @@ class Agent:
             llm = inference.LLM.from_model_string(llm)
         if isinstance(tts, str):
             tts = inference.TTS.from_model_string(tts)
+
+        if is_given(expressive):
+            # resolved per turn (agent value over session), no live plumbing needed
+            self._expressive = expressive
 
         if self._activity is None:
             # not running: replace stored config, applied on the next start
@@ -686,6 +695,21 @@ class Agent:
             NotGivenOr[tts.TTS | None]: An optional TTS component for generating audio output.
         """  # noqa: E501
         return self._tts
+
+    @property
+    def expressive(self) -> NotGivenOr[bool | ExpressiveOptions]:
+        """
+        Retrieves the expressive TTS delivery setting for the agent.
+
+        If this property was not set at Agent creation, the ``AgentSession``'s ``expressive``
+        value will be used at runtime instead. When set, it overrides the session value for
+        this agent's turns, matching how ``llm`` and ``tts`` overrides behave.
+
+        Returns:
+            NotGivenOr[bool | ExpressiveOptions]: Whether expressive delivery is enabled,
+                or its configuration.
+        """
+        return self._expressive
 
     @property
     def mcp_servers(self) -> NotGivenOr[list[mcp.MCPServer] | None]:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2693,7 +2693,10 @@ class AgentActivity(RecognitionHooks):
         return instructions
 
     def _resolve_expressive_options(self) -> ExpressiveOptions | None:
-        """Resolve the session's expressive setting. Returns None if disabled.
+        """Resolve the effective expressive setting. Returns None if disabled.
+
+        The agent's ``expressive`` overrides the session's when set, matching how the
+        agent's ``llm``/``tts`` override the session models.
 
         Expressive mode requires two things:
         - the inference gateway TTS (``livekit.agents.inference.TTS``): the markup
@@ -2710,7 +2713,11 @@ class AgentActivity(RecognitionHooks):
         if not isinstance(self.tts, inference.TTS) or self.tts.markup.llm_instructions() is None:
             return None
 
-        expr = self._session._expressive
+        expr = (
+            self._agent.expressive
+            if is_given(self._agent.expressive)
+            else self._session._expressive
+        )
         if not expr and not isinstance(expr, dict):
             return None
         # speech_steering renders per-provider delivery guidelines on top of the

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -15,6 +15,7 @@ from typing import (
     Literal,
     Protocol,
     TypeVar,
+    cast,
     overload,
     runtime_checkable,
 )
@@ -207,7 +208,8 @@ DEFAULT_SPEECH_STEERING_OPTIONS: SpeechSteeringOptions = SpeechSteeringOptions(d
 
 
 class ExpressiveOptions(TypedDict, total=False):
-    """Configuration for the expressive pipeline, passed as ``AgentSession(expressive=...)``.
+    """Configuration for the expressive pipeline, passed as ``AgentSession(expressive=...)``
+    or ``Agent(expressive=...)`` (the agent value overrides the session's).
 
     Controls how TTS markup instructions are injected into the LLM when expressive is
     enabled. All keys are optional; common shapes:
@@ -468,6 +470,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 transcript. Pass an :class:`ExpressiveOptions` dict to steer or override
                 the injected instructions. Requires ``livekit.agents.inference.TTS`` with
                 a model that declares a markup dialect; it stays off otherwise.
+                An ``expressive`` set on the active :class:`Agent` overrides this value.
                 Default ``False``.
             ivr_detection (bool): Whether to detect if the agent is interacting with an IVR system.
                 Default ``False``.
@@ -1322,6 +1325,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         endpointing_opts: NotGivenOr[EndpointingOptions] = NOT_GIVEN,
         turn_detection: NotGivenOr[TurnDetectionMode | None] = NOT_GIVEN,
         keyterms: NotGivenOr[list[str]] = NOT_GIVEN,
+        expressive: NotGivenOr[bool | ExpressiveOptions] = NOT_GIVEN,
         # deprecated
         min_endpointing_delay: NotGivenOr[float] = NOT_GIVEN,
         max_endpointing_delay: NotGivenOr[float] = NOT_GIVEN,
@@ -1335,9 +1339,18 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 when the user has finished speaking. ``None`` reverts to automatic selection.
             keyterms (NotGivenOr[list[str]], optional): Replace the user-defined keyterms applied
                 to the STT. Auto-detected keyterms are left untouched.
+            expressive (NotGivenOr[bool | ExpressiveOptions], optional): Turn expressive TTS
+                delivery on/off or change its options mid-session. Takes effect on the
+                next reply. An ``expressive`` set on the active :class:`Agent` overrides the
+                session value. When a turn runs with expressive off, markup left in past
+                assistant messages is stripped from the chat history so the LLM doesn't
+                imitate tags nothing downstream converts.
             min_endpointing_delay: Deprecated, use ``endpointing_opts`` instead.
             max_endpointing_delay: Deprecated, use ``endpointing_opts`` instead.
         """
+        if is_given(expressive):
+            # mypy can't narrow NotGiven out of the TypedDict union here
+            self._expressive = cast("bool | ExpressiveOptions", expressive)
         if is_given(keyterms):
             self._keyterm_detector.set_static_keyterms(keyterms)
         if is_given(min_endpointing_delay) or is_given(max_endpointing_delay):

--- a/tests/test_expressive_toggle.py
+++ b/tests/test_expressive_toggle.py
@@ -4,8 +4,10 @@ import asyncio
 
 import pytest
 
-from livekit.agents import Agent, AgentSession, ExpressiveOptions
+from livekit.agents import Agent, AgentSession, ExpressiveOptions, inference
 from livekit.agents.llm.chat_context import ChatContext
+from livekit.agents.utils import is_given
+from livekit.agents.voice.agent_activity import AgentActivity
 from livekit.agents.voice.generation import (
     EXPRESSIVE_INSTRUCTIONS_MESSAGE_ID,
     _strip_assistant_markup,
@@ -79,6 +81,62 @@ def test_expressive_param_defaults_off() -> None:
 
     opts: ExpressiveOptions = {"tts_instructions_append": "Stay upbeat."}
     assert AgentSession(expressive=opts)._expressive == opts
+
+
+def test_update_options_expressive() -> None:
+    session = AgentSession(expressive=True)
+    assert session._expressive is True
+
+    # turn off
+    session.update_options(expressive=False)
+    assert session._expressive is False
+
+    # turn back on with options
+    opts: ExpressiveOptions = {"tts_instructions_append": "Stay upbeat."}
+    session.update_options(expressive=opts)
+    assert session._expressive == opts
+
+    # untouched when not given
+    session.update_options()
+    assert session._expressive == opts
+
+
+def test_agent_expressive() -> None:
+    # unset by default: falls back to the session value at runtime
+    assert not is_given(Agent(instructions="test").expressive)
+
+    agent = Agent(instructions="test", expressive=True)
+    assert agent.expressive is True
+
+    agent.update_options(expressive=False)
+    assert agent.expressive is False
+
+    opts: ExpressiveOptions = {"tts_instructions_append": "Stay upbeat."}
+    agent.update_options(expressive=opts)
+    assert agent.expressive == opts
+
+    # untouched when not given
+    agent.update_options()
+    assert agent.expressive == opts
+
+
+def test_agent_expressive_overrides_session() -> None:
+    # constructed hermetically; fishaudio declares a markup dialect, which expressive requires
+    tts = inference.TTS("fishaudio/s2.1-pro", api_key="fake", api_secret="fake")
+
+    session_on = AgentSession(expressive=True, tts=tts)
+    session_off = AgentSession(tts=tts)
+
+    def resolves(agent: Agent, session: AgentSession) -> bool:
+        return AgentActivity(agent, session)._resolve_expressive_options() is not None
+
+    # agent unset: the session value applies
+    assert resolves(Agent(instructions="test"), session_on)
+    assert not resolves(Agent(instructions="test"), session_off)
+
+    # agent value wins over the session in both directions
+    assert not resolves(Agent(instructions="test", expressive=False), session_on)
+    assert resolves(Agent(instructions="test", expressive=True), session_off)
 
 
 async def test_expressive_off_turn_scrubs_history() -> None:


### PR DESCRIPTION
expose expressive= on AgentSession.update_options and add it to Agent (constructor + update_options). The agent value overrides the session's, matching how the agent's llm/tts override the session models; resolution stays per-turn so changes apply on the next reply.

https://community.livekit.io/t/making-voice-agents-sound-human-with-expressive-mode/1854/3