### PR TITLE
fix(interruption): tolerate websocket teardown race on session.close write

### DIFF
--- a/livekit-agents/livekit/agents/inference/interruption.py
+++ b/livekit-agents/livekit/agents/inference/interruption.py
@@ -823,10 +823,17 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                 )
 
             closing_ws = True
+            if ws.closed:
+                return
             msg = InterruptionWSSessionCloseMessage(
                 type=InterruptionWSMessageType.SESSION_CLOSE,
             )
-            await ws.send_str(msg.model_dump_json())
+            try:
+                await ws.send_str(msg.model_dump_json())
+            except ConnectionResetError:
+                # aiohttp raises ConnectionResetError (ClientConnectionResetError on newer
+                # versions) if the peer wins the close race. session.close is best-effort.
+                return
 
         async def recv_task(ws: aiohttp.ClientWebSocketResponse) -> None:
             nonlocal closing_ws
@@ -980,15 +987,15 @@ class InterruptionWebSocketStream(InterruptionStreamBase):
                     self._reconnect_event.clear()
                 finally:
                     closing_ws = True
-                    if ws is not None and not ws.closed:
-                        await ws.close()
-                        ws = None
                     await aio.gracefully_cancel(*tasks, wait_reconnect_task)
                     tasks_group.cancel()
                     try:
                         tasks_group.exception()
                     except asyncio.CancelledError:
                         pass
+                    if ws is not None and not ws.closed:
+                        await ws.close()
+                        ws = None
             finally:
                 closing_ws = True
                 if ws is not None and not ws.closed:

--- a/tests/test_interruption/test_interruption_failover.py
+++ b/tests/test_interruption/test_interruption_failover.py
@@ -204,6 +204,88 @@ class TestWsCacheTimeout:
         assert len(unrecoverable_errors) == 1
 
 
+class TestWsConnectionReset:
+    @pytest.mark.asyncio
+    async def test_session_close_reset_is_ignored_during_teardown(self) -> None:
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_ws = MagicMock(spec=aiohttp.ClientWebSocketResponse)
+        mock_ws.closed = False
+        mock_ws.close_code = None
+        session_created = asyncio.Event()
+        session_close_attempted = asyncio.Event()
+        send_count = 0
+
+        async def _send_str(_data: str) -> None:
+            nonlocal send_count
+            send_count += 1
+            if send_count == 1:
+                session_created.set()
+                return
+            session_close_attempted.set()
+            raise ConnectionResetError("Cannot write to closing transport")
+
+        async def _receive() -> aiohttp.WSMessage:
+            await session_close_attempted.wait()
+            return aiohttp.WSMessage(type=aiohttp.WSMsgType.CLOSING, data=None, extra=None)
+
+        mock_ws.send_str = _send_str
+        mock_ws.send_bytes = AsyncMock()
+        mock_ws.receive = _receive
+        mock_ws.close = AsyncMock(return_value=True)
+        mock_session.ws_connect = AsyncMock(return_value=mock_ws)
+
+        detector = _create_detector(mock_session)
+        errors = _collect_errors(detector)
+        stream = detector.stream(conn_options=CONN_OPTIONS)
+
+        try:
+            await session_created.wait()
+            stream.end_input()
+            await asyncio.wait_for(stream._task, timeout=1.0)
+        finally:
+            await stream.aclose()
+
+        assert send_count == 2
+        assert errors == []
+        mock_ws.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_audio_send_reset_fails_instead_of_hanging(self) -> None:
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_ws = MagicMock(spec=aiohttp.ClientWebSocketResponse)
+        mock_ws.closed = False
+        mock_ws.close_code = None
+        mock_ws.send_str = AsyncMock()
+        mock_ws.send_bytes = AsyncMock(side_effect=ConnectionResetError("audio transport reset"))
+
+        async def _receive_hang() -> aiohttp.WSMessage:
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+        mock_ws.receive = _receive_hang
+        mock_ws.close = AsyncMock(return_value=True)
+        mock_session.ws_connect = AsyncMock(return_value=mock_ws)
+
+        detector = _create_detector(mock_session)
+        errors = _collect_errors(detector)
+        stream = detector.stream(conn_options=CONN_OPTIONS)
+        stream.push_frame(_AgentSpeechStartedSentinel())
+        stream.push_frame(
+            _OverlapSpeechStartedSentinel(speech_duration=0.5, started_at=time.time())
+        )
+        stream.push_frame(_make_audio_frame())
+
+        try:
+            with pytest.raises(ConnectionResetError, match="audio transport reset"):
+                await asyncio.wait_for(asyncio.shield(stream._task), timeout=1.0)
+        finally:
+            await stream.aclose()
+
+        assert mock_ws.send_bytes.await_count == 1
+        assert len(errors) == 1
+        assert errors[0].recoverable is False
+
+
 class TestWsSessionCreatedMissingThreshold:
     @pytest.mark.asyncio
     async def test_immediate_unrecoverable_when_server_omits_threshold(self) -> None:


### PR DESCRIPTION
## Summary

Fixes an unhandled `ClientConnectionResetError: Cannot write to closing transport` that escapes the adaptive interruption (barge-in) WebSocket during teardown, surfacing as spurious error reports and silently killing barge-in detection for the affected activity.

## Problem

`InterruptionWebSocketStream.send_task` writes a final `session.close` frame once the audio input channel closes. If the transport is already closing at that moment — the inference server won the close race, or the local shutdown path called `ws.close()` first — aiohttp's writer guard raises:

```text
aiohttp/_websocket/writer.py:79 in send_frame
  raise ClientConnectionResetError("Cannot write to closing transport")
aiohttp/client_ws.py:245 in send_str
livekit/agents/inference/interruption.py:819 in send_task
```

Because `ClientConnectionResetError` is **not** an `APIError`, neither `_main_task`'s retry/emit-error path nor `AudioRecognition._interruption_task`'s `except APIError: return` swallows it. It escapes as an unhandled asyncio task exception whenever an agent activity is torn down around the interruption stream (embedded agent handoffs, call end) — and the adaptive barge-in capability for that activity silently stops.

Observed in production on LiveKit Cloud: 3 occurrences in ~3 weeks, all at the `session.close` write during teardown, all with zero impact on the call itself — pure crash-report noise plus lost false-interruption filtering.

## Fix

- **`send_task`**: skip the `session.close` write when `ws.closed`, and swallow the connection reset when the peer wins the close race. The close message is best-effort — if the transport is already gone, there is nothing worth sending.
- **`_run` finally**: cancel the send/recv/forward tasks **before** `ws.close()`, so the local close can no longer arm the writer guard while `send_task` is mid-write. This removes the local half of the race; the `try/except` covers the remaining peer-initiated half.
- Mid-stream **audio** send failures intentionally still surface as an unrecoverable detector error (new test documents this) — only the final benign teardown write is suppressed.

## Tests

- `tests/test_interruption/test_interruption_failover.py::TestWsConnectionReset::test_session_close_reset_is_ignored_during_teardown` — the teardown close race produces no error event and no task exception.
- `tests/test_interruption/test_interruption_failover.py::TestWsConnectionReset::test_audio_send_reset_fails_instead_of_hanging` — a mid-stream send reset surfaces as exactly one unrecoverable error.

Validated locally: full `tests/test_interruption/` suite (17 tests) green, `ruff check` and `ruff format --check` clean, `scripts/check_types.py` (strict mypy) reports no issues.
