### PR TITLE
fix: place Gemini realtime user turns before replies

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -1349,6 +1349,7 @@ class RealtimeSession(llm.RealtimeSession):
                         item_id=current_gen.input_id,
                         transcript=current_gen.input_transcription,
                         is_final=False,
+                        turn_started_at=current_gen._created_timestamp,
                     ),
                 )
 
@@ -1390,6 +1391,7 @@ class RealtimeSession(llm.RealtimeSession):
                     item_id=gen.input_id,
                     transcript=gen.input_transcription,
                     is_final=True,
+                    turn_started_at=gen._created_timestamp,
                 ),
             )
 

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -110,6 +110,29 @@ async def test_late_content_after_generation_complete_is_dropped(
         assert any("after generation completed" in r.message for r in caplog.records)
 
 
+async def test_input_transcription_uses_generation_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interim and final transcripts stay on the timeline before the reply they prompted."""
+    async with _make_session(monkeypatch) as session:
+        transcripts: list[llm.InputTranscriptionCompleted] = []
+        session.on("input_audio_transcription_completed", transcripts.append)
+        session._start_new_generation()
+        gen = session._current_generation
+        assert gen is not None
+        gen._created_timestamp = 1234.5
+
+        session._handle_server_content(
+            types.LiveServerContent(input_transcription=types.Transcription(text="hello"))
+        )
+        session._handle_server_content(types.LiveServerContent(turn_complete=True))
+
+        assert [(event.is_final, event.turn_started_at) for event in transcripts] == [
+            (False, 1234.5),
+            (True, 1234.5),
+        ]
+
+
 async def test_session_close_releases_the_genai_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Gemini can deliver the final user transcript after its reply, which makes session reports show the answer before the question. Anchor interim and final transcript events to the response generation time so the user turn stays before the reply it prompted.

Addresses AGT-3186

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> I got a customer report that gemini realtime model gave misaligned (timestamp wise) transcript.
>
> okay, can you open a PR?

</details>