### PR TITLE
Add large payload utilities

### DIFF
--- a/examples/other/large-payload.py
+++ b/examples/other/large-payload.py
@@ -1,0 +1,154 @@
+"""Send application payloads that may be too large for a data packet.
+
+This example uses a data-channel descriptor for control metadata. Small payloads
+are embedded in that descriptor. Larger payloads are sent through a byte stream,
+and the descriptor points receivers to the stream topic/name.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+
+from dotenv import load_dotenv
+
+from livekit import api, rtc
+from livekit.agents.utils import aio
+from livekit.agents.utils.large_payload import (
+    ATTR_PAYLOAD_SHA256,
+    ATTR_PAYLOAD_SIZE,
+    ATTR_PAYLOAD_TOPIC,
+    LargePayloadError,
+    parse_large_payload_descriptor,
+    publish_large_payload,
+    read_large_payload_stream,
+)
+
+load_dotenv()
+
+logger = logging.getLogger("large-payload-example")
+logging.basicConfig(level=logging.INFO)
+
+CONTROL_TOPIC = "example.payload"
+STREAM_TOPIC = "example.payload.bytes"
+MAX_PAYLOAD_BYTES = 8 * 1024 * 1024
+
+
+class PayloadReceiver:
+    def __init__(self, room: rtc.Room) -> None:
+        self._room = room
+        self._stream_tasks: set[asyncio.Task[None]] = set()
+
+    def register(self) -> None:
+        self._room.register_byte_stream_handler(STREAM_TOPIC, self._on_byte_stream)
+
+        @self._room.on("data_received")
+        def _on_data(packet: rtc.DataPacket) -> None:
+            if packet.topic != CONTROL_TOPIC:
+                return
+            try:
+                descriptor = parse_large_payload_descriptor(packet.data)
+            except LargePayloadError:
+                logger.exception("invalid payload descriptor")
+                return
+
+            if descriptor.transfer == "inline":
+                payload = descriptor.decode_inline_payload()
+                logger.info("received inline payload: %d bytes", len(payload))
+            else:
+                logger.info(
+                    "payload %s is carried on byte stream topic %s",
+                    descriptor.payload_id,
+                    descriptor.stream_topic,
+                )
+
+    def _on_byte_stream(self, reader: rtc.ByteStreamReader, participant_identity: str) -> None:
+        task = asyncio.create_task(self._read_stream(reader, participant_identity))
+        self._stream_tasks.add(task)
+        task.add_done_callback(self._stream_tasks.discard)
+
+    async def aclose(self) -> None:
+        await aio.cancel_and_wait(*self._stream_tasks)
+
+    async def _read_stream(self, reader: rtc.ByteStreamReader, participant_identity: str) -> None:
+        try:
+            attributes = reader.info.attributes or {}
+            expected_size = attributes.get(ATTR_PAYLOAD_SIZE)
+            payload = await read_large_payload_stream(
+                reader,
+                max_bytes=MAX_PAYLOAD_BYTES,
+                expected_size=int(expected_size) if expected_size else None,
+                expected_sha256=attributes.get(ATTR_PAYLOAD_SHA256),
+            )
+            logger.info(
+                "received streamed payload from %s on %s: %d bytes",
+                participant_identity,
+                attributes.get(ATTR_PAYLOAD_TOPIC, ""),
+                len(payload),
+            )
+        except Exception:
+            logger.exception("failed to read streamed payload from %s", participant_identity)
+
+
+async def publish_example_payload(room: rtc.Room) -> None:
+    payload = json.dumps(
+        {
+            "kind": "document",
+            "title": "Quarterly update",
+            "sections": [{"heading": "Summary", "body": "..." * 8_000}],
+        },
+        separators=(",", ":"),
+    )
+
+    info = await publish_large_payload(
+        room.local_participant,
+        payload,
+        topic=CONTROL_TOPIC,
+        stream_topic=STREAM_TOPIC,
+        content_type="application/json",
+        attributes={"kind": "document"},
+    )
+    logger.info(
+        "published %s payload descriptor: %d bytes",
+        info.descriptor.transfer,
+        info.descriptor_bytes,
+    )
+
+
+async def main() -> None:
+    room_name = os.environ.get("LIVEKIT_ROOM", "large-payload-example")
+    identity = os.environ.get("LIVEKIT_IDENTITY", "payload-demo")
+    url = os.environ["LIVEKIT_URL"]
+    api_key = os.environ["LIVEKIT_API_KEY"]
+    api_secret = os.environ["LIVEKIT_API_SECRET"]
+
+    token = (
+        api.AccessToken(api_key, api_secret)
+        .with_identity(identity)
+        .with_grants(
+            api.VideoGrants(
+                room_join=True,
+                room=room_name,
+                can_publish=True,
+                can_publish_data=True,
+                can_subscribe=True,
+            )
+        )
+        .to_jwt()
+    )
+
+    room = rtc.Room()
+    receiver = PayloadReceiver(room)
+    receiver.register()
+    await room.connect(url, token)
+    try:
+        await publish_example_payload(room)
+    finally:
+        await receiver.aclose()
+        await room.disconnect()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/other/large-payload.py
+++ b/examples/other/large-payload.py
@@ -79,7 +79,7 @@ class PayloadReceiver:
             payload = await read_large_payload_stream(
                 reader,
                 max_bytes=MAX_PAYLOAD_BYTES,
-                expected_size=int(expected_size) if expected_size else None,
+                expected_size=int(expected_size) if expected_size is not None else None,
                 expected_sha256=attributes.get(ATTR_PAYLOAD_SHA256),
             )
             logger.info(

--- a/livekit-agents/livekit/agents/utils/__init__.py
+++ b/livekit-agents/livekit/agents/utils/__init__.py
@@ -1,11 +1,24 @@
 from livekit import rtc
 
-from . import aio, audio, codecs, http_context, http_server, hw, images
+from . import aio, audio, codecs, http_context, http_server, hw, images, large_payload
 from .audio import AudioArrayBuffer, AudioBuffer, combine_frames, merge_frames
 from .bounded_dict import BoundedDict
 from .connection_pool import ConnectionPool
 from .env import resolve_env_var
 from .exp_filter import ExpFilter
+from .large_payload import (
+    DEFAULT_INLINE_PAYLOAD_LIMIT,
+    DEFAULT_STREAM_PAYLOAD_LIMIT,
+    LargePayloadChecksumError,
+    LargePayloadDescriptor,
+    LargePayloadDescriptorTooLargeError,
+    LargePayloadError,
+    LargePayloadInfo,
+    LargePayloadTooLargeError,
+    parse_large_payload_descriptor,
+    publish_large_payload,
+    read_large_payload_stream,
+)
 from .log import log_exceptions
 from .misc import is_dev_mode, is_given, is_hosted, nodename, shortuuid, time_ms
 from .moving_average import MovingAverage
@@ -33,6 +46,7 @@ __all__ = [
     "audio",
     "aio",
     "hw",
+    "large_payload",
     "is_dev_mode",
     "is_given",
     "is_hosted",
@@ -41,6 +55,17 @@ __all__ = [
     "wait_for_participant",
     "wait_for_track_publication",
     "resolve_env_var",
+    "DEFAULT_INLINE_PAYLOAD_LIMIT",
+    "DEFAULT_STREAM_PAYLOAD_LIMIT",
+    "LargePayloadChecksumError",
+    "LargePayloadDescriptor",
+    "LargePayloadDescriptorTooLargeError",
+    "LargePayloadError",
+    "LargePayloadInfo",
+    "LargePayloadTooLargeError",
+    "parse_large_payload_descriptor",
+    "publish_large_payload",
+    "read_large_payload_stream",
 ]
 
 # Cleanup docs of unexported modules

--- a/livekit-agents/livekit/agents/utils/large_payload.py
+++ b/livekit-agents/livekit/agents/utils/large_payload.py
@@ -1,0 +1,505 @@
+"""Utilities for publishing payloads that may be too large for a data packet.
+
+The helper publishes a compact descriptor on a data topic. If the descriptor can
+carry the payload inline, the bytes are base64-encoded into that descriptor. If
+not, the bytes are sent through a byte stream and the descriptor points to that
+stream by topic/name with size and checksum metadata.
+"""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import hashlib
+import hmac
+import json
+from collections.abc import AsyncIterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from livekit import rtc
+
+from .misc import shortuuid
+
+DEFAULT_INLINE_PAYLOAD_LIMIT = 15 * 1024
+DEFAULT_STREAM_PAYLOAD_LIMIT = 64 * 1024 * 1024
+
+DESCRIPTOR_TYPE = "lk.large_payload"
+DESCRIPTOR_VERSION = 1
+
+ATTR_PAYLOAD_ID = "lk.large_payload.id"
+ATTR_PAYLOAD_TOPIC = "lk.large_payload.topic"
+ATTR_PAYLOAD_SHA256 = "lk.large_payload.sha256"
+ATTR_PAYLOAD_SIZE = "lk.large_payload.size"
+ATTR_PAYLOAD_CONTENT_TYPE = "lk.large_payload.content_type"
+
+PayloadTransfer = Literal["inline", "byte_stream"]
+_SHA256_HEX_CHARS = frozenset("0123456789abcdef")
+
+
+class LargePayloadError(ValueError):
+    """Base exception for large payload helper errors."""
+
+
+class LargePayloadTooLargeError(LargePayloadError):
+    """Raised when a received stream exceeds its configured size limit."""
+
+
+class LargePayloadDescriptorTooLargeError(LargePayloadError):
+    """Raised when the descriptor itself is too large for a data packet."""
+
+
+class LargePayloadChecksumError(LargePayloadError):
+    """Raised when received bytes do not match the expected SHA-256 digest."""
+
+
+@dataclass(frozen=True)
+class LargePayloadDescriptor:
+    """Control message describing a payload sent inline or through a byte stream."""
+
+    payload_id: str
+    topic: str
+    transfer: PayloadTransfer
+    size: int
+    sha256: str
+    content_type: str
+    stream_topic: str | None = None
+    stream_name: str | None = None
+    data: str | None = None
+    attributes: dict[str, str] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-serializable descriptor representation.
+
+        The returned dictionary is suitable for sending as the control message
+        on a data topic after JSON serialization.
+
+        Returns:
+            A JSON-serializable descriptor dictionary.
+        """
+        descriptor: dict[str, Any] = {
+            "type": DESCRIPTOR_TYPE,
+            "version": DESCRIPTOR_VERSION,
+            "id": self.payload_id,
+            "topic": self.topic,
+            "transfer": self.transfer,
+            "size": self.size,
+            "sha256": self.sha256,
+            "content_type": self.content_type,
+        }
+        if self.stream_topic is not None:
+            descriptor["stream_topic"] = self.stream_topic
+        if self.stream_name is not None:
+            descriptor["stream_name"] = self.stream_name
+        if self.data is not None:
+            descriptor["data"] = self.data
+            descriptor["encoding"] = "base64"
+        if self.attributes:
+            descriptor["attributes"] = dict(self.attributes)
+        return descriptor
+
+    @classmethod
+    def from_dict(cls, descriptor: Mapping[str, Any]) -> LargePayloadDescriptor:
+        """Validate and build a descriptor from parsed JSON data.
+
+        Args:
+            descriptor: Parsed JSON object received on a data topic.
+
+        Returns:
+            A validated large payload descriptor.
+
+        Raises:
+            LargePayloadError: If the object is not a supported descriptor.
+        """
+        if descriptor.get("type") != DESCRIPTOR_TYPE:
+            raise LargePayloadError("not a LiveKit large payload descriptor")
+        version = descriptor.get("version")
+        if version != DESCRIPTOR_VERSION:
+            raise LargePayloadError(f"unsupported large payload descriptor version: {version}")
+
+        transfer = descriptor.get("transfer")
+        if transfer not in ("inline", "byte_stream"):
+            raise LargePayloadError(f"unsupported large payload transfer: {transfer}")
+
+        payload_id = _required_str(descriptor, "id")
+        topic = _required_str(descriptor, "topic")
+        size = _required_int(descriptor, "size")
+        sha256 = _required_str(descriptor, "sha256")
+        content_type = _required_str(descriptor, "content_type")
+
+        attributes_raw = descriptor.get("attributes")
+        attributes = (
+            {str(k): str(v) for k, v in attributes_raw.items()}
+            if isinstance(attributes_raw, Mapping)
+            else None
+        )
+
+        return cls(
+            payload_id=payload_id,
+            topic=topic,
+            transfer=transfer,
+            size=size,
+            sha256=sha256,
+            content_type=content_type,
+            stream_topic=_optional_str(descriptor, "stream_topic"),
+            stream_name=_optional_str(descriptor, "stream_name"),
+            data=_optional_str(descriptor, "data"),
+            attributes=attributes,
+        )
+
+    def decode_inline_payload(self) -> bytes:
+        """Decode and verify an inline payload carried by this descriptor."""
+        if self.transfer != "inline" or self.data is None:
+            raise LargePayloadError("descriptor does not contain an inline payload")
+        try:
+            data = base64.b64decode(self.data.encode("ascii"), validate=True)
+        except Exception as e:
+            raise LargePayloadError("inline payload is not valid base64") from e
+        _verify_payload(data, expected_size=self.size, expected_sha256=self.sha256)
+        return data
+
+
+@dataclass(frozen=True)
+class LargePayloadInfo:
+    """Result returned after a payload descriptor has been published."""
+
+    descriptor: LargePayloadDescriptor
+    descriptor_bytes: int
+
+
+async def publish_large_payload(
+    participant: rtc.LocalParticipant,
+    payload: bytes | str,
+    *,
+    topic: str,
+    content_type: str = "application/octet-stream",
+    attributes: Mapping[str, str] | None = None,
+    reliable: bool = True,
+    destination_identities: Sequence[str] | None = None,
+    max_inline_bytes: int = DEFAULT_INLINE_PAYLOAD_LIMIT,
+    max_descriptor_bytes: int = DEFAULT_INLINE_PAYLOAD_LIMIT,
+    max_stream_bytes: int | None = DEFAULT_STREAM_PAYLOAD_LIMIT,
+    payload_id: str | None = None,
+    stream_topic: str | None = None,
+    stream_name: str | None = None,
+) -> LargePayloadInfo:
+    """Publish a payload descriptor, using a byte stream when it cannot fit inline.
+
+    The receiver should listen for descriptors on ``topic``. Small payloads are
+    embedded in the descriptor as base64. Larger payloads are sent through
+    ``stream_bytes`` and the descriptor identifies the stream topic/name and the
+    expected size/checksum.
+
+    Args:
+        participant: Local participant used to publish data and byte streams.
+        payload: Bytes or UTF-8 text to publish.
+        topic: Data topic used for the descriptor.
+        content_type: MIME type for the payload.
+        attributes: Optional application metadata copied into the descriptor and
+            stream attributes.
+        reliable: Whether to publish the descriptor on the reliable data channel.
+        destination_identities: Optional recipient identities.
+        max_inline_bytes: Maximum descriptor size allowed for inline transfer.
+            Set to ``0`` to always use a byte stream.
+        max_descriptor_bytes: Maximum size of the data-channel descriptor.
+        max_stream_bytes: Maximum byte-stream payload size. Set to ``None`` to
+            disable this helper-level bound.
+        payload_id: Optional stable payload identifier.
+        stream_topic: Optional byte-stream topic for streamed payloads.
+        stream_name: Optional byte-stream name for streamed payloads.
+
+    Returns:
+        Information about the descriptor that was published.
+
+    Raises:
+        ValueError: If a size limit or topic argument is invalid.
+        LargePayloadTooLargeError: If the payload exceeds ``max_stream_bytes``.
+        LargePayloadDescriptorTooLargeError: If the descriptor cannot fit in a
+            data packet.
+    """
+    if not topic:
+        raise ValueError("topic is required")
+    if not content_type:
+        raise ValueError("content_type is required")
+    if max_inline_bytes < 0:
+        raise ValueError("max_inline_bytes must be non-negative")
+    if max_descriptor_bytes < 1:
+        raise ValueError("max_descriptor_bytes must be positive")
+    if max_stream_bytes is not None and max_stream_bytes < 0:
+        raise ValueError("max_stream_bytes must be non-negative")
+    inline_limit = min(max_inline_bytes, max_descriptor_bytes)
+
+    data = _coerce_payload(payload)
+    payload_id = payload_id or shortuuid("payload_")
+    sha256 = hashlib.sha256(data).hexdigest()
+    size = len(data)
+    attrs = _string_attrs(attributes)
+    destinations = list(destination_identities or [])
+
+    if (
+        inline_limit > 0
+        and _estimate_inline_descriptor_size(
+            payload_id=payload_id,
+            topic=topic,
+            size=size,
+            sha256=sha256,
+            content_type=content_type,
+            attributes=attrs or None,
+        )
+        <= inline_limit
+    ):
+        inline_descriptor = LargePayloadDescriptor(
+            payload_id=payload_id,
+            topic=topic,
+            transfer="inline",
+            size=size,
+            sha256=sha256,
+            content_type=content_type,
+            data=base64.b64encode(data).decode("ascii"),
+            attributes=attrs or None,
+        )
+        inline_bytes = _descriptor_bytes(inline_descriptor)
+        if len(inline_bytes) <= inline_limit:
+            await participant.publish_data(
+                inline_bytes,
+                reliable=reliable,
+                destination_identities=destinations,
+                topic=topic,
+            )
+            return LargePayloadInfo(
+                descriptor=inline_descriptor,
+                descriptor_bytes=len(inline_bytes),
+            )
+
+    if max_stream_bytes is not None and size > max_stream_bytes:
+        raise LargePayloadTooLargeError(
+            f"large payload exceeded max_stream_bytes ({max_stream_bytes})"
+        )
+
+    stream_topic = stream_topic or f"{topic}.payload"
+    stream_name = stream_name or f"{payload_id}.bin"
+    stream_descriptor = LargePayloadDescriptor(
+        payload_id=payload_id,
+        topic=topic,
+        transfer="byte_stream",
+        size=size,
+        sha256=sha256,
+        content_type=content_type,
+        stream_topic=stream_topic,
+        stream_name=stream_name,
+        attributes=attrs or None,
+    )
+    stream_descriptor_bytes = _descriptor_bytes(stream_descriptor)
+    if len(stream_descriptor_bytes) > max_descriptor_bytes:
+        raise LargePayloadDescriptorTooLargeError(
+            f"large payload descriptor exceeded max_descriptor_bytes ({max_descriptor_bytes})"
+        )
+
+    stream_attrs = {
+        **attrs,
+        ATTR_PAYLOAD_ID: payload_id,
+        ATTR_PAYLOAD_TOPIC: topic,
+        ATTR_PAYLOAD_SHA256: sha256,
+        ATTR_PAYLOAD_SIZE: str(size),
+        ATTR_PAYLOAD_CONTENT_TYPE: content_type,
+    }
+    writer = await participant.stream_bytes(
+        name=stream_name,
+        topic=stream_topic,
+        mime_type=content_type,
+        attributes=stream_attrs,
+        total_size=size,
+        destination_identities=destinations,
+    )
+    try:
+        await writer.write(data)
+    except BaseException:
+        with contextlib.suppress(Exception):
+            await writer.aclose(reason="large payload write failed")
+        raise
+    else:
+        await writer.aclose()
+
+    await participant.publish_data(
+        stream_descriptor_bytes,
+        reliable=reliable,
+        destination_identities=destinations,
+        topic=topic,
+    )
+    return LargePayloadInfo(
+        descriptor=stream_descriptor,
+        descriptor_bytes=len(stream_descriptor_bytes),
+    )
+
+
+def parse_large_payload_descriptor(payload: bytes | str) -> LargePayloadDescriptor:
+    """Parse a JSON large-payload descriptor received on a data topic.
+
+    Args:
+        payload: Descriptor bytes or text received through ``publish_data``.
+
+    Returns:
+        A validated descriptor.
+
+    Raises:
+        LargePayloadError: If the payload is not valid descriptor JSON.
+    """
+    try:
+        raw = payload.decode("utf-8") if isinstance(payload, bytes) else payload
+    except UnicodeDecodeError as e:
+        raise LargePayloadError("large payload descriptor is not valid UTF-8") from e
+    try:
+        descriptor = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise LargePayloadError("large payload descriptor is not valid JSON") from e
+    if not isinstance(descriptor, Mapping):
+        raise LargePayloadError("large payload descriptor must be a JSON object")
+    return LargePayloadDescriptor.from_dict(descriptor)
+
+
+async def read_large_payload_stream(
+    reader: AsyncIterable[bytes],
+    *,
+    max_bytes: int | None = DEFAULT_STREAM_PAYLOAD_LIMIT,
+    expected_size: int | None = None,
+    expected_sha256: str | None = None,
+    require_expected_metadata: bool = True,
+) -> bytes:
+    """Read a byte stream with size and checksum validation.
+
+    Args:
+        reader: Async byte stream reader.
+        max_bytes: Maximum bytes to buffer while reading. Defaults to
+            ``DEFAULT_STREAM_PAYLOAD_LIMIT``. Set to ``None`` only for trusted
+            senders or when another layer already enforces a bound.
+        expected_size: Expected payload size from a descriptor or stream
+            attribute. Required unless ``require_expected_metadata`` is ``False``.
+            If it exceeds ``max_bytes``, reading fails before consuming the
+            stream.
+        expected_sha256: Expected SHA-256 hex digest. Required unless
+            ``require_expected_metadata`` is ``False``.
+        require_expected_metadata: Whether ``expected_size`` and
+            ``expected_sha256`` are required. Defaults to ``True`` so untrusted
+            streams are validated unless callers explicitly opt out.
+
+    Returns:
+        The complete stream payload.
+
+    Raises:
+        ValueError: If a size argument is invalid.
+        LargePayloadTooLargeError: If the stream exceeds ``max_bytes``.
+        LargePayloadChecksumError: If checksum validation fails.
+        LargePayloadError: If size validation fails.
+    """
+    if max_bytes is not None and max_bytes < 0:
+        raise ValueError("max_bytes must be non-negative")
+    if expected_size is not None and expected_size < 0:
+        raise ValueError("expected_size must be non-negative")
+    if require_expected_metadata:
+        if expected_size is None:
+            raise LargePayloadError("expected_size is required")
+        if expected_sha256 is None:
+            raise LargePayloadError("expected_sha256 is required")
+    if max_bytes is not None and expected_size is not None and expected_size > max_bytes:
+        raise LargePayloadTooLargeError(
+            f"large payload expected_size exceeds max_bytes ({max_bytes})"
+        )
+
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in reader:
+        data = bytes(chunk)
+        total += len(data)
+        if max_bytes is not None and total > max_bytes:
+            raise LargePayloadTooLargeError(
+                f"large payload stream exceeded max_bytes ({max_bytes})"
+            )
+        chunks.append(data)
+
+    payload = b"".join(chunks)
+    _verify_payload(payload, expected_size=expected_size, expected_sha256=expected_sha256)
+    return payload
+
+
+def _coerce_payload(payload: bytes | str) -> bytes:
+    return payload.encode("utf-8") if isinstance(payload, str) else bytes(payload)
+
+
+def _string_attrs(attributes: Mapping[str, str] | None) -> dict[str, str]:
+    if not attributes:
+        return {}
+    return {str(k): str(v) for k, v in attributes.items()}
+
+
+def _descriptor_bytes(descriptor: LargePayloadDescriptor) -> bytes:
+    return json.dumps(descriptor.to_dict(), separators=(",", ":")).encode("utf-8")
+
+
+def _base64_encoded_len(size: int) -> int:
+    return ((size + 2) // 3) * 4
+
+
+def _estimate_inline_descriptor_size(
+    *,
+    payload_id: str,
+    topic: str,
+    size: int,
+    sha256: str,
+    content_type: str,
+    attributes: dict[str, str] | None,
+) -> int:
+    empty_descriptor = LargePayloadDescriptor(
+        payload_id=payload_id,
+        topic=topic,
+        transfer="inline",
+        size=size,
+        sha256=sha256,
+        content_type=content_type,
+        data="",
+        attributes=attributes,
+    )
+    return len(_descriptor_bytes(empty_descriptor)) + _base64_encoded_len(size)
+
+
+def _required_str(descriptor: Mapping[str, Any], key: str) -> str:
+    value = descriptor.get(key)
+    if not isinstance(value, str) or not value:
+        raise LargePayloadError(f"large payload descriptor field {key!r} must be a string")
+    return value
+
+
+def _optional_str(descriptor: Mapping[str, Any], key: str) -> str | None:
+    value = descriptor.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise LargePayloadError(f"large payload descriptor field {key!r} must be a string")
+    return value
+
+
+def _required_int(descriptor: Mapping[str, Any], key: str) -> int:
+    value = descriptor.get(key)
+    if not isinstance(value, int) or value < 0:
+        raise LargePayloadError(
+            f"large payload descriptor field {key!r} must be a non-negative integer"
+        )
+    return value
+
+
+def _verify_payload(
+    payload: bytes,
+    *,
+    expected_size: int | None,
+    expected_sha256: str | None,
+) -> None:
+    if expected_size is not None and len(payload) != expected_size:
+        raise LargePayloadError(
+            f"large payload size mismatch: expected {expected_size}, got {len(payload)}"
+        )
+    if expected_sha256 is not None:
+        digest = hashlib.sha256(payload).hexdigest()
+        expected = expected_sha256.strip().lower()
+        if len(expected) != 64 or any(c not in _SHA256_HEX_CHARS for c in expected):
+            raise LargePayloadChecksumError("large payload sha256 is not a valid hex digest")
+        if not hmac.compare_digest(digest, expected):
+            raise LargePayloadChecksumError("large payload checksum mismatch")

--- a/livekit-agents/livekit/agents/utils/large_payload.py
+++ b/livekit-agents/livekit/agents/utils/large_payload.py
@@ -134,6 +134,19 @@ class LargePayloadDescriptor:
             else None
         )
 
+        stream_topic = _optional_str(descriptor, "stream_topic")
+        stream_name = _optional_str(descriptor, "stream_name")
+        data = _optional_str(descriptor, "data")
+        if transfer == "byte_stream" and (not stream_topic or not stream_name):
+            raise LargePayloadError(
+                "large payload descriptor must include 'stream_topic' and 'stream_name' "
+                "for byte_stream transfer"
+            )
+        if transfer == "inline" and data is None:
+            raise LargePayloadError(
+                "large payload descriptor must include 'data' for inline transfer"
+            )
+
         return cls(
             payload_id=payload_id,
             topic=topic,
@@ -141,9 +154,9 @@ class LargePayloadDescriptor:
             size=size,
             sha256=sha256,
             content_type=content_type,
-            stream_topic=_optional_str(descriptor, "stream_topic"),
-            stream_name=_optional_str(descriptor, "stream_name"),
-            data=_optional_str(descriptor, "data"),
+            stream_topic=stream_topic,
+            stream_name=stream_name,
+            data=data,
             attributes=attributes,
         )
 

--- a/tests/test_large_payload.py
+++ b/tests/test_large_payload.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from livekit.agents.utils.large_payload import (
+    ATTR_PAYLOAD_CONTENT_TYPE,
+    ATTR_PAYLOAD_ID,
+    ATTR_PAYLOAD_SHA256,
+    ATTR_PAYLOAD_SIZE,
+    ATTR_PAYLOAD_TOPIC,
+    DESCRIPTOR_TYPE,
+    LargePayloadChecksumError,
+    LargePayloadDescriptorTooLargeError,
+    LargePayloadError,
+    LargePayloadTooLargeError,
+    parse_large_payload_descriptor,
+    publish_large_payload,
+    read_large_payload_stream,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class _FakeWriter:
+    chunks: list[bytes] = field(default_factory=list)
+    closed: bool = False
+    close_reason: str = ""
+    close_attributes: dict[str, str] | None = None
+    write_error: BaseException | None = None
+    close_error: BaseException | None = None
+
+    async def write(self, data: bytes) -> None:
+        if self.write_error is not None:
+            raise self.write_error
+        self.chunks.append(data)
+
+    async def aclose(self, *, reason: str = "", attributes: dict[str, str] | None = None) -> None:
+        self.closed = True
+        self.close_reason = reason
+        self.close_attributes = attributes
+        if self.close_error is not None:
+            raise self.close_error
+
+
+class _FakeParticipant:
+    def __init__(self) -> None:
+        self.published: list[dict[str, Any]] = []
+        self.streams: list[dict[str, Any]] = []
+        self.writer = _FakeWriter()
+
+    async def publish_data(
+        self,
+        payload: bytes,
+        *,
+        reliable: bool = True,
+        destination_identities: list[str] | None = None,
+        topic: str = "",
+    ) -> None:
+        self.published.append(
+            {
+                "payload": payload,
+                "reliable": reliable,
+                "destination_identities": destination_identities,
+                "topic": topic,
+            }
+        )
+
+    async def stream_bytes(self, **kwargs: Any) -> _FakeWriter:
+        self.streams.append(kwargs)
+        return self.writer
+
+
+class _FakeReader:
+    def __init__(self, *chunks: bytes) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+@pytest.mark.asyncio
+async def test_publish_large_payload_inlines_small_payload() -> None:
+    participant = _FakeParticipant()
+
+    info = await publish_large_payload(
+        participant, b'{"status":"ok"}', topic="generic-status", payload_id="payload-1"
+    )
+
+    assert not participant.streams
+    assert len(participant.published) == 1
+    assert participant.published[0]["topic"] == "generic-status"
+
+    descriptor = parse_large_payload_descriptor(participant.published[0]["payload"])
+    assert descriptor.payload_id == "payload-1"
+    assert descriptor.transfer == "inline"
+    assert descriptor.content_type == "application/octet-stream"
+    assert descriptor.decode_inline_payload() == b'{"status":"ok"}'
+    assert info.descriptor == descriptor
+
+
+@pytest.mark.asyncio
+async def test_publish_large_payload_rejects_empty_content_type() -> None:
+    participant = _FakeParticipant()
+
+    with pytest.raises(ValueError, match="content_type"):
+        await publish_large_payload(
+            participant,
+            b"data",
+            topic="generic-status",
+            content_type="",
+        )
+
+    assert not participant.streams
+    assert not participant.published
+
+
+@pytest.mark.asyncio
+async def test_publish_large_payload_streams_when_descriptor_exceeds_inline_limit() -> None:
+    participant = _FakeParticipant()
+
+    info = await publish_large_payload(
+        participant,
+        b"x" * 64,
+        topic="generic-payload",
+        content_type="application/json",
+        attributes={"source": "test"},
+        destination_identities=["receiver"],
+        payload_id="payload-2",
+        max_inline_bytes=80,
+    )
+
+    assert len(participant.streams) == 1
+    stream = participant.streams[0]
+    assert stream["name"] == "payload-2.bin"
+    assert stream["topic"] == "generic-payload.payload"
+    assert stream["mime_type"] == "application/json"
+    assert stream["total_size"] == 64
+    assert stream["destination_identities"] == ["receiver"]
+    assert stream["attributes"]["source"] == "test"
+    assert stream["attributes"][ATTR_PAYLOAD_ID] == "payload-2"
+    assert stream["attributes"][ATTR_PAYLOAD_TOPIC] == "generic-payload"
+    assert stream["attributes"][ATTR_PAYLOAD_SIZE] == "64"
+    assert stream["attributes"][ATTR_PAYLOAD_CONTENT_TYPE] == "application/json"
+    assert stream["attributes"][ATTR_PAYLOAD_SHA256] == info.descriptor.sha256
+
+    assert participant.writer.chunks == [b"x" * 64]
+    assert participant.writer.closed
+
+    assert len(participant.published) == 1
+    descriptor = parse_large_payload_descriptor(participant.published[0]["payload"])
+    assert descriptor.transfer == "byte_stream"
+    assert descriptor.stream_topic == "generic-payload.payload"
+    assert descriptor.stream_name == "payload-2.bin"
+    assert descriptor.data is None
+    assert descriptor.attributes == {"source": "test"}
+
+
+@pytest.mark.asyncio
+async def test_publish_large_payload_streams_when_inline_exceeds_descriptor_limit() -> None:
+    participant = _FakeParticipant()
+
+    info = await publish_large_payload(
+        participant,
+        b"x" * 200,
+        topic="generic-payload",
+        payload_id="payload-2a",
+        max_inline_bytes=1000,
+        max_descriptor_bytes=400,
+    )
+
+    assert info.descriptor.transfer == "byte_stream"
+    assert participant.streams
+    assert participant.published
+
+
+@pytest.mark.asyncio
+async def test_publish_large_payload_skips_inline_encoding_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    participant = _FakeParticipant()
+
+    def _fail_b64encode(data: bytes) -> bytes:
+        raise AssertionError("inline base64 path should not run")
+
+    monkeypatch.setattr("livekit.agents.utils.large_payload.base64.b64encode", _fail_b64encode)
+
+    info = await publish_large_payload(
+        participant,
+        b"x" * 64,
+        topic="generic-payload",
+        payload_id="payload-2b",
+        max_inline_bytes=0,
+    )
+
+    assert info.descriptor.transfer == "byte_stream"
+    assert participant.streams
+    assert participant.published
+
+
+@pytest.mark.asyncio
+async def test_publish_large_payload_rejects_payload_over_stream_limit() -> None:
+    participant = _FakeParticipant()
+
+    with pytest.raises(LargePayloadTooLargeError):
+        await publish_large_payload(
+            participant,
+            b"x" * 17,
+            topic="generic-payload",
+            payload_id="payload-too-large",
+            max_inline_bytes=0,
+            max_stream_bytes=16,
+        )
+
+    assert not participant.streams
+    assert not participant.published
+
+
+@pytest.mark.asyncio
+async def test_publish_large_payload_allows_custom_stream_limit() -> None:
+    participant = _FakeParticipant()
+
+    info = await publish_large_payload(
+        participant,
+        b"x" * 17,
+        topic="generic-payload",
+        payload_id="payload-custom-limit",
+        max_inline_bytes=0,
+        max_stream_bytes=17,
+    )
+
+    assert info.descriptor.transfer == "byte_stream"
+    assert participant.streams
+    assert participant.published
+
+
+@pytest.mark.asyncio
+async def test_publish_large_payload_uses_custom_stream_topic_and_name() -> None:
+    participant = _FakeParticipant()
+
+    await publish_large_payload(
+        participant,
+        "payload body",
+        topic="generic-control",
+        payload_id="payload-3",
+        max_inline_bytes=0,
+        stream_topic="generic-streams",
+        stream_name="payload-3.json",
+    )
+
+    stream = participant.streams[0]
+    assert stream["topic"] == "generic-streams"
+    assert stream["name"] == "payload-3.json"
+
+    descriptor = parse_large_payload_descriptor(participant.published[0]["payload"])
+    assert descriptor.stream_topic == "generic-streams"
+    assert descriptor.stream_name == "payload-3.json"
+
+
+@pytest.mark.asyncio
+async def test_publish_large_payload_aborts_stream_when_write_fails() -> None:
+    participant = _FakeParticipant()
+    participant.writer.write_error = RuntimeError("write failed")
+    participant.writer.close_error = RuntimeError("close failed")
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        await publish_large_payload(
+            participant,
+            b"x" * 64,
+            topic="generic-payload",
+            payload_id="payload-3a",
+            max_inline_bytes=0,
+        )
+
+    assert participant.writer.closed
+    assert participant.writer.close_reason == "large payload write failed"
+    assert not participant.published
+
+
+@pytest.mark.asyncio
+async def test_publish_large_payload_rejects_oversized_stream_descriptor() -> None:
+    participant = _FakeParticipant()
+
+    with pytest.raises(LargePayloadDescriptorTooLargeError):
+        await publish_large_payload(
+            participant,
+            b"x" * 64,
+            topic="generic-payload",
+            attributes={"metadata": "x" * 128},
+            payload_id="payload-4",
+            max_inline_bytes=1,
+            max_descriptor_bytes=80,
+        )
+
+    assert not participant.streams
+    assert not participant.published
+
+
+@pytest.mark.asyncio
+async def test_read_large_payload_stream_validates_size_and_checksum() -> None:
+    expected = "3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7"
+
+    payload = await read_large_payload_stream(
+        _FakeReader(b"da", b"ta"),
+        expected_size=4,
+        expected_sha256=expected,
+    )
+
+    assert payload == b"data"
+
+
+@pytest.mark.asyncio
+async def test_read_large_payload_stream_rejects_payload_over_max_bytes() -> None:
+    with pytest.raises(LargePayloadTooLargeError):
+        await read_large_payload_stream(
+            _FakeReader(b"abc", b"def"),
+            max_bytes=4,
+            require_expected_metadata=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_read_large_payload_stream_rejects_expected_size_over_max_before_read() -> None:
+    with pytest.raises(LargePayloadTooLargeError):
+        await read_large_payload_stream(
+            _FakeReader(b"a"),
+            max_bytes=4,
+            expected_size=5,
+            expected_sha256="0" * 64,
+        )
+
+
+@pytest.mark.asyncio
+async def test_read_large_payload_stream_rejects_checksum_mismatch() -> None:
+    with pytest.raises(LargePayloadChecksumError):
+        await read_large_payload_stream(
+            _FakeReader(b"data"), expected_size=4, expected_sha256="bad"
+        )
+
+
+@pytest.mark.asyncio
+async def test_read_large_payload_stream_rejects_missing_expected_metadata() -> None:
+    with pytest.raises(LargePayloadError, match="expected_size"):
+        await read_large_payload_stream(_FakeReader(b"data"), expected_sha256="bad")
+
+
+@pytest.mark.asyncio
+async def test_read_large_payload_stream_rejects_invalid_checksum_text() -> None:
+    with pytest.raises(LargePayloadChecksumError, match="valid hex digest"):
+        await read_large_payload_stream(
+            _FakeReader(b"data"),
+            expected_size=4,
+            expected_sha256="x" * 63 + chr(9731),
+        )
+
+
+@pytest.mark.asyncio
+async def test_read_large_payload_stream_accepts_uppercase_checksum() -> None:
+    expected = "3A6EB0790F39AC87C94F3856B2DD2C5D110E6811602261A9A923D3BB23ADC8B7"
+
+    payload = await read_large_payload_stream(
+        _FakeReader(b"data"),
+        expected_size=4,
+        expected_sha256=expected,
+    )
+
+    assert payload == b"data"
+
+
+def test_parse_large_payload_descriptor_rejects_non_descriptor() -> None:
+    payload = json.dumps({"type": "other", "version": 1}).encode("utf-8")
+
+    with pytest.raises(LargePayloadError):
+        parse_large_payload_descriptor(payload)
+
+
+def test_parse_large_payload_descriptor_rejects_invalid_utf8() -> None:
+    with pytest.raises(LargePayloadError, match="UTF-8"):
+        parse_large_payload_descriptor(b"\xff")
+
+
+def test_parse_large_payload_descriptor_rejects_missing_required_fields() -> None:
+    payload = json.dumps(
+        {
+            "type": DESCRIPTOR_TYPE,
+            "version": 1,
+            "transfer": "inline",
+            "topic": "generic",
+            "size": 1,
+            "sha256": "digest",
+            "content_type": "application/octet-stream",
+        }
+    )
+
+    with pytest.raises(LargePayloadError, match="'id'"):
+        parse_large_payload_descriptor(payload)

--- a/tests/test_large_payload.py
+++ b/tests/test_large_payload.py
@@ -400,3 +400,39 @@ def test_parse_large_payload_descriptor_rejects_missing_required_fields() -> Non
 
     with pytest.raises(LargePayloadError, match="'id'"):
         parse_large_payload_descriptor(payload)
+
+
+def test_parse_large_payload_descriptor_rejects_missing_stream_location() -> None:
+    payload = json.dumps(
+        {
+            "type": DESCRIPTOR_TYPE,
+            "version": 1,
+            "id": "payload-5",
+            "transfer": "byte_stream",
+            "topic": "generic",
+            "size": 1,
+            "sha256": "digest",
+            "content_type": "application/octet-stream",
+        }
+    )
+
+    with pytest.raises(LargePayloadError, match="stream_topic"):
+        parse_large_payload_descriptor(payload)
+
+
+def test_parse_large_payload_descriptor_rejects_missing_inline_data() -> None:
+    payload = json.dumps(
+        {
+            "type": DESCRIPTOR_TYPE,
+            "version": 1,
+            "id": "payload-6",
+            "transfer": "inline",
+            "topic": "generic",
+            "size": 1,
+            "sha256": "digest",
+            "content_type": "application/octet-stream",
+        }
+    )
+
+    with pytest.raises(LargePayloadError, match="'data'"):
+        parse_large_payload_descriptor(payload)


### PR DESCRIPTION
## Summary

* add `utils.large_payload` helpers for publishing application payloads that may exceed practical data-packet size limits
* use a compact descriptor on a data topic, with inline base64 for small payloads and `stream_bytes` fallback for larger payloads
* add receiver-side helpers for descriptor parsing, streamed-byte size checks, and SHA-256 verification
* add a generic example under `examples/other` and focused unit coverage

Refs livekit/agents#6906

## Testing

* `python -m ruff check --fix livekit-agents/livekit/agents/utils/large_payload.py tests/test_large_payload.py livekit-agents/livekit/agents/utils/__init__.py examples/other/large-payload.py`
* `python -m ruff format livekit-agents/livekit/agents/utils/large_payload.py tests/test_large_payload.py livekit-agents/livekit/agents/utils/__init__.py examples/other/large-payload.py`
* `PYTHONPATH=livekit-agents python -m pytest tests/test_large_payload.py --unit`
* `MYPYPATH=livekit-agents python -m mypy --explicit-package-bases livekit-agents/livekit/agents/utils/large_payload.py`