### PR TITLE
fix(agents): omit separator for empty exception details

### DIFF
--- a/livekit-agents/livekit/agents/_exceptions.py
+++ b/livekit-agents/livekit/agents/_exceptions.py
@@ -135,14 +135,18 @@ class APIConnectionError(APIError):
         # naming our own type by .message keeps a cycle that ends on one out of __str__, which
         # would otherwise re-enter here through the same chain.
         if isinstance(root, APIConnectionError):
-            detail = f"{type(root).__name__}: {root.message}"
+            root_message = root.message
         else:
             # a third-party __str__ may raise (e.g. aiohttp.ClientConnectorError on a partially
             # initialized connection key); the type name alone still beats losing the message.
             try:
-                detail = f"{type(root).__name__}: {root}"
+                root_message = str(root)
             except Exception:
-                detail = type(root).__name__
+                root_message = ""
+
+        detail = type(root).__name__
+        if root_message:
+            detail += f": {root_message}"
 
         return f"{self.message} (caused by {detail})"
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -76,9 +76,14 @@ def test_str_stops_after_ten_distinct_causes() -> None:
     assert str(_wrap(root)) == "Connection error. (caused by APIConnectionError: wrapped 10)"
 
 
-def test_timeout_subclass_keeps_its_own_message() -> None:
+def test_str_omits_separator_for_empty_cause_message() -> None:
     err = _wrap(TimeoutError(), APITimeoutError())
-    assert str(err).startswith("Request timed out. (caused by TimeoutError")
+    assert str(err) == "Request timed out. (caused by TimeoutError)"
+
+
+def test_str_omits_separator_for_empty_connection_error_message() -> None:
+    err = _wrap(APIConnectionError(""))
+    assert str(err) == "Connection error. (caused by APIConnectionError)"
 
 
 def test_raise_from_populates_the_message() -> None:


### PR DESCRIPTION
## Summary
- render empty root-cause messages using only the exception type
- avoid trailing colon-space output such as `ReadTimeout: `
- cover empty third-party and nested APIConnectionError messages

## Testing
- `uv run pytest tests/test_exceptions.py --unit`
- `make check`