### PR TITLE
fix: preserve cancellation during audio recognition close

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -813,8 +813,7 @@ class AudioRecognition:
         self._closing.set()
         try:
             if self._commit_user_turn_atask is not None:
-                # A cancelled child becomes a result, but cancellation of _aclose still
-                # propagates and cancels the child.
+                # return_exceptions suppresses child cancellation, not cancellation of _aclose().
                 result = (
                     await asyncio.gather(self._commit_user_turn_atask, return_exceptions=True)
                 )[0]

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -813,7 +813,6 @@ class AudioRecognition:
         self._closing.set()
         try:
             if self._commit_user_turn_atask is not None:
-                # return_exceptions suppresses child cancellation, not cancellation of _aclose().
                 result = (
                     await asyncio.gather(self._commit_user_turn_atask, return_exceptions=True)
                 )[0]

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -811,19 +811,17 @@ class AudioRecognition:
 
     async def _aclose(self) -> None:
         self._closing.set()
-        # WARNING: Suppressing CancelledError for either turn task can also suppress
-        # cancellation of _aclose() itself. Cleanup can therefore continue past the
-        # job runner's 60-second session-close timeout.
         try:
             if self._commit_user_turn_atask is not None:
-                try:
-                    await self._commit_user_turn_atask
-                except asyncio.CancelledError:
-                    pass
-                except Exception as exc:
+                # A cancelled child becomes a result, but cancellation of _aclose still
+                # propagates and cancels the child.
+                result = (
+                    await asyncio.gather(self._commit_user_turn_atask, return_exceptions=True)
+                )[0]
+                if isinstance(result, Exception):
                     logger.warning(
                         "error while committing the final user turn on close: %s",
-                        type(exc).__name__,
+                        type(result).__name__,
                     )
 
             if self._stt_pipeline is not None:
@@ -842,14 +840,11 @@ class AudioRecognition:
                 await aio.cancel_and_wait(self._interruption_atask)
 
             if self._end_of_turn_task is not None:
-                try:
-                    await self._end_of_turn_task
-                except asyncio.CancelledError:
-                    pass
-                except Exception as exc:
+                result = (await asyncio.gather(self._end_of_turn_task, return_exceptions=True))[0]
+                if isinstance(result, Exception):
                     logger.warning(
                         "error while completing the final user turn on close: %s",
-                        type(exc).__name__,
+                        type(result).__name__,
                     )
 
             if self._turn_detector_stream is not None:

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -1,5 +1,3 @@
-"""Tests for cancellation while closing ``AudioRecognition``."""
-
 import asyncio
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,8 +10,6 @@ pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurr
 
 
 class TestAudioRecognitionAclose:
-    """Test ``AudioRecognition._aclose()`` task handling."""
-
     def _create_audio_recognition(self) -> AudioRecognition:
         """Create an AudioRecognition instance with mocked dependencies."""
         with patch.object(AudioRecognition, "__init__", lambda self, *args, **kwargs: None):
@@ -105,7 +101,6 @@ class TestAudioRecognitionAclose:
 
     @pytest.mark.asyncio
     async def test_aclose_handles_precancelled_tasks_gracefully(self):
-        """A pre-cancelled turn task does not stop the remaining cleanup."""
         audio_recognition = self._create_audio_recognition()
 
         async def long_running_task():

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -1,12 +1,4 @@
-"""
-Tests to validate that AudioRecognition.aclose() handles pre-cancelled tasks gracefully.
-
-Before the fix, if _commit_user_turn_atask or _end_of_turn_task were cancelled
-before aclose() was called, awaiting them would raise CancelledError and
-propagate up, causing cleanup to fail.
-
-The fix wraps these awaits in try-except blocks to catch CancelledError.
-"""
+"""Tests for cancellation while closing ``AudioRecognition``."""
 
 import asyncio
 import logging
@@ -20,7 +12,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurr
 
 
 class TestAudioRecognitionAclose:
-    """Test cases for AudioRecognition.aclose() handling cancelled tasks."""
+    """Test ``AudioRecognition._aclose()`` task handling."""
 
     def _create_audio_recognition(self) -> AudioRecognition:
         """Create an AudioRecognition instance with mocked dependencies."""
@@ -113,22 +105,7 @@ class TestAudioRecognitionAclose:
 
     @pytest.mark.asyncio
     async def test_aclose_handles_precancelled_tasks_gracefully(self):
-        """
-        PROVES THE FIX: Both tasks are properly cleaned up even when pre-cancelled.
-
-        Fixed aclose() pattern:
-            if self._commit_user_turn_atask is not None:
-                try:
-                    await self._commit_user_turn_atask
-                except asyncio.CancelledError:
-                    pass  # <-- Catches the error, continues cleanup
-            # ... other cleanup ...
-            if self._end_of_turn_task is not None:
-                try:
-                    await self._end_of_turn_task
-                except asyncio.CancelledError:
-                    pass  # <-- This is now reached!
-        """
+        """A pre-cancelled turn task does not stop the remaining cleanup."""
         audio_recognition = self._create_audio_recognition()
 
         async def long_running_task():
@@ -179,6 +156,31 @@ class TestAudioRecognitionAclose:
         release.set()
         await close_task
         assert task.done()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("task_attr", ["_commit_user_turn_atask", "_end_of_turn_task"])
+    async def test_aclose_propagates_cancellation_while_waiting_for_turn_task(
+        self, task_attr: str
+    ) -> None:
+        audio_recognition = self._create_audio_recognition()
+        started = asyncio.Event()
+
+        async def pending_task() -> None:
+            started.set()
+            await asyncio.Event().wait()
+
+        task = asyncio.create_task(pending_task())
+        await started.wait()
+        setattr(audio_recognition, task_attr, task)
+
+        close_task = asyncio.create_task(audio_recognition._aclose())
+        await asyncio.sleep(0)
+        close_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+
+        assert task.cancelled()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(


### PR DESCRIPTION
**Problem:** PR #6897 lets pre-cancelled final-turn tasks finish cleanup, but the same `CancelledError` handler also swallows cancellation of `AudioRecognition._aclose()`.

**Behavior:** Distinguish child cancellation from upstream close cancellation. Independent child cancellation and failures still allow cleanup; upstream cancellation now cancels the child and propagates. The trailing-transcript behavior remains covered.

Addresses AGT-3333

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> 6897 fixed the regression, but it also breaks the cooperative cancellation. Can you find a way for us to clean up without swallowing the cancellation?
>
> okay, let's fix that, and create a PR

</details>
