### PR TITLE
fix(voice): keep the agent thinking while a tool is still running

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2766,7 +2766,11 @@ class AgentActivity(RecognitionHooks):
 
     def _on_pipeline_reply_done(self, _: asyncio.Task[None]) -> None:
         if not self._speech_q and (not self._current_speech or self._current_speech.done()):
-            self._session._update_agent_state("listening")
+            # a speech awaiting its tool executions keeps the agent busy: stay in
+            # "thinking" so the user-away timer isn't armed mid-tool (#6904)
+            self._session._update_agent_state(
+                "thinking" if self._background_speeches else "listening"
+            )
             if self._audio_recognition:
                 self._audio_recognition._on_end_of_agent_speech(
                     ignore_user_transcript_until=time.time()
@@ -2999,7 +3003,9 @@ class AgentActivity(RecognitionHooks):
             self._session._conversation_item_added(msg)
 
         if self._session.agent_state == "speaking":
-            self._session._update_agent_state("listening")
+            self._session._update_agent_state(
+                "thinking" if self._background_speeches else "listening"
+            )
             if self._audio_recognition:
                 self._audio_recognition._on_end_of_agent_speech(
                     ignore_user_transcript_until=time.time()
@@ -3495,7 +3501,7 @@ class AgentActivity(RecognitionHooks):
             speech_handle._item_added([msg])
             current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, forwarded_text)
 
-        if not speech_handle.interrupted and len(tool_output.output) > 0:
+        if not speech_handle.interrupted and (len(tool_output.output) > 0 or not exe_task.done()):
             self._session._update_agent_state("thinking")
             if self._audio_recognition:
                 self._audio_recognition._on_end_of_agent_speech(

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -23,6 +23,7 @@ from livekit.agents import (
     MetricsCollectedEvent,
     ModelSettings,
     NotGivenOr,
+    RunContext,
     TurnHandlingOptions,
     UserInputTranscribedEvent,
     UserStateChangedEvent,
@@ -394,6 +395,46 @@ async def test_tool_call() -> None:
     assert chat_ctx_items[6].type == "message"
     assert chat_ctx_items[6].role == "assistant"
     assert chat_ctx_items[6].text_content == "The weather in Tokyo is sunny today."
+
+
+async def test_slow_tool_keeps_agent_thinking_after_filler() -> None:
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Look up my order")
+    actions.add_llm(
+        content="Let me check.",
+        tool_calls=[FunctionToolCall(name="lookup_order", arguments="{}", call_id="1")],
+    )
+    actions.add_tts(2.0)
+    actions.add_tts(1.0, input="Just a moment.")
+    actions.add_llm(content="Order 42 is on the way.", input="order 42 shipped")
+    actions.add_tts(1.0)
+
+    class SlowToolAgent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="You are a helpful assistant.")
+
+        @function_tool
+        async def lookup_order(self, context: RunContext) -> str:
+            async with context.with_filler("Just a moment.", delay=0.5):
+                await asyncio.sleep(8.0)
+            return "order 42 shipped"
+
+    session = create_session(actions, extra_kwargs={"user_away_timeout": 3.0})
+
+    agent_state_events: list[AgentStateChangedEvent] = []
+    user_state_events: list[UserStateChangedEvent] = []
+    session.on("agent_state_changed", agent_state_events.append)
+    session.on("user_state_changed", user_state_events.append)
+
+    await asyncio.wait_for(
+        run_session(session, SlowToolAgent(), drain_delay=10), timeout=SESSION_TIMEOUT
+    )
+
+    # both the reply and the filler end while the tool is still running, so each
+    # must hand back "thinking", not "listening" (which arms the user-away timer)
+    speaking_ends = [ev.new_state for ev in agent_state_events if ev.old_state == "speaking"]
+    assert speaking_ends == ["thinking", "thinking", "listening"]
+    assert all(ev.new_state != "away" for ev in user_state_events)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`with_filler` speech during a long tool call knocks the session back to `listening`, which arms the user-away timer while the tool is still running. With `user_away_timeout` set, the user gets marked `away` mid-lookup and the app's inactivity handling fires over the agent's own tool call.

Two paths reset the state when a speech ends, and neither knows a tool is in flight:

- `_tts_task_impl` sets `listening` when the filler finishes playing
- `_on_pipeline_reply_done` does the same as the say task's done callback

The pipeline reply has the same gap without any filler: at playout end it only picks `thinking` when a tool already finished (`len(tool_output.output) > 0`), so a slow tool drops the state to `listening` until its result comes back.

The fix consults in-flight tool executions at those three spots. `_background_speeches` already tracks speeches that are awaiting their tools, so the two speech-end paths hand back `thinking` when it's non-empty. The reply task also stays in `thinking` when `exe_task` hasn't completed yet.

Added a test that runs a slow tool with a filler and a short `user_away_timeout`. On main the filler ends in `listening` and the user flips to `away` mid-tool. With the fix both speech ends return to `thinking` and the away timer stays disarmed. Unit suite, ruff and mypy are green.

Fixes #6904
