### PR TITLE
fix: wait for final user turn during close

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -817,10 +817,10 @@ class AudioRecognition:
                     await self._commit_user_turn_atask
                 except asyncio.CancelledError:
                     pass
-                except Exception:
+                except Exception as exc:
                     logger.warning(
-                        "error while committing the final user turn on close",
-                        exc_info=True,
+                        "error while committing the final user turn on close: %s",
+                        type(exc).__name__,
                     )
 
             if self._stt_pipeline is not None:
@@ -843,10 +843,10 @@ class AudioRecognition:
                     await self._end_of_turn_task
                 except asyncio.CancelledError:
                     pass
-                except Exception:
+                except Exception as exc:
                     logger.warning(
-                        "error while completing the final user turn on close",
-                        exc_info=True,
+                        "error while completing the final user turn on close: %s",
+                        type(exc).__name__,
                     )
 
             if self._turn_detector_stream is not None:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -811,6 +811,9 @@ class AudioRecognition:
 
     async def _aclose(self) -> None:
         self._closing.set()
+        # WARNING: Suppressing CancelledError for either turn task can also suppress
+        # cancellation of _aclose() itself. Cleanup can therefore continue past the
+        # job runner's 60-second session-close timeout.
         try:
             if self._commit_user_turn_atask is not None:
                 try:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -817,6 +817,11 @@ class AudioRecognition:
                     await self._commit_user_turn_atask
                 except asyncio.CancelledError:
                     pass
+                except Exception:
+                    logger.warning(
+                        "error while committing the final user turn on close",
+                        exc_info=True,
+                    )
 
             if self._stt_pipeline is not None:
                 await self._stt_pipeline.aclose()
@@ -838,6 +843,11 @@ class AudioRecognition:
                     await self._end_of_turn_task
                 except asyncio.CancelledError:
                     pass
+                except Exception:
+                    logger.warning(
+                        "error while completing the final user turn on close",
+                        exc_info=True,
+                    )
 
             if self._turn_detector_stream is not None:
                 await self._turn_detector_stream.aclose()

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -813,7 +813,10 @@ class AudioRecognition:
         self._closing.set()
         try:
             if self._commit_user_turn_atask is not None:
-                await aio.cancel_and_wait(self._commit_user_turn_atask)
+                try:
+                    await self._commit_user_turn_atask
+                except asyncio.CancelledError:
+                    pass
 
             if self._stt_pipeline is not None:
                 await self._stt_pipeline.aclose()
@@ -831,7 +834,10 @@ class AudioRecognition:
                 await aio.cancel_and_wait(self._interruption_atask)
 
             if self._end_of_turn_task is not None:
-                await aio.cancel_and_wait(self._end_of_turn_task)
+                try:
+                    await self._end_of_turn_task
+                except asyncio.CancelledError:
+                    pass
 
             if self._turn_detector_stream is not None:
                 await self._turn_detector_stream.aclose()

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -9,6 +9,7 @@ The fix wraps these awaits in try-except blocks to catch CancelledError.
 """
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -178,6 +179,38 @@ class TestAudioRecognitionAclose:
         release.set()
         await close_task
         assert task.done()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("task_attr", "warning"),
+        [
+            (
+                "_commit_user_turn_atask",
+                "error while committing the final user turn on close",
+            ),
+            ("_end_of_turn_task", "error while completing the final user turn on close"),
+        ],
+    )
+    async def test_aclose_logs_failed_turn_task(
+        self,
+        task_attr: str,
+        warning: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        audio_recognition = self._create_audio_recognition()
+
+        async def failed_task() -> None:
+            raise RuntimeError("turn task failed")
+
+        setattr(audio_recognition, task_attr, asyncio.create_task(failed_task()))
+
+        with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+            await audio_recognition._aclose()
+
+        records = [record for record in caplog.records if record.message == warning]
+        assert len(records) == 1
+        assert records[0].exc_info is not None
+        assert isinstance(records[0].exc_info[1], RuntimeError)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(("is_recording", "expected_end_count"), [(True, 1), (False, 0)])

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -186,9 +186,12 @@ class TestAudioRecognitionAclose:
         [
             (
                 "_commit_user_turn_atask",
-                "error while committing the final user turn on close",
+                "error while committing the final user turn on close: RuntimeError",
             ),
-            ("_end_of_turn_task", "error while completing the final user turn on close"),
+            (
+                "_end_of_turn_task",
+                "error while completing the final user turn on close: RuntimeError",
+            ),
         ],
     )
     async def test_aclose_logs_failed_turn_task(
@@ -207,10 +210,9 @@ class TestAudioRecognitionAclose:
         with caplog.at_level(logging.WARNING, logger="livekit.agents"):
             await audio_recognition._aclose()
 
-        records = [record for record in caplog.records if record.message == warning]
+        records = [record for record in caplog.records if record.getMessage() == warning]
         assert len(records) == 1
-        assert records[0].exc_info is not None
-        assert isinstance(records[0].exc_info[1], RuntimeError)
+        assert records[0].exc_info is None
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(("is_recording", "expected_end_count"), [(True, 1), (False, 0)])

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -155,6 +155,31 @@ class TestAudioRecognitionAclose:
         assert end_of_turn_task.done()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("task_attr", ["_commit_user_turn_atask", "_end_of_turn_task"])
+    async def test_aclose_waits_for_pending_turn_task(self, task_attr: str) -> None:
+        audio_recognition = self._create_audio_recognition()
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def pending_task() -> None:
+            started.set()
+            await release.wait()
+
+        task = asyncio.create_task(pending_task())
+        await started.wait()
+        setattr(audio_recognition, task_attr, task)
+
+        close_task = asyncio.create_task(audio_recognition._aclose())
+        await asyncio.sleep(0)
+
+        assert not close_task.done()
+        assert not task.cancelled()
+
+        release.set()
+        await close_task
+        assert task.done()
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(("is_recording", "expected_end_count"), [(True, 1), (False, 0)])
     async def test_aclose_finalizes_user_turn_span(
         self, is_recording: bool, expected_end_count: int

--- a/tests/test_session_close_user_turn.py
+++ b/tests/test_session_close_user_turn.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from livekit.agents import Agent, AgentSession
+from livekit.agents.voice.transcription.synchronizer import _SyncedAudioOutput
+
+from .fake_io import FakeAudioInput
+from .fake_session import FakeActions, create_session
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+_TRANSCRIPT = "the mailbox is full and cannot accept new messages at this time"
+
+
+async def _start_session() -> tuple[AgentSession, Agent]:
+    actions = FakeActions()
+    actions.add_user_speech(0.05, 0.2, _TRANSCRIPT, stt_delay=0.3)
+    session = create_session(
+        actions,
+        turn_handling={"turn_detection": "stt"},
+        extra_kwargs={"session_close_transcript_timeout": 2.0},
+    )
+    agent = Agent(instructions="You are a helpful assistant.")
+    await session.start(agent)
+
+    audio_input = session.input.audio
+    assert isinstance(audio_input, FakeAudioInput)
+    audio_input.push(0.1)
+    await asyncio.sleep(0.1)
+    return session, agent
+
+
+async def _close_session(session: AgentSession) -> None:
+    audio_output = session.output.audio
+    transcription_sync = (
+        audio_output._synchronizer if isinstance(audio_output, _SyncedAudioOutput) else None
+    )
+    await session.aclose()
+    if transcription_sync is not None:
+        await transcription_sync.aclose()
+
+
+def _user_transcripts(agent: Agent) -> list[str | None]:
+    return [
+        item.text_content
+        for item in agent.chat_ctx.items
+        if item.type == "message" and item.role == "user"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_session_close_commits_trailing_transcript() -> None:
+    session, agent = await _start_session()
+
+    await _close_session(session)
+
+    assert _user_transcripts(agent) == [_TRANSCRIPT]


### PR DESCRIPTION
**Problem:** `AudioRecognition._aclose()` cancels the pending transcript flush and end-of-turn task. A clean session close can lose the final user turn.

**Behavior:** Restore the pre-livekit/agents#4722 waits for both tasks. Cancellation and task failures do not stop cleanup; failures emit type-only warnings. Cleanup can continue past the job runner's 60-second close timeout.

Fixes livekit/agents#6889<br>Supersedes livekit/agents#6891<br>Addresses livekit/agents#6889

<details><summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> can you review: [https://github.com/livekit/agents/pull/6891](<https://github.com/livekit/agents/pull/6891>)?
>
> okay, so \_end_of_turn_task was the same regression, right? It was changed to cancel and wait in the same PR.
>
> okay, let's create a new PR that address the issue, add the original PR author as co-author.
>
> we can add the warning log when it is errored too?
>
> exc info might contain user transcript?
>
> just print the error type instead
>
> okay, let's add a warn comment instead about this clean up might continue after the 60s timeout

</details>