### PR TITLE
fix(tts): include supported encodings in RuntimeError message

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
@@ -491,4 +491,7 @@ def _encoding_to_mimetype(encoding: texttospeech.AudioEncoding) -> str:
     elif encoding == texttospeech.AudioEncoding.OGG_OPUS:
         return "audio/opus"
     else:
-        raise RuntimeError(f"encoding {encoding} isn't supported")
+        raise RuntimeError(
+            f"encoding {encoding} isn't supported, supported encodings: "
+            "PCM, LINEAR16, MP3, OGG_OPUS"
+        )


### PR DESCRIPTION
## Description
This PR updates the `RuntimeError` message thrown when an unsupported audio encoding is provided to explicitly list the supported encoding types (`PCM`, `LINEAR16`, `MP3`, `OGG_OPUS`).

## Why is this change needed?
Previously, when an invalid encoding was passed, developers had to check the source code or external documentation to find out which encodings were actually supported. This small QoL (Quality of Life) update improves Developer Experience (DX) by making the error message directly actionable.