### PR TITLE
fix(agents): accept Instructions in update_instructions

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -183,7 +183,7 @@ class Agent:
         assert activity._audio_recognition is not None
         return activity._audio_recognition
 
-    async def update_instructions(self, instructions: str) -> None:
+    async def update_instructions(self, instructions: str | Instructions) -> None:
         """
         Updates the agent's instructions.
 
@@ -191,8 +191,9 @@ class Agent:
         the instructions for the ongoing realtime session.
 
         Args:
-            instructions (str):
-                The new instructions to set for the agent.
+            instructions (str | Instructions):
+                The new instructions to set for the agent. Modality-specific
+                ``Instructions`` resolve the same way they do at construction.
 
         Raises:
             llm.RealtimeError: If updating the realtime session instructions fails.

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -559,18 +559,25 @@ class AgentActivity(RecognitionHooks):
 
         return use_aligned_transcript is True
 
-    async def update_instructions(self, instructions: str) -> None:
+    async def update_instructions(self, instructions: str | Instructions) -> None:
         self._agent._instructions = instructions
 
-        # Record the configuration change
+        # Record the configuration change. Collapse modality variants for the
+        # record; audio-first matches the initial AgentConfigUpdate.
         config_update = llm.AgentConfigUpdate(
-            instructions=instructions,
+            instructions=(
+                instructions.render(modality="audio")
+                if isinstance(instructions, Instructions)
+                else instructions
+            ),
         )
         self._agent._chat_ctx.insert(config_update)
         self._session._chat_ctx.insert(config_update)
 
         if self._rt_session is not None:
-            await self._rt_session.update_instructions(instructions)
+            await self._rt_session.update_instructions(
+                self._render_realtime_instructions(instructions)
+            )
         else:
             update_instructions(
                 self._agent._chat_ctx, instructions=instructions, add_if_missing=True

--- a/tests/test_agent_update_options.py
+++ b/tests/test_agent_update_options.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from livekit.agents import Agent, AgentSession
+from livekit.agents.llm.chat_context import Instructions
 
 from .fake_llm import FakeLLM
 from .fake_realtime import FakeRealtimeModel
@@ -237,5 +238,46 @@ async def test_update_options_vad_check_is_atomic() -> None:
         # rejected before any mutation — STT and VAD are untouched
         assert agent.stt is old_stt
         assert agent.vad is old_vad
+    finally:
+        await session.aclose()
+
+
+@pytest.mark.asyncio
+async def test_update_instructions_accepts_instructions_object() -> None:
+    """update_instructions must accept the same type the constructor accepts."""
+    agent = Agent(
+        instructions=Instructions(audio="audio-initial", text="text-initial"),
+        llm=FakeLLM(),
+    )
+    session = AgentSession(turn_handling={"turn_detection": None})
+    await session.start(agent)
+    try:
+        await agent.update_instructions(Instructions(audio="audio-new", text="text-new"))
+
+        # the modality split survives the update
+        assert isinstance(agent.instructions, Instructions)
+        assert agent.instructions.render(modality="audio") == "audio-new"
+        assert agent.instructions.render(modality="text") == "text-new"
+
+        # the recorded config update collapses to the audio variant
+        updates = [it for it in agent.chat_ctx.items if it.type == "agent_config_update"]
+        assert updates
+        assert updates[-1].instructions == "audio-new"
+    finally:
+        await session.aclose()
+
+
+@pytest.mark.asyncio
+async def test_update_instructions_still_accepts_str() -> None:
+    agent = Agent(instructions="initial", llm=FakeLLM())
+    session = AgentSession(turn_handling={"turn_detection": None})
+    await session.start(agent)
+    try:
+        await agent.update_instructions("updated")
+
+        assert agent.instructions == "updated"
+        updates = [it for it in agent.chat_ctx.items if it.type == "agent_config_update"]
+        assert updates
+        assert updates[-1].instructions == "updated"
     finally:
         await session.aclose()


### PR DESCRIPTION
Calling `Agent.update_instructions()` with an `Instructions` object raises a pydantic `ValidationError` at runtime.

### The problem

`Agent.__init__` accepts `str | Instructions` (`agent.py:43`), but `update_instructions` is typed `str` and passes its argument straight into `AgentConfigUpdate`, whose `instructions` field is `str | None` (`chat_context.py`):

```
ValidationError: 1 validation error for AgentConfigUpdate
instructions
  Input should be a valid string [type=string_type, input_value=Instructions(...), input_type=Instructions]
```

So an agent constructed with modality-split instructions can never refresh them. The failure is easy to miss because it only fires once a session is active — with `self._activity is None`, `update_instructions` just assigns and returns.

### Why this looks like an oversight rather than a design choice

Every other consumer already handles the union:

- `generation.update_instructions()` takes `str | Instructions` and renders internally using a `modality` argument.
- The realtime path has `_render_realtime_instructions()`.
- The initial `AgentConfigUpdate` in `AgentActivity` renders with an `isinstance` check, under a comment that reads *"collapse modality variants for the record; audio-first matches the update_instructions default for voice sessions"* — describing behaviour `update_instructions` did not actually have.

Only `Agent.update_instructions` and `AgentActivity.update_instructions` were missed.

### The change

- Widen both signatures to `str | Instructions`.
- Collapse the config-update record to the audio variant, matching the initial `AgentConfigUpdate` and the comment above.
- Route the realtime session through `_render_realtime_instructions`. This also fixes a second latent bug on the same path: the old code passed the raw value to `RealtimeSession.update_instructions`, which is typed `str`.

### Tests

Two regression tests in `tests/test_agent_update_options.py`. There was no existing coverage for `update_instructions` with an `Instructions` object.

Verified the first test fails on `main` with exactly the `ValidationError` above and passes with the fix. `ruff check`, `ruff format --check`, and `scripts/check_types.py` are clean on the touched files.