### PR TITLE
feat(elevenlabs): secondary languages and language detection for realtime STT

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -69,15 +69,6 @@ def _speech_confidence(words: list[dict[str, Any]] | None) -> float:
     return min(1.0, max(0.0, math.exp(sum(logprobs) / len(logprobs))))
 
 
-def _wire_language(language: str) -> str:
-    """Normalize a language to the code the realtime API accepts.
-
-    It takes ISO-639-1 or ISO-639-3 and rejects the whole session on anything else, including
-    the region-tagged tags `LanguageCode` happily produces ("ru-RU"), so the region comes off.
-    """
-    return LanguageCode(language).language
-
-
 class VADOptions(TypedDict, total=False):
     vad_silence_threshold_secs: float | None
     """Silence threshold in seconds for VAD. Default to 1.5"""
@@ -99,7 +90,7 @@ class STTOptions:
     api_key: str
     base_url: str
     language_code: LanguageCode | None
-    secondary_languages: NotGivenOr[list[str]]
+    secondary_languages: NotGivenOr[list[LanguageCode]]
     include_language_detection: NotGivenOr[bool]
     tag_audio_events: bool
     include_timestamps: bool
@@ -240,7 +231,9 @@ class STT(stt.STT):
             api_key=elevenlabs_api_key,
             base_url=base_url if is_given(base_url) else API_BASE_URL_V1,
             language_code=LanguageCode(language_code) if language_code else None,
-            secondary_languages=secondary_languages,
+            secondary_languages=[LanguageCode(language) for language in secondary_languages]
+            if is_given(secondary_languages)
+            else NOT_GIVEN,
             include_language_detection=include_language_detection,
             tag_audio_events=tag_audio_events,
             sample_rate=sample_rate,
@@ -404,7 +397,7 @@ class STT(stt.STT):
             stt=self,
             opts=self._opts,
             conn_options=conn_options,
-            language=language if is_given(language) else self._opts.language_code,
+            language=LanguageCode(language) if is_given(language) else self._opts.language_code,
             http_session=self._ensure_session(),
         )
         self._streams.add(stream)
@@ -420,7 +413,7 @@ class SpeechStream(stt.SpeechStream):
         stt: STT,
         opts: STTOptions,
         conn_options: APIConnectOptions,
-        language: str | None,
+        language: LanguageCode | None,
         http_session: aiohttp.ClientSession,
     ) -> None:
         super().__init__(stt=stt, conn_options=conn_options, sample_rate=opts.sample_rate)
@@ -668,12 +661,14 @@ class SpeechStream(stt.SpeechStream):
             if (min_silence_duration_ms := server_vad.get("min_silence_duration_ms")) is not None:
                 params.append(f"min_silence_duration_ms={min_silence_duration_ms}")
 
+        # the realtime API takes a bare ISO-639-1/639-3 code and rejects the session on a
+        # region-tagged one ("ru-RU"), so both language params go on the wire without the region
         if self._language:
-            params.append(f"language_code={quote(_wire_language(self._language))}")
+            params.append(f"language_code={quote(self._language.language)}")
 
         if is_given(self._opts.secondary_languages):
             params.extend(
-                f"secondary_languages={quote(_wire_language(language))}"
+                f"secondary_languages={quote(language.language)}"
                 for language in self._opts.secondary_languages
             )
 

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -70,7 +70,7 @@ def _speech_confidence(words: list[dict[str, Any]] | None) -> float:
 
 
 def _wire_language(language: str) -> str:
-    """Normalize a secondary language to the code the realtime API accepts.
+    """Normalize a language to the code the realtime API accepts.
 
     It takes ISO-639-1 or ISO-639-3 and rejects the whole session on anything else, including
     the region-tagged tags `LanguageCode` happily produces ("ru-RU"), so the region comes off.
@@ -669,7 +669,7 @@ class SpeechStream(stt.SpeechStream):
                 params.append(f"min_silence_duration_ms={min_silence_duration_ms}")
 
         if self._language:
-            params.append(f"language_code={self._language}")
+            params.append(f"language_code={quote(_wire_language(self._language))}")
 
         if is_given(self._opts.secondary_languages):
             params.extend(

--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -69,6 +69,15 @@ def _speech_confidence(words: list[dict[str, Any]] | None) -> float:
     return min(1.0, max(0.0, math.exp(sum(logprobs) / len(logprobs))))
 
 
+def _wire_language(language: str) -> str:
+    """Normalize a secondary language to the code the realtime API accepts.
+
+    It takes ISO-639-1 or ISO-639-3 and rejects the whole session on anything else, including
+    the region-tagged tags `LanguageCode` happily produces ("ru-RU"), so the region comes off.
+    """
+    return LanguageCode(language).language
+
+
 class VADOptions(TypedDict, total=False):
     vad_silence_threshold_secs: float | None
     """Silence threshold in seconds for VAD. Default to 1.5"""
@@ -90,6 +99,8 @@ class STTOptions:
     api_key: str
     base_url: str
     language_code: LanguageCode | None
+    secondary_languages: NotGivenOr[list[str]]
+    include_language_detection: NotGivenOr[bool]
     tag_audio_events: bool
     include_timestamps: bool
     sample_rate: STTRealtimeSampleRates
@@ -107,6 +118,8 @@ class STT(stt.STT):
         api_key: NotGivenOr[str] = NOT_GIVEN,
         base_url: NotGivenOr[str] = NOT_GIVEN,
         language_code: NotGivenOr[str] = NOT_GIVEN,
+        secondary_languages: NotGivenOr[list[str]] = NOT_GIVEN,
+        include_language_detection: NotGivenOr[bool] = NOT_GIVEN,
         tag_audio_events: bool = True,
         use_realtime: NotGivenOr[bool] = NOT_GIVEN,  # Deprecated
         sample_rate: STTRealtimeSampleRates = 16000,
@@ -127,6 +140,16 @@ class STT(stt.STT):
             api_key (NotGivenOr[str]): ElevenLabs API key. Can be set via argument or `ELEVEN_API_KEY` environment variable.
             base_url (NotGivenOr[str]): Custom base URL for the API. Optional.
             language_code (NotGivenOr[str]): Language code for the STT model. Optional.
+            secondary_languages (NotGivenOr[list[str]]): Additional languages that may be spoken in
+                the audio, on top of `language_code`. Keeps the primary language hinted while still
+                recognizing the others, which is what a code-switching speaker needs. Names and
+                ISO-639-3 codes are accepted and normalized to what the API takes. Only supported
+                for Scribe v2 realtime.
+            include_language_detection (NotGivenOr[bool]): Whether the committed transcript reports
+                the language the model actually heard. Defaults to True when no `language_code` is
+                set and False otherwise. Turning it off while no `language_code` is set leaves the
+                plugin with no language to report and every transcript falls back to "en". Only
+                supported for Scribe v2 realtime.
             tag_audio_events (bool): Whether to tag audio events like (laughter), (footsteps), etc. in the transcription.
                 Only supported for Scribe v1 model. Default is True.
             use_realtime (bool): Whether to use "scribe_v2_realtime" model for streaming mode. Default is NOT_GIVEN.
@@ -177,6 +200,20 @@ class STT(stt.STT):
         if not use_realtime and is_given(server_vad):
             logger.warning("Server-side VAD is only supported for Scribe v2 realtime model")
 
+        if not use_realtime and is_given(secondary_languages):
+            logger.warning(
+                "`secondary_languages` is only supported for Scribe v2 realtime model "
+                "and will be ignored"
+            )
+            secondary_languages = NOT_GIVEN
+
+        if not use_realtime and is_given(include_language_detection):
+            logger.warning(
+                "`include_language_detection` is only supported for Scribe v2 realtime model "
+                "and will be ignored"
+            )
+            include_language_detection = NOT_GIVEN
+
         resolved_previous_text = previous_text if is_given(previous_text) else None
         if not use_realtime and resolved_previous_text is not None:
             logger.warning(
@@ -203,6 +240,8 @@ class STT(stt.STT):
             api_key=elevenlabs_api_key,
             base_url=base_url if is_given(base_url) else API_BASE_URL_V1,
             language_code=LanguageCode(language_code) if language_code else None,
+            secondary_languages=secondary_languages,
+            include_language_detection=include_language_detection,
             tag_audio_events=tag_audio_events,
             sample_rate=sample_rate,
             server_vad=server_vad,
@@ -424,6 +463,29 @@ class SpeechStream(stt.SpeechStream):
     def _server_vad(self) -> VADOptions | None:
         return self._opts.server_vad if is_given(self._opts.server_vad) else None
 
+    @property
+    def _language_detection(self) -> bool:
+        """Whether the session reports the language the model actually heard.
+
+        Defaults to on when no language was pinned, which is the only case where the plugin
+        used to request it."""
+        if is_given(self._opts.include_language_detection):
+            return self._opts.include_language_detection
+
+        return not self._language
+
+    @property
+    def _final_message_type(self) -> str:
+        """The committed message this session treats as the final transcript.
+
+        ElevenLabs sends every commit twice and puts the word timestamps and the detected
+        language on the delayed copy only, so that copy is the final one whenever either is
+        asked for."""
+        if self._opts.include_timestamps or self._language_detection:
+            return "committed_transcript_with_timestamps"
+
+        return "committed_transcript"
+
     async def _run(self) -> None:
         """Run the streaming transcription session"""
         closing_ws = False
@@ -591,7 +653,7 @@ class SpeechStream(stt.SpeechStream):
             f"enable_logging={str(self._opts.enable_logging).lower()}",
         ]
 
-        if not self._language:
+        if self._language_detection:
             params.append("include_language_detection=true")
 
         if (server_vad := self._server_vad) is not None:
@@ -608,6 +670,12 @@ class SpeechStream(stt.SpeechStream):
 
         if self._language:
             params.append(f"language_code={self._language}")
+
+        if is_given(self._opts.secondary_languages):
+            params.extend(
+                f"secondary_languages={quote(_wire_language(language))}"
+                for language in self._opts.secondary_languages
+            )
 
         if self._opts.include_timestamps:
             params.append("include_timestamps=true")
@@ -662,7 +730,7 @@ class SpeechStream(stt.SpeechStream):
             end_time=end_time + self.start_time_offset,
             confidence=_speech_confidence(words),
         )
-        if words:
+        if words and self._opts.include_timestamps:
             speech_data.words = [
                 TimedString(
                     text=word.get("text", ""),
@@ -691,10 +759,8 @@ class SpeechStream(stt.SpeechStream):
                 )
                 self._event_ch.send_nowait(interim_event)
 
-        # 11labs sends both when include_timestamps is True or when the model is scribe_v2_realtime :(
-        elif (message_type == "committed_transcript" and not self._opts.include_timestamps) or (
-            message_type == "committed_transcript_with_timestamps" and self._opts.include_timestamps
-        ):
+        # 11labs sends every commit twice; _final_message_type picks the copy this session reads
+        elif message_type == self._final_message_type:
             # Final committed transcripts - these are sent to the LLM/TTS layer in LiveKit agents
             # and trigger agent responses (unlike partial transcripts which are UI-only)
             if text:
@@ -722,8 +788,8 @@ class SpeechStream(stt.SpeechStream):
                     self._event_ch.send_nowait(stt.SpeechEvent(type=SpeechEventType.END_OF_SPEECH))
                     self._speaking = False
 
-        elif message_type == "committed_transcript":
-            # if timestamps are included, these will be ignored above since we are handling committed_transcript_with_timestamps
+        elif message_type in ("committed_transcript", "committed_transcript_with_timestamps"):
+            # the other copy of a commit the branch above already emitted
             pass
 
         elif message_type == "session_started":
@@ -749,11 +815,6 @@ class SpeechStream(stt.SpeechStream):
                 details_suffix,
             )
             raise APIConnectionError(f"{message_type}: {error_msg}{details_suffix}")
-        elif (
-            message_type == "committed_transcript_with_timestamps"
-            and not self._opts.include_timestamps
-        ):
-            pass
         else:
             logger.warning("ElevenLabs STT unknown message type: %s, data: %s", message_type, data)
 

--- a/tests/test_plugin_elevenlabs_stt.py
+++ b/tests/test_plugin_elevenlabs_stt.py
@@ -31,15 +31,24 @@ class _EventSink:
         self.events.append(event)
 
 
-def _new_stream(*, server_vad=NOT_GIVEN) -> elevenlabs_stt.SpeechStream:
+def _new_stream(
+    *,
+    server_vad=NOT_GIVEN,
+    language: str | None = "en",
+    include_timestamps: bool = False,
+    include_language_detection=NOT_GIVEN,
+    secondary_languages=NOT_GIVEN,
+) -> elevenlabs_stt.SpeechStream:
     stream = object.__new__(elevenlabs_stt.SpeechStream)
     stream._opts = elevenlabs_stt.STTOptions(
         model_id="scribe_v2_realtime",
         api_key="test-key",
         base_url=elevenlabs_stt.API_BASE_URL_V1,
         language_code=None,
+        secondary_languages=secondary_languages,
+        include_language_detection=include_language_detection,
         tag_audio_events=True,
-        include_timestamps=False,
+        include_timestamps=include_timestamps,
         sample_rate=16000,
         server_vad=server_vad,
         keyterms=NOT_GIVEN,
@@ -47,16 +56,23 @@ def _new_stream(*, server_vad=NOT_GIVEN) -> elevenlabs_stt.SpeechStream:
         enable_logging=True,
         previous_text=None,
     )
-    stream._language = None
+    stream._language = language
     stream._event_ch = _EventSink()
     stream._speaking = False
     stream._start_time_offset = 0.0
     return stream
 
 
-def _committed_transcript(text: str) -> dict:
-    return {
-        "message_type": "committed_transcript",
+def _committed_transcript(
+    text: str,
+    *,
+    with_timestamps: bool = False,
+    language_code: str | None = None,
+) -> dict:
+    message: dict = {
+        "message_type": "committed_transcript_with_timestamps"
+        if with_timestamps
+        else "committed_transcript",
         "text": text,
         "words": [
             {"text": text, "start": 0.1, "end": 0.4},
@@ -64,6 +80,11 @@ def _committed_transcript(text: str) -> dict:
         if text
         else [],
     }
+    # the server only carries the detected language on the delayed copy, and only when
+    # language detection is enabled
+    if language_code is not None:
+        message["language_code"] = language_code
+    return message
 
 
 def test_server_vad_commit_emits_end_of_speech() -> None:
@@ -269,6 +290,131 @@ def test_stream_update_options_sets_keyterms_and_requests_reconnect() -> None:
 
     assert stream._opts.keyterms == ["nginx"]
     assert stream._reconnect_event.is_set()
+
+
+async def test_connect_ws_includes_secondary_languages() -> None:
+    # secondary languages ride along with the pinned primary one and are sent as
+    # repeated query params, the only serialization the realtime API accepts.
+    stream = _new_stream(language="en", secondary_languages=["ru", "es"])
+
+    url = await _connect_ws_url(stream)
+
+    assert "language_code=en" in url
+    assert URL(url).query.getall("secondary_languages") == ["ru", "es"]
+
+
+async def test_connect_ws_normalizes_secondary_languages() -> None:
+    # the realtime API takes ISO-639-1/3 and rejects anything else, including the region-tagged
+    # tags LanguageCode produces, so names and regions are mapped before the connect URL
+    stream = _new_stream(language="en", secondary_languages=["ru_RU", "french", "spa"])
+
+    url = await _connect_ws_url(stream)
+
+    assert URL(url).query.getall("secondary_languages") == ["ru", "fr", "es"]
+
+
+async def test_connect_ws_omits_secondary_languages_when_not_given() -> None:
+    url = await _connect_ws_url(_new_stream(language="en"))
+
+    assert "secondary_languages=" not in url
+
+
+def test_secondary_languages_ignored_for_batch_model(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level("WARNING"):
+        instance = elevenlabs_stt.STT(
+            api_key="test-key", model="scribe_v2", secondary_languages=["ru"]
+        )
+
+    assert instance._opts.secondary_languages is NOT_GIVEN
+    assert "only supported for Scribe v2 realtime" in caplog.text
+
+
+async def test_connect_ws_requests_language_detection_when_no_language_is_pinned() -> None:
+    url = await _connect_ws_url(_new_stream(language=None))
+
+    assert "include_language_detection=true" in url
+
+
+async def test_connect_ws_omits_language_detection_when_language_is_pinned() -> None:
+    url = await _connect_ws_url(_new_stream(language="en"))
+
+    assert "include_language_detection" not in url
+
+
+async def test_connect_ws_requests_language_detection_when_explicitly_enabled() -> None:
+    stream = _new_stream(language="en", include_language_detection=True)
+
+    url = await _connect_ws_url(stream)
+
+    assert "include_language_detection=true" in url
+
+
+async def test_connect_ws_omits_language_detection_when_explicitly_disabled() -> None:
+    url = await _connect_ws_url(_new_stream(language=None, include_language_detection=False))
+
+    assert "include_language_detection" not in url
+
+
+def test_final_transcript_reports_the_detected_language() -> None:
+    # with detection on, the detected language only reaches the delayed copy of the
+    # commit, so that copy has to be the final one or every transcript is labelled
+    # with the pinned language (or "en" when nothing is pinned).
+    stream = _new_stream(
+        server_vad={"vad_silence_threshold_secs": 0.5},
+        language="en",
+        include_language_detection=True,
+        secondary_languages=["ru"],
+    )
+
+    stream._process_stream_event(_committed_transcript("привет"))
+    stream._process_stream_event(
+        _committed_transcript("привет", with_timestamps=True, language_code="ru")
+    )
+
+    finals = [
+        event
+        for event in stream._event_ch.events
+        if event.type is stt.SpeechEventType.FINAL_TRANSCRIPT
+    ]
+    assert len(finals) == 1
+    assert finals[0].alternatives[0].language == "ru"
+
+
+def test_autodetected_language_reaches_the_final_transcript() -> None:
+    # without a pinned language the plugin asks the server to detect one; that language
+    # only rides on the delayed copy, so dropping it labelled every transcript "en"
+    stream = _new_stream(server_vad={"vad_silence_threshold_secs": 0.5}, language=None)
+
+    stream._process_stream_event(
+        _committed_transcript("привет", with_timestamps=True, language_code="ru")
+    )
+    stream._process_stream_event(_committed_transcript("привет"))
+
+    finals = [
+        event
+        for event in stream._event_ch.events
+        if event.type is stt.SpeechEventType.FINAL_TRANSCRIPT
+    ]
+    assert len(finals) == 1
+    assert finals[0].alternatives[0].language == "ru"
+    # reading the timestamped copy must not start handing out word timings the caller
+    # never asked for
+    assert finals[0].alternatives[0].words is None
+
+
+def test_final_transcript_keeps_the_plain_copy_without_detection() -> None:
+    stream = _new_stream(server_vad={"vad_silence_threshold_secs": 0.5}, language="es")
+
+    stream._process_stream_event(_committed_transcript("hola"))
+    stream._process_stream_event(_committed_transcript("hola", with_timestamps=True))
+
+    finals = [
+        event
+        for event in stream._event_ch.events
+        if event.type is stt.SpeechEventType.FINAL_TRANSCRIPT
+    ]
+    assert len(finals) == 1
+    assert finals[0].alternatives[0].language == "es"
 
 
 class _FakeWS:

--- a/tests/test_plugin_elevenlabs_stt.py
+++ b/tests/test_plugin_elevenlabs_stt.py
@@ -37,15 +37,18 @@ def _new_stream(
     language: str | None = "en",
     include_timestamps: bool = False,
     include_language_detection=NOT_GIVEN,
-    secondary_languages=NOT_GIVEN,
+    secondary_languages: list[str] | Any = NOT_GIVEN,
 ) -> elevenlabs_stt.SpeechStream:
+    # mirrors what STT.__init__ stores: both language options are normalized on the way in
     stream = object.__new__(elevenlabs_stt.SpeechStream)
     stream._opts = elevenlabs_stt.STTOptions(
         model_id="scribe_v2_realtime",
         api_key="test-key",
         base_url=elevenlabs_stt.API_BASE_URL_V1,
         language_code=None,
-        secondary_languages=secondary_languages,
+        secondary_languages=[LanguageCode(code) for code in secondary_languages]
+        if secondary_languages is not NOT_GIVEN
+        else NOT_GIVEN,
         include_language_detection=include_language_detection,
         tag_audio_events=True,
         include_timestamps=include_timestamps,
@@ -56,7 +59,7 @@ def _new_stream(
         enable_logging=True,
         previous_text=None,
     )
-    stream._language = language
+    stream._language = LanguageCode(language) if language else None
     stream._event_ch = _EventSink()
     stream._speaking = False
     stream._start_time_offset = 0.0
@@ -295,7 +298,7 @@ def test_stream_update_options_sets_keyterms_and_requests_reconnect() -> None:
 async def test_connect_ws_normalizes_the_primary_language() -> None:
     # LanguageCode keeps the region ("en-US") but the realtime API rejects it, so the primary
     # language goes on the wire through the same normalization the secondary ones get
-    stream = _new_stream(language=LanguageCode("en_US"), secondary_languages=["ru-RU"])
+    stream = _new_stream(language="en_US", secondary_languages=["ru-RU"])
 
     url = await _connect_ws_url(stream)
 
@@ -328,6 +331,21 @@ async def test_connect_ws_omits_secondary_languages_when_not_given() -> None:
     url = await _connect_ws_url(_new_stream(language="en"))
 
     assert "secondary_languages=" not in url
+
+
+def test_secondary_languages_are_normalized_on_the_options() -> None:
+    instance = elevenlabs_stt.STT(
+        api_key="test-key",
+        model="scribe_v2_realtime",
+        language_code="en_US",
+        secondary_languages=["ru_RU", "french", "spa"],
+    )
+
+    assert instance._opts.language_code == LanguageCode("en-US")
+    assert instance._opts.secondary_languages == ["ru-RU", "fr", "es"]
+    assert all(
+        isinstance(code, LanguageCode) for code in cast(list, instance._opts.secondary_languages)
+    )
 
 
 def test_secondary_languages_ignored_for_batch_model(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/test_plugin_elevenlabs_stt.py
+++ b/tests/test_plugin_elevenlabs_stt.py
@@ -15,7 +15,7 @@ from multidict import CIMultiDict
 from yarl import URL
 
 from livekit import rtc
-from livekit.agents import DEFAULT_API_CONNECT_OPTIONS, stt
+from livekit.agents import DEFAULT_API_CONNECT_OPTIONS, LanguageCode, stt
 from livekit.agents.types import NOT_GIVEN
 from livekit.plugins.elevenlabs import stt as elevenlabs_stt
 from livekit.plugins.elevenlabs._utils import trace_id_from_headers
@@ -290,6 +290,17 @@ def test_stream_update_options_sets_keyterms_and_requests_reconnect() -> None:
 
     assert stream._opts.keyterms == ["nginx"]
     assert stream._reconnect_event.is_set()
+
+
+async def test_connect_ws_normalizes_the_primary_language() -> None:
+    # LanguageCode keeps the region ("en-US") but the realtime API rejects it, so the primary
+    # language goes on the wire through the same normalization the secondary ones get
+    stream = _new_stream(language=LanguageCode("en_US"), secondary_languages=["ru-RU"])
+
+    url = await _connect_ws_url(stream)
+
+    assert URL(url).query.getall("language_code") == ["en"]
+    assert URL(url).query.getall("secondary_languages") == ["ru"]
 
 
 async def test_connect_ws_includes_secondary_languages() -> None:


### PR DESCRIPTION
### What

Two additions to the ElevenLabs realtime STT plugin, and the fix that makes the second one observable:

1. **`secondary_languages`** — passed through to Scribe v2 realtime. Declares extra languages that may appear in the audio while keeping the primary one hinted. Codes are normalized to what the API accepts: it takes ISO-639-1/639-3 and rejects everything else, including the region-tagged tags `LanguageCode` produces (`ru-RU`), so the region comes off before the connect URL. The primary `language_code` goes through the same normalization — it was sent verbatim before, and the API rejects a region-tagged primary code too, so `language_code="en-US"` produced a session that stayed connected and never transcribed.
2. **`include_language_detection`** — now an explicit option. It was implicit: on when no `language_code` was set, off otherwise, with no way to change either.
3. **Fix: the detected language never reached `SpeechData.language`.** Detail below.

### Why

Sessions where the speaker switches language mid-call — a tutor whose learner drops into their native language for a sentence, support lines in bilingual regions. Pinning `language_code` biases recognition toward the expected language, which you want, but there was no way to say "and they might also speak Russian".

The detected language matters beyond the transcript text: `MultilingualModel.unlikely_threshold()` keys the per-language EOU threshold on `SpeechData.language`, so a wrong label silently picks the wrong turn-detection threshold (or, for a language outside `languages.json`, `supports_language()` returns False and the EOU model is skipped entirely).

### The bug

The plugin asks for language detection whenever no `language_code` is pinned, but the server puts the detected language **only** on the delayed `committed_transcript_with_timestamps` copy of the commit — and the plugin ignores that copy unless `include_timestamps=True`. So the detection it requested was thrown away, and every transcript came out labelled with the pinned language, or the hardcoded `LanguageCode("en")` fallback in auto-detect mode.

Measured against the live API with `scribe_v2_realtime`, one English utterance followed by one Russian one:

| session config | `committed_transcript` | `committed_transcript_with_timestamps` |
| --- | --- | --- |
| `language_code=en` | `lang` absent | `lang` absent |
| `language_code=en&include_language_detection=true` | `lang` absent | `lang='en'`, then `lang='ru'` |
| no `language_code` (what the plugin sends today) | `lang` absent | `lang='en'`, then `lang='ru'` |

After the change, the final comes from whichever copy carries what the session asked for: `include_timestamps or include_language_detection`. Word timings are still only attached when `include_timestamps` was requested, so enabling detection doesn't start handing out `TimedString`s the caller never asked for and the `aligned_transcript` capability stays truthful.

**Latency:** none for the detection-only path — the timestamped copy arrives within ~1ms of the plain one (0.855s vs 0.856s, 1.888s vs 1.889s in the run above). The ~80ms lag people associate with that copy comes from `include_timestamps=true`, whose behavior is unchanged here.

### Serialization

`secondary_languages` is a repeated query param. Verified against the live API — `secondary_languages=ru&secondary_languages=es` is echoed back as `"secondary_languages": ["ru", "es"]` in `session_started.config`, while a comma-joined or JSON-encoded value is rejected with `invalid_request: Invalid language code received: 'ru,es'`.

Both new options are realtime-only and warn + no-op on batch models, matching how `server_vad` and `previous_text` behave.

### Verification

End-to-end against the live API with the patched plugin, same two utterances:

```
{'language_code': 'en'}                                                   -> en / en
{'language_code': 'en', 'secondary_languages': ['ru']}                    -> en / en
{..., 'secondary_languages': ['ru'], 'include_language_detection': True}  -> en / ru
```

`uv run pytest --unit` → 1987 passed, `make check` clean. 12 new tests in `tests/test_plugin_elevenlabs_stt.py` cover the query params, the normalization of both the primary and the secondary codes, the batch-model warning, and both the pinned-language and auto-detect final-transcript paths — `uv run pytest tests/test_plugin_elevenlabs_stt.py` → 37 passed. That module is marked `plugin("elevenlabs")`, so it runs in the `livekit-plugins-elevenlabs` job rather than under `--unit`, and that job is gated on `head.repo.fork == false` — it is skipped on this PR.

### Out of scope on purpose

One neighbouring problem this PR deliberately leaves alone, found while testing it and ready to send separately if you want it:

- The error branch in `_process_stream_event` never reaches the caller — `recv_task` catches everything it raises and only logs, so a session the server rejects stays connected and silent for the rest of the call.

