### PR TITLE
fix(voice): place recorded audio where it actually played

### DIFF
--- a/livekit-agents/livekit/agents/voice/io.py
+++ b/livekit-agents/livekit/agents/voice/io.py
@@ -124,11 +124,28 @@ class PlaybackStartedEvent:
 
 
 @dataclass
+class PlaybackProgressedEvent:
+    """A stretch of the current segment that has played.
+
+    Reported once the audio can no longer be discarded, so it is never revised.
+    """
+
+    started_at: float
+    """The timestamp (time.time()) at which this stretch began to play"""
+    offset: float
+    """Where it starts in the audio captured for the current segment"""
+    duration: float
+    """How much of it played"""
+
+
+@dataclass
 class AudioOutputCapabilities:
     pause: bool
 
 
-class AudioOutput(ABC, rtc.EventEmitter[Literal["playback_finished", "playback_started"]]):
+class AudioOutput(
+    ABC, rtc.EventEmitter[Literal["playback_finished", "playback_started", "playback_progressed"]]
+):
     def __init__(
         self,
         *,
@@ -167,6 +184,7 @@ class AudioOutput(ABC, rtc.EventEmitter[Literal["playback_finished", "playback_s
         if next_in_chain is not None:
             next_in_chain.on("playback_finished", self._forward_next_playback_finished)
             next_in_chain.on("playback_started", self._forward_next_playback_started)
+            next_in_chain.on("playback_progressed", self._forward_next_playback_progressed)
 
     def _forward_next_playback_finished(self, ev: PlaybackFinishedEvent) -> None:
         self.on_playback_finished(
@@ -178,6 +196,11 @@ class AudioOutput(ABC, rtc.EventEmitter[Literal["playback_finished", "playback_s
     def _forward_next_playback_started(self, ev: PlaybackStartedEvent) -> None:
         self.on_playback_started(created_at=ev.created_at)
 
+    def _forward_next_playback_progressed(self, ev: PlaybackProgressedEvent) -> None:
+        self.on_playback_progressed(
+            started_at=ev.started_at, offset=ev.offset, duration=ev.duration
+        )
+
     @property
     def label(self) -> str:
         return self.__label
@@ -188,6 +211,17 @@ class AudioOutput(ABC, rtc.EventEmitter[Literal["playback_finished", "playback_s
 
     def on_playback_started(self, *, created_at: float) -> None:
         self.emit("playback_started", PlaybackStartedEvent(created_at=created_at))
+
+    def on_playback_progressed(self, *, started_at: float, offset: float, duration: float) -> None:
+        """Report a stretch of the current segment that has played.
+
+        Sinks that own their playback device report one run at a time; one that reports
+        nothing is described by its segment endpoints instead.
+        """
+        self.emit(
+            "playback_progressed",
+            PlaybackProgressedEvent(started_at=started_at, offset=offset, duration=duration),
+        )
 
     def on_playback_finished(
         self,
@@ -336,6 +370,7 @@ class _AudioSinkProxy(AudioOutput):
         if old is not None:
             old.off("playback_finished", self._forward_next_playback_finished)
             old.off("playback_started", self._forward_next_playback_started)
+            old.off("playback_progressed", self._forward_next_playback_progressed)
             if self._pending_playback_count > 0:
                 # stop audio still playing on the old sink
                 old.clear_buffer()
@@ -347,6 +382,7 @@ class _AudioSinkProxy(AudioOutput):
 
         new.on("playback_finished", self._forward_next_playback_finished)
         new.on("playback_started", self._forward_next_playback_started)
+        new.on("playback_progressed", self._forward_next_playback_progressed)
         if self._attached:
             new.on_attached()
 

--- a/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
+++ b/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
@@ -41,7 +41,6 @@ class _Captured:
     channel: int
     started_at: float
     frame: rtc.AudioFrame
-    ends_run: bool
 
 
 @dataclass
@@ -62,12 +61,18 @@ class _Track:
         self._run_samples = 0
         self.dropped_samples = 0
 
-    def _resample(self, frame: rtc.AudioFrame, *, flush: bool) -> np.ndarray:
+    def _resample(self, frame: rtc.AudioFrame) -> list[rtc.AudioFrame]:
+        """Mono frames at the recording rate, of which the resampler may still hold some back."""
         data = np.frombuffer(frame.data, dtype=np.int16).reshape(-1, frame.num_channels)
         mono = data.mean(axis=1).astype(np.int16) if frame.num_channels > 1 else data[:, 0]
-
+        mono_frame = rtc.AudioFrame(
+            data=mono.tobytes(),
+            sample_rate=frame.sample_rate,
+            num_channels=1,
+            samples_per_channel=len(mono),
+        )
         if frame.sample_rate == self._sample_rate:
-            return mono.astype(np.float32) / 32768.0
+            return [mono_frame]
 
         if self._resampler is None or self._source_rate != frame.sample_rate:
             self._source_rate = frame.sample_rate
@@ -75,24 +80,22 @@ class _Track:
                 input_rate=frame.sample_rate, output_rate=self._sample_rate, num_channels=1
             )
 
-        out = self._resampler.push(
-            rtc.AudioFrame(
-                data=mono.tobytes(),
-                sample_rate=frame.sample_rate,
-                num_channels=1,
-                samples_per_channel=len(mono),
-            )
-        )
-        if flush:
-            out = [*out, *self._resampler.flush()]
-        if not out:
-            return np.zeros(0, dtype=np.float32)
+        return self._resampler.push(mono_frame)
 
-        joined = np.concatenate([np.frombuffer(f.data, dtype=np.int16) for f in out])
-        return joined.astype(np.float32) / 32768.0
-
-    def push(self, started_at: float, frame: rtc.AudioFrame, *, ends_run: bool) -> None:
+    def push(self, started_at: float, frame: rtc.AudioFrame) -> None:
         """Add audio that began at ``started_at``, extending the open run where it fits."""
+
+        def _place(frames: list[rtc.AudioFrame]) -> None:
+            if not frames:
+                return
+
+            assert self._run_start is not None
+            joined = np.concatenate([np.frombuffer(f.data, dtype=np.int16) for f in frames])
+            samples = joined.astype(np.float32) / 32768.0
+            start = round((self._run_start - self._t0) * self._sample_rate) + self._run_samples
+            self._placed.append((start, samples))
+            self._run_samples += len(samples)
+
         expected = (
             None
             if self._run_start is None
@@ -100,19 +103,11 @@ class _Track:
         )
         if expected is None or abs(started_at - expected) > RESYNC_TOLERANCE:
             if self._resampler is not None:
-                # the leftover belongs to the run that just ended
-                self._resampler.flush()
+                # whatever the resampler still holds is the tail of the run that just ended
+                _place(self._resampler.flush())
             self._run_start, self._run_samples = started_at, 0
 
-        samples = self._resample(frame, flush=ends_run)
-        if len(samples):
-            assert self._run_start is not None
-            start = round((self._run_start - self._t0) * self._sample_rate) + self._run_samples
-            self._placed.append((start, samples))
-            self._run_samples += len(samples)
-
-        if ends_run:
-            self._run_start, self._run_samples = None, 0
+        _place(self._resample(frame))
 
     def take(self, start: int, end: int) -> np.ndarray:
         """The channel over ``[start, end)``, silent wherever nothing was placed."""
@@ -200,9 +195,7 @@ class RecorderIO:
         def on_frame(started_at: float, frame: rtc.AudioFrame) -> None:
             # a contiguous stream, so what has arrived is exactly what is settled
             self._input_settled = started_at + frame.duration
-            self._q.put_nowait(
-                _Captured(channel=0, started_at=started_at, frame=frame, ends_run=False)
-            )
+            self._q.put_nowait(_Captured(channel=0, started_at=started_at, frame=frame))
 
         self._in_record = RecorderAudioInput(
             recording_io=self, source=audio_input, on_frame=on_frame
@@ -212,9 +205,7 @@ class RecorderIO:
     def record_output(self, audio_output: io.AudioOutput) -> RecorderAudioOutput:
 
         def on_played(started_at: float, frame: rtc.AudioFrame) -> None:
-            self._q.put_nowait(
-                _Captured(channel=1, started_at=started_at, frame=frame, ends_run=False)
-            )
+            self._q.put_nowait(_Captured(channel=1, started_at=started_at, frame=frame))
 
         self._out_record = RecorderAudioOutput(
             recording_io=self, audio_output=audio_output, on_played=on_played
@@ -278,9 +269,7 @@ class RecorderIO:
             with container:
                 while (item := self._q.get()) is not None:
                     if isinstance(item, _Captured):
-                        tracks[item.channel].push(
-                            item.started_at, item.frame, ends_run=item.ends_run
-                        )
+                        tracks[item.channel].push(item.started_at, item.frame)
                         continue
 
                     end = round((item.until - self._t0) * self._sample_rate)

--- a/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
+++ b/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
@@ -5,10 +5,10 @@ import contextlib
 import queue
 import threading
 import time
-from collections import deque
 from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import av
 import numpy as np
@@ -17,17 +17,122 @@ from livekit import rtc
 
 from ... import utils
 from ...log import logger
-from ...utils.audio import silence_frame as _create_silence_frame
 from .. import io
 
 if TYPE_CHECKING:
     from ..agent_session import AgentSession
 
-# the recorder currently assume the input is a continous uninterrupted audio stream
-
+# Both channels sit on one absolute timeline: the user's audio where it arrived, the agent's
+# where the device reports it played. Silence is whatever nothing was written over.
 
 WRITE_INTERVAL = 2.5
 FFMPEG_STRICT_LEVEL = "experimental"
+
+# how long the writer waits on a source that stopped delivering before taking the silence as real
+INPUT_STALL_TIMEOUT = 1.0
+
+# a run continues while its own clock stays this close to the timestamps coming in; re-anchoring
+# beyond it keeps a drifting capture clock from sliding the channel
+RESYNC_TOLERANCE = 0.1
+
+
+@dataclass
+class _Captured:
+    channel: int
+    started_at: float
+    frame: rtc.AudioFrame
+    ends_run: bool
+
+
+@dataclass
+class _Flush:
+    until: float
+
+
+class _Track:
+    """One channel of the recording, holding runs of audio placed on the absolute timeline."""
+
+    def __init__(self, *, sample_rate: int, t0: float) -> None:
+        self._sample_rate = sample_rate
+        self._t0 = t0
+        self._placed: list[tuple[int, np.ndarray]] = []  # (start sample, mono float32)
+        self._resampler: rtc.AudioResampler | None = None
+        self._source_rate: int | None = None
+        self._run_start: float | None = None
+        self._run_samples = 0
+        self.dropped_samples = 0
+
+    def _resample(self, frame: rtc.AudioFrame, *, flush: bool) -> np.ndarray:
+        data = np.frombuffer(frame.data, dtype=np.int16).reshape(-1, frame.num_channels)
+        mono = data.mean(axis=1).astype(np.int16) if frame.num_channels > 1 else data[:, 0]
+
+        if frame.sample_rate == self._sample_rate:
+            return mono.astype(np.float32) / 32768.0
+
+        if self._resampler is None or self._source_rate != frame.sample_rate:
+            self._source_rate = frame.sample_rate
+            self._resampler = rtc.AudioResampler(
+                input_rate=frame.sample_rate, output_rate=self._sample_rate, num_channels=1
+            )
+
+        out = self._resampler.push(
+            rtc.AudioFrame(
+                data=mono.tobytes(),
+                sample_rate=frame.sample_rate,
+                num_channels=1,
+                samples_per_channel=len(mono),
+            )
+        )
+        if flush:
+            out = [*out, *self._resampler.flush()]
+        if not out:
+            return np.zeros(0, dtype=np.float32)
+
+        joined = np.concatenate([np.frombuffer(f.data, dtype=np.int16) for f in out])
+        return joined.astype(np.float32) / 32768.0
+
+    def push(self, started_at: float, frame: rtc.AudioFrame, *, ends_run: bool) -> None:
+        """Add audio that began at ``started_at``, extending the open run where it fits."""
+        expected = (
+            None
+            if self._run_start is None
+            else self._run_start + self._run_samples / self._sample_rate
+        )
+        if expected is None or abs(started_at - expected) > RESYNC_TOLERANCE:
+            if self._resampler is not None:
+                # the leftover belongs to the run that just ended
+                self._resampler.flush()
+            self._run_start, self._run_samples = started_at, 0
+
+        samples = self._resample(frame, flush=ends_run)
+        if len(samples):
+            assert self._run_start is not None
+            start = round((self._run_start - self._t0) * self._sample_rate) + self._run_samples
+            self._placed.append((start, samples))
+            self._run_samples += len(samples)
+
+        if ends_run:
+            self._run_start, self._run_samples = None, 0
+
+    def take(self, start: int, end: int) -> np.ndarray:
+        """The channel over ``[start, end)``, silent wherever nothing was placed."""
+        block = np.zeros(max(0, end - start), dtype=np.float32)
+        keep: list[tuple[int, np.ndarray]] = []
+        for pos, samples in self._placed:
+            stop = pos + len(samples)
+            if stop <= start:
+                self.dropped_samples += len(samples)
+                continue
+            if pos >= end:
+                keep.append((pos, samples))
+                continue
+
+            lo, hi = max(pos, start), min(stop, end)
+            block[lo - start : hi - start] += samples[lo - pos : hi - pos]
+            if stop > end:
+                keep.append((end, samples[end - pos :]))
+        self._placed = keep
+        return block
 
 
 class RecorderIO:
@@ -41,8 +146,7 @@ class RecorderIO:
         self._in_record: RecorderAudioInput | None = None
         self._out_record: RecorderAudioOutput | None = None
 
-        self._in_q: queue.Queue[list[rtc.AudioFrame] | None] = queue.Queue()
-        self._out_q: queue.Queue[list[rtc.AudioFrame] | None] = queue.Queue()
+        self._q: queue.Queue[_Captured | _Flush | None] = queue.Queue()
         self._session = agent_session
         self._sample_rate = sample_rate
         self._started = False
@@ -50,9 +154,10 @@ class RecorderIO:
         self._lock = asyncio.Lock()
         self._close_fut: asyncio.Future[None] = self._loop.create_future()
         self._output_path: Path | None = None
-        self._forward_atask: asyncio.Task[None] | None = None
+        self._write_atask: asyncio.Task[None] | None = None
 
-        self._skip_padding_warning = False
+        self._t0: float | None = None
+        self._input_settled: float = 0.0
 
     async def start(self, *, output_path: str | Path) -> None:
         async with self._lock:
@@ -61,15 +166,15 @@ class RecorderIO:
 
             if not self._in_record or not self._out_record:
                 raise RuntimeError(
-                    "RecorderIO not properly initialized: both `record_input()` and `record_output()` "
-                    "must be called before starting the recorder."
+                    "RecorderIO not properly initialized: both `record_input()` and "
+                    "`record_output()` must be called before starting the recorder."
                 )
 
             self._output_path = Path(output_path)
             self._started = True
-            self._skip_padding_warning = False
             self._close_fut = self._loop.create_future()
-            self._forward_atask = asyncio.create_task(self._forward_task())
+            self._t0 = self._input_settled = time.time()
+            self._write_atask = asyncio.create_task(self._write_task())
 
             thread = threading.Thread(
                 target=self._encode_thread, daemon=True, name="recorder_io_encode_thread"
@@ -81,22 +186,38 @@ class RecorderIO:
             if not self._started:
                 return
 
-            if self._forward_atask is not None:
-                await utils.aio.cancel_and_wait(self._forward_atask)
-                self._forward_atask = None
+            if self._write_atask is not None:
+                await utils.aio.cancel_and_wait(self._write_atask)
+                self._write_atask = None
 
-            self._in_q.put_nowait(None)
-            self._out_q.put_nowait(None)
+            self._q.put_nowait(_Flush(until=time.time()))
+            self._q.put_nowait(None)
             await asyncio.shield(self._close_fut)
             self._started = False
 
     def record_input(self, audio_input: io.AudioInput) -> RecorderAudioInput:
-        self._in_record = RecorderAudioInput(recording_io=self, source=audio_input)
+
+        def on_frame(started_at: float, frame: rtc.AudioFrame) -> None:
+            # a contiguous stream, so what has arrived is exactly what is settled
+            self._input_settled = started_at + frame.duration
+            self._q.put_nowait(
+                _Captured(channel=0, started_at=started_at, frame=frame, ends_run=False)
+            )
+
+        self._in_record = RecorderAudioInput(
+            recording_io=self, source=audio_input, on_frame=on_frame
+        )
         return self._in_record
 
     def record_output(self, audio_output: io.AudioOutput) -> RecorderAudioOutput:
+
+        def on_played(started_at: float, frame: rtc.AudioFrame) -> None:
+            self._q.put_nowait(
+                _Captured(channel=1, started_at=started_at, frame=frame, ends_run=False)
+            )
+
         self._out_record = RecorderAudioOutput(
-            recording_io=self, audio_output=audio_output, write_fnc=self._write_cb
+            recording_io=self, audio_output=audio_output, on_played=on_played
         )
         return self._out_record
 
@@ -110,46 +231,24 @@ class RecorderIO:
 
     @property
     def recording_started_at(self) -> float | None:
-        in_t = self._in_record.started_wall_time if self._in_record else None
-        out_t = self._out_record.started_wall_time if self._out_record else None
+        return self._t0
 
-        if in_t is None:
-            return out_t
-
-        if out_t is None:
-            return in_t
-
-        return min(in_t, out_t)
-
-    def _write_cb(self, buf: list[rtc.AudioFrame]) -> None:
-        assert self._in_record is not None
-
-        input_buf = self._in_record.take_buf(
-            pad_since=self._out_record._last_speech_end_time if self._out_record else None
-        )
-        self._in_q.put_nowait(input_buf)
-        self._out_q.put_nowait(buf)
-
-    async def _forward_task(self) -> None:
-        assert self._in_record is not None
+    async def _write_task(self) -> None:
         assert self._out_record is not None
 
-        # Forward the input audio to the encoder every WRITE_INTERVAL seconds.
         while True:
             await asyncio.sleep(WRITE_INTERVAL)
-            if self._out_record.has_pending_data:
-                # if the output is currenetly playing audio, wait for it to stay in sync
-                continue  # always wait for the complete output
 
-            input_buf = self._in_record.take_buf(pad_since=self._out_record._last_speech_end_time)
-            self._in_q.put_nowait(input_buf)
-            self._out_q.put_nowait([])
+            # a source gone quiet would hold the writer forever, so it is only waited on so long
+            settled = max(self._input_settled, time.time() - INPUT_STALL_TIMEOUT)
+            if pending := self._out_record.pending_since:
+                # a segment in flight has not said where its audio went
+                settled = min(settled, pending)
+
+            self._q.put_nowait(_Flush(until=settled))
 
     def _encode_thread(self) -> None:
-        GROW_FACTOR = 1.5
-        INV_INT16 = 1.0 / 32768.0
-
-        assert self._output_path is not None
+        assert self._output_path is not None and self._t0 is not None
         self._output_path.parent.mkdir(parents=True, exist_ok=True)
 
         container = av.open(self._output_path, mode="w", format="ogg")
@@ -172,117 +271,27 @@ class RecorderIO:
         if codec_name == "opus":
             stream.codec_context.options["strict"] = FFMPEG_STRICT_LEVEL
 
-        in_resampler: rtc.AudioResampler | None = None
-        out_resampler: rtc.AudioResampler | None = None
-
-        capacity = self._sample_rate * 6  # 6s, 1ch
-        stereo_buf = np.zeros((2, capacity), dtype=np.float32)
-
-        def remix_and_resample(frames: list[rtc.AudioFrame], channel_idx: int) -> int:
-            total_samples = sum(f.samples_per_channel * f.num_channels for f in frames)
-
-            nonlocal capacity, stereo_buf
-            if total_samples > capacity:
-                while capacity < total_samples:
-                    capacity = int(capacity * GROW_FACTOR)
-
-                stereo_buf.resize((2, capacity), refcheck=False)
-
-            pos = 0
-            dest = stereo_buf[channel_idx]
-            for f in frames:
-                count = f.samples_per_channel * f.num_channels
-                arr_i16 = np.frombuffer(f.data, dtype=np.int16, count=count).reshape(
-                    -1, f.num_channels
-                )
-                slice_ = dest[pos : pos + f.samples_per_channel]
-                np.sum(arr_i16, axis=1, dtype=np.float32, out=slice_)
-                slice_ *= INV_INT16 / f.num_channels
-                pos += f.samples_per_channel
-
-            return pos
+        tracks = [_Track(sample_rate=self._sample_rate, t0=self._t0) for _ in range(2)]
+        cursor = 0
 
         try:
             with container:
-                while True:
-                    input_buf = self._in_q.get()
-                    output_buf = self._out_q.get()
-
-                    if input_buf is None or output_buf is None:
-                        break
-
-                    # lazy creation of the resamplers
-                    if in_resampler is None and len(input_buf):
-                        input_rate, num_channels = (
-                            input_buf[0].sample_rate,
-                            input_buf[0].num_channels,
+                while (item := self._q.get()) is not None:
+                    if isinstance(item, _Captured):
+                        tracks[item.channel].push(
+                            item.started_at, item.frame, ends_run=item.ends_run
                         )
-                        in_resampler = rtc.AudioResampler(
-                            input_rate=input_rate,
-                            output_rate=self._sample_rate,
-                            num_channels=num_channels,
-                        )
-
-                    if out_resampler is None and len(output_buf):
-                        input_rate, num_channels = (
-                            output_buf[0].sample_rate,
-                            output_buf[0].num_channels,
-                        )
-                        out_resampler = rtc.AudioResampler(
-                            input_rate=input_rate,
-                            output_rate=self._sample_rate,
-                            num_channels=num_channels,
-                        )
-
-                    input_resampled = []
-                    for frame in input_buf:
-                        assert in_resampler is not None
-                        input_resampled.extend(in_resampler.push(frame))
-
-                    output_resampled = []
-                    for frame in output_buf:
-                        assert out_resampler is not None
-                        output_resampled.extend(out_resampler.push(frame))
-
-                    if output_buf:
-                        assert out_resampler is not None
-                        # the output is sent per-segment. Always flush when the playback is done
-                        output_resampled.extend(out_resampler.flush())
-
-                    len_left = remix_and_resample(input_resampled, 0)
-                    len_right = remix_and_resample(output_resampled, 1)
-
-                    if len_left != len_right:
-                        diff = abs(len_right - len_left)
-                        if len_left < len_right:
-                            if not self._skip_padding_warning:
-                                logger.warning(
-                                    f"Input is shorter by {diff} samples; silence has been prepended "
-                                    "to align the input channel. The resulting recording may not "
-                                    "accurately reflect the original audio. This is expected if the "
-                                    "input device or audio input is disabled. This warning will only "
-                                    "be shown once."
-                                )
-                                self._skip_padding_warning = True
-
-                            stereo_buf[0, diff : diff + len_left] = stereo_buf[0, :len_left]
-                            stereo_buf[0, :diff] = 0.0
-                            len_left = len_right
-                        else:
-                            stereo_buf[1, diff : diff + len_right] = stereo_buf[1, :len_right]
-                            stereo_buf[1, :diff] = 0.0
-                            len_right = len_left
-
-                    max_len = max(len_left, len_right)
-                    if max_len <= 0:
                         continue
 
-                    stereo_slice = stereo_buf[:, :max_len]
-                    av_frame = av.AudioFrame.from_ndarray(
-                        stereo_slice, format="fltp", layout="stereo"
-                    )
-                    av_frame.sample_rate = self._sample_rate
+                    end = round((item.until - self._t0) * self._sample_rate)
+                    if end <= cursor:
+                        continue
 
+                    block = np.stack([t.take(cursor, end) for t in tracks])
+                    cursor = end
+
+                    av_frame = av.AudioFrame.from_ndarray(block, format="fltp", layout="stereo")
+                    av_frame.sample_rate = self._sample_rate
                     for packet in stream.encode(av_frame):
                         container.mux(packet)
 
@@ -291,6 +300,13 @@ class RecorderIO:
         except Exception:
             logger.exception("recorder encode thread failed; recording may be incomplete")
         finally:
+            for label, track in zip(("input", "output"), tracks, strict=True):
+                if track.dropped_samples:
+                    logger.warning(
+                        "recorder dropped audio that reached it after its place in the timeline "
+                        "had been written",
+                        extra={"channel": label, "samples": track.dropped_samples},
+                    )
 
             def resolve_close_fut() -> None:
                 if not self._close_fut.done():
@@ -301,49 +317,17 @@ class RecorderIO:
 
 
 class RecorderAudioInput(io.AudioInput):
-    def __init__(self, *, recording_io: RecorderIO, source: io.AudioInput) -> None:
+    def __init__(
+        self,
+        *,
+        recording_io: RecorderIO,
+        source: io.AudioInput,
+        on_frame: Callable[[float, rtc.AudioFrame], None],
+    ) -> None:
         super().__init__(label="RecorderIO", source=source)
         self.__audio_input = source
         self.__recording_io = recording_io
-        self.__acc_frames: list[rtc.AudioFrame] = []
-        self.__started_time: None | float = None
-        self.__padded: bool = False
-
-    @property
-    def started_wall_time(self) -> float | None:
-        return self.__started_time
-
-    def take_buf(self, pad_since: float | None = None) -> list[rtc.AudioFrame]:
-        frames = self.__acc_frames
-        self.__acc_frames = []
-        if (
-            pad_since
-            and self.__started_time
-            and (padding := self.__started_time - pad_since) > 0
-            and not self.__padded
-            and len(frames) > 0
-        ):
-            logger.warning(
-                "input speech started after last agent speech ended",
-                extra={
-                    "last_agent_speech_time": pad_since,
-                    "input_started_time": self.__started_time,
-                },
-            )
-            self.__padded = True
-            frames = [
-                _create_silence_frame(padding, frames[0].sample_rate, frames[0].num_channels),
-                *frames,
-            ]
-        # we could pad with silence here with some fixed SR and channels,
-        # but it's better for the user to know that this is happening
-        elif pad_since and self.__started_time is None and not self.__padded and not frames:
-            logger.warning(
-                "input speech hasn't started yet, skipping silence padding, "
-                "recording may be inaccurate until the speech starts"
-            )
-
-        return frames
+        self.__on_frame = on_frame
 
     def __aiter__(self) -> AsyncIterator[rtc.AudioFrame]:
         return self
@@ -352,10 +336,8 @@ class RecorderAudioInput(io.AudioInput):
         frame = await self.__audio_input.__anext__()
 
         if self.__recording_io.recording:
-            if self.__started_time is None:
-                self.__started_time = time.time()
-
-            self.__acc_frames.append(frame)
+            # frames carry no capture timestamp, so arrival is the clock
+            self.__on_frame(time.time() - frame.duration, frame)
 
         return frame
 
@@ -366,24 +348,20 @@ class RecorderAudioOutput(io.AudioOutput):
         *,
         recording_io: RecorderIO,
         audio_output: io.AudioOutput | None = None,
-        write_fnc: Callable[[list[rtc.AudioFrame]], Any],
+        on_played: Callable[[float, rtc.AudioFrame], None],
     ) -> None:
         super().__init__(
             label="RecorderIO",
             next_in_chain=audio_output,
-            # TODO: support pause
-            capabilities=io.AudioOutputCapabilities(pause=True),  # depends on the next_in_chain
+            capabilities=io.AudioOutputCapabilities(pause=True),
         )
         self.__recording_io = recording_io
-        self.__write = write_fnc
-        self.__acc_frames: list[rtc.AudioFrame] = []
-        self.__started_time: None | float = None
-        self._last_speech_end_time: None | float = None
-        self._last_speech_start_time: None | float = None
-
-        # pause tracking
-        self.__current_pause_start: float | None = None
-        self.__pause_wall_times: list[tuple[float, float]] = []
+        self.__on_played = on_played
+        self.__acc: list[rtc.AudioFrame] = []
+        self.__pcm: np.ndarray | None = None  # the segment's frames, joined on first slice
+        self.__segment_since: float | None = None
+        self.__started_at: float | None = None
+        self.__reported = False
 
     @property
     def sample_rate(self) -> int | None:
@@ -392,38 +370,21 @@ class RecorderAudioOutput(io.AudioOutput):
         return self.next_in_chain.sample_rate if self.next_in_chain else None
 
     @property
-    def started_wall_time(self) -> float | None:
-        return self.__started_time
+    def pending_since(self) -> float | None:
+        """Wall time from which the agent channel is unsettled, while a segment is in flight."""
+        return self.__segment_since
 
-    @property
-    def recorder_io(self) -> RecorderIO:
-        return self.__recording_io
+    def on_playback_started(self, *, created_at: float) -> None:
+        super().on_playback_started(created_at=created_at)
+        if self.__started_at is None:
+            self.__started_at = created_at
 
-    @property
-    def has_pending_data(self) -> bool:
-        return len(self.__acc_frames) > 0
+    def on_playback_progressed(self, *, started_at: float, offset: float, duration: float) -> None:
+        super().on_playback_progressed(started_at=started_at, offset=offset, duration=duration)
 
-    def pause(self) -> None:
-        """Pause playback and record the wall time."""
-        if self.__current_pause_start is None and self.__recording_io.recording:
-            self.__current_pause_start = time.time()
-
-        if self.next_in_chain:
-            self.next_in_chain.pause()
-
-    def resume(self) -> None:
-        """Resume playback and record the pause interval."""
-        if self.__current_pause_start is not None and self.__recording_io.recording:
-            self.__pause_wall_times.append((self.__current_pause_start, time.time()))
-            self.__current_pause_start = None
-
-        if self.next_in_chain:
-            self.next_in_chain.resume()
-
-    def _reset_pause_state(self) -> None:
-        """Reset all pause tracking state."""
-        self.__current_pause_start = None
-        self.__pause_wall_times = []
+        if self.__recording_io.recording:
+            self.__reported = True
+            self.__place(started_at=started_at, offset=offset, duration=duration)
 
     def on_playback_finished(
         self,
@@ -432,108 +393,52 @@ class RecorderAudioOutput(io.AudioOutput):
         interrupted: bool,
         synchronized_transcript: str | None = None,
     ) -> None:
-        finish_time = self.__current_pause_start or time.time()
-        trailing_silence_duration = max(0.0, time.time() - finish_time)
-
-        if self._last_speech_start_time is None:
-            logger.warning(
-                "playback finished before speech started",
-                extra={
-                    "finish_time": finish_time,
-                    "playback_position": playback_position,
-                    "interrupted": interrupted,
-                },
-            )
-            playback_position = 0.0
-
-        playback_position = max(
-            0.0,
-            min(
-                finish_time - (self._last_speech_start_time or 0.0),
-                playback_position,
-            ),
-        )
-
         super().on_playback_finished(
             playback_position=playback_position,
             interrupted=interrupted,
             synchronized_transcript=synchronized_transcript,
         )
 
-        if not self.__recording_io.recording:
+        if self.__recording_io.recording and not self.__reported and self.__acc:
+            # the sink reports nothing of its own, so its endpoints describe the segment
+            self.__place(
+                started_at=self.__started_at
+                if self.__started_at is not None
+                else time.time() - playback_position,
+                offset=0.0,
+                duration=playback_position,
+            )
+
+        self.__acc = []
+        self.__pcm = None
+        self.__segment_since = None
+        self.__started_at = None
+        self.__reported = False
+
+    def __place(self, *, started_at: float, offset: float, duration: float) -> None:
+        """Hand the recorder the captured audio a report covers, at the time it played."""
+        if not self.__acc or duration <= 0:
             return
 
-        if self.__current_pause_start is not None:
-            self.__pause_wall_times.append((self.__current_pause_start, finish_time))
-            self.__current_pause_start = None
+        rate, channels = self.__acc[0].sample_rate, self.__acc[0].num_channels
+        if self.__pcm is None:
+            self.__pcm = np.concatenate([np.frombuffer(f.data, dtype=np.int16) for f in self.__acc])
 
-        if not self.__acc_frames:
-            self._reset_pause_state()
-            self._last_speech_end_time = time.time()
-            self._last_speech_start_time = None
+        lo = round(offset * rate) * channels
+        hi = min(round((offset + duration) * rate) * channels, len(self.__pcm))
+        if hi <= lo:
             return
 
-        pause_events: deque[tuple[float, float]] = deque()  # (position, duration)
-        playback_start_time = finish_time - playback_position
-        if self.__pause_wall_times:
-            total_pause_duration = sum(end - start for start, end in self.__pause_wall_times)
-            playback_start_time = finish_time - playback_position - total_pause_duration
-
-            accumulated_pause = 0.0
-            for pause_start, pause_end in self.__pause_wall_times:
-                position = (pause_start - playback_start_time) - accumulated_pause
-                duration = pause_end - pause_start
-                position = max(0.0, min(position, playback_position))
-                pause_events.append((position, duration))
-                accumulated_pause += duration
-
-        buf: list[rtc.AudioFrame] = []
-        acc_dur = 0.0
-        sample_rate = self.__acc_frames[0].sample_rate
-        num_channels = self.__acc_frames[0].num_channels
-
-        should_break = False
-        for frame in self.__acc_frames:
-            if frame.duration + acc_dur > playback_position:
-                frame, _ = _split_frame(frame, playback_position - acc_dur)
-                should_break = True
-
-            # process any pauses before this frame starts
-            while pause_events and pause_events[0][0] <= acc_dur:
-                pause_pos, pause_dur = pause_events.popleft()
-                buf.append(_create_silence_frame(pause_dur, sample_rate, num_channels))
-
-            # process any pauses within this frame
-            while pause_events and pause_events[0][0] < acc_dur + frame.duration:
-                pause_pos, pause_dur = pause_events.popleft()
-                left, frame = _split_frame(frame, pause_pos - acc_dur)
-                buf.append(left)
-                acc_dur += left.duration
-                buf.append(_create_silence_frame(pause_dur, sample_rate, num_channels))
-
-            buf.append(frame)
-            acc_dur += frame.duration
-
-            if should_break:
-                break
-
-        while pause_events:
-            pause_pos, pause_dur = pause_events.popleft()
-            if pause_pos <= playback_position:
-                buf.append(_create_silence_frame(pause_dur, sample_rate, num_channels))
-
-        buf = [f for f in buf if f.duration > 0.0]
-        if buf:
-            if trailing_silence_duration > 0.0:
-                buf.append(
-                    _create_silence_frame(trailing_silence_duration, sample_rate, num_channels)
-                )
-            self.__write(buf)
-
-        self.__acc_frames = []
-        self._reset_pause_state()
-        self._last_speech_end_time = time.time()
-        self._last_speech_start_time = None
+        chunk = self.__pcm[lo:hi]
+        self.__on_played(
+            started_at,
+            rtc.AudioFrame(
+                data=chunk.tobytes(),
+                sample_rate=rate,
+                num_channels=channels,
+                samples_per_channel=len(chunk) // channels,
+            ),
+        )
 
     async def capture_frame(self, frame: rtc.AudioFrame) -> None:
         if self.next_in_chain:
@@ -542,28 +447,10 @@ class RecorderAudioOutput(io.AudioOutput):
         await super().capture_frame(frame)
 
         if self.__recording_io.recording:
-            self.__acc_frames.append(frame)
-
-        if self.__started_time is None or self._last_speech_start_time is None:
-            capture_time = time.time()
-
-            if self.__started_time is None:
-                self.__started_time = capture_time
-
-            if self._last_speech_start_time is None:
-                # exclude pauses from before this segment.
-                self.__pause_wall_times = [
-                    (max(start, capture_time), end)
-                    for start, end in self.__pause_wall_times
-                    if end > capture_time
-                ]
-                # a pause cannot start before the segment
-                if self.__current_pause_start is not None:
-                    self.__current_pause_start = max(
-                        self.__current_pause_start,
-                        capture_time,
-                    )
-                self._last_speech_start_time = capture_time
+            if not self.__acc:
+                self.__segment_since = time.time()
+            self.__acc.append(frame)
+            self.__pcm = None
 
     def flush(self) -> None:
         super().flush()
@@ -574,44 +461,3 @@ class RecorderAudioOutput(io.AudioOutput):
     def clear_buffer(self) -> None:
         if self.next_in_chain:
             self.next_in_chain.clear_buffer()
-
-
-def _split_frame(frame: rtc.AudioFrame, position: float) -> tuple[rtc.AudioFrame, rtc.AudioFrame]:
-    if position <= 0.0:
-        return rtc.AudioFrame(
-            data=b"",
-            num_channels=frame.num_channels,
-            samples_per_channel=0,
-            sample_rate=frame.sample_rate,
-        ), frame
-
-    if position >= frame.duration:
-        return frame, rtc.AudioFrame(
-            data=b"",
-            num_channels=frame.num_channels,
-            samples_per_channel=0,
-            sample_rate=frame.sample_rate,
-        )
-
-    samples_needed = min(int(position * frame.sample_rate), frame.samples_per_channel)
-
-    # `frame.data` is a memoryview of int16 samples (format "h"), so it is indexed in
-    # samples, not bytes. The split point in that buffer is `samples_per_channel` worth
-    # of interleaved samples across all channels.
-    split = samples_needed * frame.num_channels
-    data = frame.data
-
-    return (
-        rtc.AudioFrame(
-            data=bytes(data[:split]),
-            num_channels=frame.num_channels,
-            samples_per_channel=samples_needed,
-            sample_rate=frame.sample_rate,
-        ),
-        rtc.AudioFrame(
-            data=bytes(data[split:]),
-            num_channels=frame.num_channels,
-            samples_per_channel=frame.samples_per_channel - samples_needed,
-            sample_rate=frame.sample_rate,
-        ),
-    )

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -68,6 +68,11 @@ class _ParticipantAudioOutput(io.AudioOutput):
         self._source_discarded_duration: float = 0.0
         self._interruption_generation = 0
 
+        # the playhead sits at `_source_pushed_duration - queued_duration`; `_dry_at` is when
+        # the source runs out if nothing more is pushed, which dates a run that has ended
+        self._run_offset: float = 0.0
+        self._dry_at: float | None = None
+
         self._playback_enabled = asyncio.Event()
         self._playback_enabled.set()
         # set only when _forward_audio is neither holding nor submitting a frame
@@ -148,6 +153,18 @@ class _ParticipantAudioOutput(io.AudioOutput):
         super().resume()
         self._playback_enabled.set()
 
+    def _report_run(
+        self, *, offset: float, ended_at: float, resumes_at: float | None = None
+    ) -> None:
+        """Report the open run, and begin the next past any audio that never played."""
+        duration = offset - self._run_offset
+        if duration > 0:
+            self.on_playback_progressed(
+                started_at=ended_at - duration, offset=self._run_offset, duration=duration
+            )
+        self._run_offset = offset if resumes_at is None else resumes_at
+        self._dry_at = None
+
     async def _wait_for_playout(self) -> None:
         wait_for_interruption = asyncio.create_task(self._interrupted_event.wait())
 
@@ -181,10 +198,18 @@ class _ParticipantAudioOutput(io.AudioOutput):
                 self._audio_buf.recv_nowait()
 
             pushed_duration = max(pushed_duration - queued_duration, 0)
+            # the playhead stops where the cleared queue begins
+            self._report_run(
+                offset=self._source_pushed_duration - queued_duration, ended_at=time.time()
+            )
             self._audio_source.clear_queue()
             wait_for_playout.cancel()
         else:
             wait_for_interruption.cancel()
+            # the source drained, so everything pushed has played
+            self._report_run(offset=self._source_pushed_duration, ended_at=time.time())
+
+        self._run_offset = 0.0
 
         self._pushed_duration = 0
         self._source_pushed_duration = 0
@@ -199,14 +224,19 @@ class _ParticipantAudioOutput(io.AudioOutput):
             self._forwarding_idle.clear()
             try:
                 if not self._playback_enabled.is_set():
-                    self._source_discarded_duration += self._audio_source.queued_duration
+                    queued = self._audio_source.queued_duration
+                    self._source_discarded_duration += queued
+                    # the dropped queue never plays, so the next run resumes past it
+                    self._report_run(
+                        offset=self._source_pushed_duration - queued,
+                        ended_at=time.time(),
+                        resumes_at=self._source_pushed_duration,
+                    )
                     self._audio_source.clear_queue()
                     await self._playback_enabled.wait()
                     # drop a paused frame when its original segment was interrupted.
                     if interruption_generation != self._interruption_generation:
                         continue
-                    # TODO(long): preserve or report cleared frames so RecorderIO can reconstruct
-                    # discarded mid-stream audio instead of only correcting playback duration.
                     # TODO(long): ignore frames from previous syllable
 
                 if self._interrupted_event.is_set() or self._pushed_duration == 0:
@@ -219,8 +249,13 @@ class _ParticipantAudioOutput(io.AudioOutput):
                 if not self._first_frame_event.is_set():
                     self._first_frame_event.set()
                     self.on_playback_started(created_at=time.time())
+                if self._dry_at is not None and time.time() >= self._dry_at:
+                    # the source ran out before this frame arrived
+                    self._report_run(offset=self._source_pushed_duration, ended_at=self._dry_at)
+
                 self._source_pushed_duration += frame.duration
                 await self._audio_source.capture_frame(frame)
+                self._dry_at = time.time() + self._audio_source.queued_duration
             finally:
                 self._forwarding_idle.set()
 

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -157,6 +157,10 @@ class _ParticipantAudioOutput(io.AudioOutput):
         self, *, offset: float, ended_at: float, resumes_at: float | None = None
     ) -> None:
         """Report the open run, and begin the next past any audio that never played."""
+        if self._dry_at is not None:
+            # a run cannot outlast the audio the source held, however late the caller noticed
+            ended_at = min(ended_at, self._dry_at)
+
         duration = offset - self._run_offset
         if duration > 0:
             self.on_playback_progressed(

--- a/tests/test_audio_sink_proxy.py
+++ b/tests/test_audio_sink_proxy.py
@@ -10,6 +10,7 @@ from livekit.agents.voice.io import (
     AudioOutput,
     AudioOutputCapabilities,
     PlaybackFinishedEvent,
+    PlaybackProgressedEvent,
     _AudioSinkProxy,
 )
 
@@ -186,6 +187,40 @@ async def test_swap_routes_playback_events_from_new_leaf() -> None:
     leaf_b.on_playback_finished(playback_position=1.0, interrupted=False)
     assert len(received) == 1
     assert received[0].playback_position == 1.0
+
+
+async def test_swap_routes_playback_progress_from_new_leaf() -> None:
+    """A wrapper above a swapped leaf keeps hearing where the audio went."""
+    leaf_a = FakeAudioOutput()
+    leaf_b = FakeAudioOutput()
+    wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
+    proxy = wrapper.next_in_chain
+    assert isinstance(proxy, _AudioSinkProxy)
+
+    received: list[PlaybackProgressedEvent] = []
+    wrapper.on("playback_progressed", received.append)
+
+    leaf_a.on_playback_progressed(started_at=100.0, offset=0.0, duration=0.5)
+    proxy.set_next_in_chain(leaf_b)
+    leaf_b.on_playback_progressed(started_at=101.0, offset=0.0, duration=0.25)
+
+    assert [(ev.started_at, ev.duration) for ev in received] == [(100.0, 0.5), (101.0, 0.25)]
+
+
+async def test_swap_stops_playback_progress_from_the_old_leaf() -> None:
+    leaf_a = FakeAudioOutput()
+    leaf_b = FakeAudioOutput()
+    wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
+    proxy = wrapper.next_in_chain
+    assert isinstance(proxy, _AudioSinkProxy)
+
+    received: list[PlaybackProgressedEvent] = []
+    wrapper.on("playback_progressed", received.append)
+
+    proxy.set_next_in_chain(leaf_b)
+    leaf_a.on_playback_progressed(started_at=100.0, offset=0.0, duration=0.5)
+
+    assert received == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -120,6 +120,27 @@ async def test_a_drained_source_ends_its_run_when_it_ran_dry() -> None:
     assert ev.started_at == pytest.approx(dry_at - played)
 
 
+async def test_a_flush_after_the_source_drained_ends_the_run_when_it_ran_dry() -> None:
+    """A segment whose flush trails its own playout still sits where it played."""
+    async with _Harness() as h:
+        # 60ms is the progressive ramp, 20ms then 40ms, so the byte stream holds nothing back
+        await h.push(0.06)
+        played, dry_at = h.sink._source_pushed_duration, h.sink._dry_at
+        assert dry_at is not None
+
+        h.source.queued_duration = 0.0
+        h.now = dry_at + 0.7  # the flush arrives long after the last audio played
+        h.sink.flush()
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+    assert len(h.progress) == 1
+    ev = h.progress[0]
+    assert ev.offset == 0.0
+    assert ev.duration == pytest.approx(played)
+    assert ev.started_at == pytest.approx(dry_at - played)
+
+
 async def test_a_cleared_queue_leaves_a_hole_rather_than_a_short_tail() -> None:
     """pause() drops what the source holds, so the audio that never played is in the middle."""
     async with _Harness() as h:

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -1,0 +1,224 @@
+"""The room sink reports where its audio actually went.
+
+Playback is continuous between discontinuities, so an event exists to describe a boundary: the
+source queue drained, the queue was cleared, or the segment finished.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from livekit import rtc
+from livekit.agents.voice import io
+from livekit.agents.voice.room_io._output import _ParticipantAudioOutput
+
+pytestmark = pytest.mark.unit
+
+RATE = 48000
+
+
+class _FakeSource:
+    """Stands in for rtc.AudioSource; the test drives `queued_duration` by hand."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.queued_duration = 0.0
+        self.cleared = 0
+
+    async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        self.queued_duration += frame.duration
+
+    def clear_queue(self) -> None:
+        self.cleared += 1
+        self.queued_duration = 0.0
+
+    async def wait_for_playout(self) -> None:
+        self.queued_duration = 0.0
+
+
+def _frame(seconds: float) -> rtc.AudioFrame:
+    n = round(seconds * RATE)
+    return rtc.AudioFrame(bytes(n * 2), RATE, 1, n)
+
+
+class _Harness:
+    def __init__(self) -> None:
+        self.now = 100.0
+        self.progress: list[io.PlaybackProgressedEvent] = []
+        with patch("livekit.agents.voice.room_io._output.rtc.AudioSource", _FakeSource):
+            self.sink = _ParticipantAudioOutput(
+                MagicMock(),
+                sample_rate=RATE,
+                num_channels=1,
+                track_publish_options=MagicMock(),
+            )
+        self.source: _FakeSource = self.sink._audio_source  # type: ignore[assignment]
+        self.sink._subscribed_fut.set_result(None)
+        self.sink.on("playback_progressed", self.progress.append)
+
+    async def __aenter__(self) -> _Harness:
+        self._patch = patch(
+            "livekit.agents.voice.room_io._output.time.time", side_effect=lambda: self.now
+        )
+        self._patch.start()
+        self._task = asyncio.create_task(self.sink._forward_audio())
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        self._task.cancel()
+        self._patch.stop()
+
+    async def push(self, seconds: float) -> None:
+        """Capture a frame and let the forwarding task hand it to the source."""
+        await self.sink.capture_frame(_frame(seconds))
+        await self.settle()
+
+    async def settle(self) -> None:
+        for _ in range(200):
+            if self.sink._audio_buf.empty() and self.sink._forwarding_idle.is_set():
+                return
+            await asyncio.sleep(0)
+
+
+async def test_uninterrupted_playback_is_reported_once() -> None:
+    async with _Harness() as h:
+        h.source.queued_duration = 0.5  # a backlog the clock never catches up with
+        for _ in range(3):
+            await h.push(0.1)
+            h.now += 0.1
+
+        assert h.progress == []  # nothing to report while playback is continuous
+
+        h.sink.flush()
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+    assert len(h.progress) == 1
+    ev = h.progress[0]
+    assert ev.offset == 0.0
+    assert ev.duration == pytest.approx(0.3)
+
+
+async def test_a_drained_source_ends_its_run_when_it_ran_dry() -> None:
+    """Not when we noticed: the gap the listener heard is the gap in the recording."""
+    async with _Harness() as h:
+        await h.push(0.2)
+        played, dry_at = h.sink._source_pushed_duration, h.sink._dry_at
+        assert dry_at is not None
+
+        h.source.queued_duration = 0.0
+        h.now = dry_at + 0.5  # the next audio arrives half a second after the source ran out
+        await h.push(0.1)
+
+    assert len(h.progress) == 1
+    ev = h.progress[0]
+    assert ev.offset == 0.0
+    assert ev.duration == pytest.approx(played)
+    # the run ended when the queue emptied, not when the next push revealed it
+    assert ev.started_at == pytest.approx(dry_at - played)
+
+
+async def test_a_cleared_queue_leaves_a_hole_rather_than_a_short_tail() -> None:
+    """pause() drops what the source holds, so the audio that never played is in the middle."""
+    async with _Harness() as h:
+        await h.push(0.5)
+        pushed = h.sink._source_pushed_duration
+        h.now += 0.3
+        h.source.queued_duration = 0.2  # 0.2s queued and about to be thrown away
+
+        h.sink.pause()
+        await h.sink.capture_frame(_frame(0.1))
+        await h.settle()  # the forwarding task notices the pause and clears the queue
+        assert h.source.cleared == 1
+
+    assert len(h.progress) == 1
+    ev = h.progress[0]
+    assert ev.offset == 0.0
+    assert ev.duration == pytest.approx(pushed - 0.2)
+    # the next run resumes past the discarded audio rather than replaying it
+    assert h.sink._run_offset == pytest.approx(pushed)
+
+
+async def test_a_pause_and_resume_report_two_runs_around_the_hole() -> None:
+    async with _Harness() as h:
+        await h.push(0.5)
+        pushed = h.sink._source_pushed_duration
+        h.now += 0.3
+        h.source.queued_duration = 0.2
+
+        h.sink.pause()
+        await h.sink.capture_frame(_frame(0.5))
+        await h.settle()
+
+        h.now += 1.0  # the agent stays silent while the user speaks
+        resumed_at = h.now
+        h.source.queued_duration = 2.0  # a backlog the clock never catches up with
+        h.sink.resume()
+        await h.settle()
+
+        h.now += 1.0  # the resumed audio plays out
+        h.sink.flush()
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+    assert len(h.progress) == 2
+    first, second = h.progress
+    assert first.offset == 0.0
+    assert first.duration == pytest.approx(pushed - 0.2)
+    # the second run resumes past the discarded audio, and only after playback came back
+    assert second.offset == pytest.approx(pushed)
+    assert second.started_at > resumed_at
+    assert second.started_at > first.started_at + first.duration
+
+
+async def test_a_pause_then_interrupt_reports_the_run_once() -> None:
+    """The pause already ended the run; the interruption has nothing left to add."""
+    async with _Harness() as h:
+        await h.push(0.5)
+        pushed = h.sink._source_pushed_duration
+        h.source.queued_duration = 0.2
+
+        h.sink.pause()
+        await h.sink.capture_frame(_frame(0.1))
+        await h.settle()
+        assert len(h.progress) == 1
+
+        h.sink.flush()
+        h.sink.clear_buffer()
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+    assert len(h.progress) == 1
+    assert h.progress[0].duration == pytest.approx(pushed - 0.2)
+
+
+async def test_an_interruption_ends_the_run_at_the_playhead() -> None:
+    async with _Harness() as h:
+        await h.push(0.5)
+        pushed = h.sink._source_pushed_duration
+        h.source.queued_duration = 0.15  # queued and about to be dropped
+
+        h.sink.flush()
+        h.sink.clear_buffer()
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+    assert len(h.progress) == 1
+    assert h.progress[0].duration == pytest.approx(pushed - 0.15)
+
+
+async def test_offsets_restart_with_each_segment() -> None:
+    async with _Harness() as h:
+        for _ in range(2):
+            h.source.queued_duration = 0.5
+            await h.push(0.2)
+            h.sink.flush()
+            for _ in range(50):
+                await asyncio.sleep(0)
+            h.now += 1.0
+
+    assert len(h.progress) == 2
+    assert [ev.offset for ev in h.progress] == [0.0, 0.0]
+    assert all(ev.duration == pytest.approx(0.2) for ev in h.progress)

--- a/tests/test_recorder_io.py
+++ b/tests/test_recorder_io.py
@@ -155,7 +155,7 @@ def _loud(samples: int, sample_rate: int = 1000, channels: int = 1) -> rtc.Audio
 
 def test_placed_audio_lands_at_its_own_timestamp() -> None:
     track = _Track(sample_rate=1000, t0=0.0)
-    track.push(2.0, _loud(100), ends_run=True)
+    track.push(2.0, _loud(100))
 
     block = track.take(0, 3000)
     assert np.all(block[:2000] == 0.0)  # unwritten time is silence
@@ -165,8 +165,8 @@ def test_placed_audio_lands_at_its_own_timestamp() -> None:
 
 def test_a_gap_between_runs_stays_a_gap() -> None:
     track = _Track(sample_rate=1000, t0=0.0)
-    track.push(0.0, _loud(100), ends_run=True)
-    track.push(0.5, _loud(100), ends_run=True)
+    track.push(0.0, _loud(100))
+    track.push(0.5, _loud(100))
 
     block = track.take(0, 1000)
     assert np.all(block[:100] > 0.0)
@@ -177,7 +177,7 @@ def test_a_gap_between_runs_stays_a_gap() -> None:
 def test_audio_arriving_after_its_window_was_written_is_dropped_and_counted() -> None:
     track = _Track(sample_rate=1000, t0=0.0)
     track.take(0, 2000)  # the first two seconds have already gone to the encoder
-    track.push(0.5, _loud(100), ends_run=True)
+    track.push(0.5, _loud(100))
 
     assert np.all(track.take(2000, 3000) == 0.0)
     assert track.dropped_samples == 100
@@ -185,26 +185,28 @@ def test_audio_arriving_after_its_window_was_written_is_dropped_and_counted() ->
 
 def test_a_run_is_re_anchored_when_its_clock_drifts() -> None:
     track = _Track(sample_rate=1000, t0=0.0)
-    track.push(0.0, _loud(100), ends_run=False)
-    track.push(0.1, _loud(100), ends_run=False)  # contiguous, extends the run
-    track.push(5.0, _loud(100), ends_run=False)  # beyond tolerance, anchors on its own timestamp
+    track.push(0.0, _loud(100))
+    track.push(0.1, _loud(100))  # contiguous, extends the run
+    track.push(5.0, _loud(100))  # beyond tolerance, anchors on its own timestamp
 
     assert [pos for pos, _ in track._placed] == [0, 100, 5000]
 
 
 def test_a_source_below_the_recording_rate_is_resampled_in_place() -> None:
     track = _Track(sample_rate=48000, t0=0.0)
-    track.push(1.0, _loud(2400, sample_rate=24000), ends_run=True)  # 100ms at 24kHz
+    track.push(1.0, _loud(2400, sample_rate=24000))  # 100ms at 24kHz
+    track.push(9.0, _loud(2400, sample_rate=24000))  # a new run, so the first one is complete
 
     block = track.take(0, 48000 * 2)
     assert np.all(block[:48000] == 0.0)
-    # 100ms of audio, twice as many samples at the recording rate
+    # 100ms of audio, twice as many samples at the recording rate; the samples the resampler
+    # still held when the run ended are part of it
     assert np.count_nonzero(block[48000:]) == pytest.approx(4800, abs=50)
 
 
 def test_a_stereo_source_is_mixed_down() -> None:
     track = _Track(sample_rate=1000, t0=0.0)
-    track.push(0.0, _loud(100, channels=2), ends_run=True)
+    track.push(0.0, _loud(100, channels=2))
 
     block = track.take(0, 200)
     assert np.count_nonzero(block) == 100  # samples, not interleaved values

--- a/tests/test_recorder_io.py
+++ b/tests/test_recorder_io.py
@@ -1,0 +1,360 @@
+"""RecorderIO places both channels on one absolute timeline.
+
+The user's audio goes where it arrived, the agent's where the sink reported it played, and
+whatever nothing was written over stays silent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import av
+import numpy as np
+import pytest
+
+from livekit import rtc
+from livekit.agents.voice import io
+from livekit.agents.voice.recorder_io import recorder_io as recorder_module
+from livekit.agents.voice.recorder_io.recorder_io import (
+    RecorderAudioOutput,
+    RecorderIO,
+    _Track,
+)
+
+pytestmark = pytest.mark.unit
+
+RATE = 48000
+_CLOCK = "livekit.agents.voice.recorder_io.recorder_io.time.time"
+
+
+def _tone(
+    seconds: float, *, sample_rate: int = RATE, channels: int = 1, level: int = 0
+) -> rtc.AudioFrame:
+    """Silence, or a 1kHz tone that survives the opus encoder."""
+    n = round(seconds * sample_rate)
+    if level:
+        phase = 2 * np.pi * 1000 * np.arange(n) / sample_rate
+        wave = (level * np.sin(phase)).astype(np.int16)
+    else:
+        wave = np.zeros(n, dtype=np.int16)
+    data = np.repeat(wave, channels) if channels > 1 else wave
+    return rtc.AudioFrame(data.tobytes(), sample_rate, channels, n)
+
+
+# ---------------------------------------------------------------------------
+# RecorderAudioOutput: audio goes where the sink says it played
+# ---------------------------------------------------------------------------
+
+
+def _placing_output() -> tuple[RecorderAudioOutput, list[tuple[float, rtc.AudioFrame]]]:
+    placed: list[tuple[float, rtc.AudioFrame]] = []
+    output = RecorderAudioOutput(
+        recording_io=MagicMock(recording=True),
+        audio_output=None,
+        on_played=lambda started_at, frame: placed.append((started_at, frame)),
+    )
+    return output, placed
+
+
+async def test_reports_place_audio_at_the_time_it_played() -> None:
+    """A gap between two reports is a gap in the recording, not silence moved to the front."""
+    output, placed = _placing_output()
+    await output.capture_frame(_tone(1.0))
+    output.flush()
+
+    output.on_playback_progressed(started_at=100.0, offset=0.0, duration=0.4)
+    output.on_playback_progressed(started_at=101.0, offset=0.4, duration=0.6)
+    output.on_playback_finished(playback_position=1.0, interrupted=False)
+
+    assert [t for t, _ in placed] == [100.0, 101.0]
+    assert [round(f.duration, 3) for _, f in placed] == [0.4, 0.6]
+
+
+async def test_a_report_skips_the_audio_that_never_played() -> None:
+    """Audio dropped from the sink's queue is a hole in the middle, not a shortened end."""
+    output, placed = _placing_output()
+    await output.capture_frame(_tone(1.0))
+    output.flush()
+
+    # 0.2s of the segment was discarded on pause, so the next run resumes past it
+    output.on_playback_progressed(started_at=100.0, offset=0.0, duration=0.3)
+    output.on_playback_progressed(started_at=100.8, offset=0.5, duration=0.5)
+    output.on_playback_finished(playback_position=0.8, interrupted=False)
+
+    assert [t for t, _ in placed] == [100.0, 100.8]
+    assert [round(f.duration, 3) for _, f in placed] == [0.3, 0.5]
+
+
+async def test_a_sink_that_reports_nothing_is_anchored_at_playback_started() -> None:
+    """The fallback is the shape a remote sink sends: one report for the whole segment."""
+    output, placed = _placing_output()
+    await output.capture_frame(_tone(1.0))
+    output.flush()
+
+    output.on_playback_started(created_at=100.0)
+    now = 105.0  # noticed long after the audio really stopped
+    with patch(_CLOCK, side_effect=lambda: now):
+        output.on_playback_finished(playback_position=1.0, interrupted=False)
+
+    assert len(placed) == 1
+    started_at, frame = placed[0]
+    assert started_at == 100.0  # not 105.0 - 1.0, which is where the old recorder put it
+    assert round(frame.duration, 3) == 1.0
+
+
+async def test_a_sink_with_no_start_of_its_own_falls_back_to_the_segment_end() -> None:
+    """Last resort for a remote sink that never reports a start: date it from the finish."""
+    output, placed = _placing_output()
+    await output.capture_frame(_tone(1.0))
+    output.flush()
+
+    now = 105.0
+    with patch(_CLOCK, side_effect=lambda: now):
+        output.on_playback_finished(playback_position=1.0, interrupted=False)
+
+    assert len(placed) == 1
+    assert placed[0][0] == pytest.approx(104.0)
+
+
+async def test_the_fallback_truncates_an_interrupted_segment() -> None:
+    output, placed = _placing_output()
+    await output.capture_frame(_tone(1.0))
+    output.flush()
+
+    output.on_playback_started(created_at=100.0)
+    output.on_playback_finished(playback_position=0.4, interrupted=True)
+
+    assert len(placed) == 1
+    assert round(placed[0][1].duration, 3) == 0.4
+
+
+async def test_a_segment_in_flight_holds_the_timeline() -> None:
+    """The writer cannot settle a window whose agent audio has not been reported yet."""
+    output, _ = _placing_output()
+    assert output.pending_since is None
+
+    await output.capture_frame(_tone(1.0))
+    assert output.pending_since is not None
+
+    output.on_playback_progressed(started_at=100.0, offset=0.0, duration=1.0)
+    output.on_playback_finished(playback_position=1.0, interrupted=False)
+    assert output.pending_since is None
+
+
+# ---------------------------------------------------------------------------
+# _Track: the absolute timeline
+# ---------------------------------------------------------------------------
+
+
+def _loud(samples: int, sample_rate: int = 1000, channels: int = 1) -> rtc.AudioFrame:
+    data = np.full(samples * channels, 1000, dtype=np.int16)
+    return rtc.AudioFrame(data.tobytes(), sample_rate, channels, samples)
+
+
+def test_placed_audio_lands_at_its_own_timestamp() -> None:
+    track = _Track(sample_rate=1000, t0=0.0)
+    track.push(2.0, _loud(100), ends_run=True)
+
+    block = track.take(0, 3000)
+    assert np.all(block[:2000] == 0.0)  # unwritten time is silence
+    assert np.all(block[2000:2100] > 0.0)
+    assert np.all(block[2100:] == 0.0)
+
+
+def test_a_gap_between_runs_stays_a_gap() -> None:
+    track = _Track(sample_rate=1000, t0=0.0)
+    track.push(0.0, _loud(100), ends_run=True)
+    track.push(0.5, _loud(100), ends_run=True)
+
+    block = track.take(0, 1000)
+    assert np.all(block[:100] > 0.0)
+    assert np.all(block[100:500] == 0.0)
+    assert np.all(block[500:600] > 0.0)
+
+
+def test_audio_arriving_after_its_window_was_written_is_dropped_and_counted() -> None:
+    track = _Track(sample_rate=1000, t0=0.0)
+    track.take(0, 2000)  # the first two seconds have already gone to the encoder
+    track.push(0.5, _loud(100), ends_run=True)
+
+    assert np.all(track.take(2000, 3000) == 0.0)
+    assert track.dropped_samples == 100
+
+
+def test_a_run_is_re_anchored_when_its_clock_drifts() -> None:
+    track = _Track(sample_rate=1000, t0=0.0)
+    track.push(0.0, _loud(100), ends_run=False)
+    track.push(0.1, _loud(100), ends_run=False)  # contiguous, extends the run
+    track.push(5.0, _loud(100), ends_run=False)  # beyond tolerance, anchors on its own timestamp
+
+    assert [pos for pos, _ in track._placed] == [0, 100, 5000]
+
+
+def test_a_source_below_the_recording_rate_is_resampled_in_place() -> None:
+    track = _Track(sample_rate=48000, t0=0.0)
+    track.push(1.0, _loud(2400, sample_rate=24000), ends_run=True)  # 100ms at 24kHz
+
+    block = track.take(0, 48000 * 2)
+    assert np.all(block[:48000] == 0.0)
+    # 100ms of audio, twice as many samples at the recording rate
+    assert np.count_nonzero(block[48000:]) == pytest.approx(4800, abs=50)
+
+
+def test_a_stereo_source_is_mixed_down() -> None:
+    track = _Track(sample_rate=1000, t0=0.0)
+    track.push(0.0, _loud(100, channels=2), ends_run=True)
+
+    block = track.take(0, 200)
+    assert np.count_nonzero(block) == 100  # samples, not interleaved values
+    assert block[0] == pytest.approx(1000 / 32768, abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# RecorderIO end to end: a file whose channels sit where the audio happened
+# ---------------------------------------------------------------------------
+
+
+class _Source(io.AudioInput):
+    """Hands over pre-made frames, one per pull."""
+
+    def __init__(self) -> None:
+        super().__init__(label="test")
+        self.frames: list[rtc.AudioFrame] = []
+
+    async def __anext__(self) -> rtc.AudioFrame:
+        if not self.frames:
+            raise StopAsyncIteration
+        return self.frames.pop(0)
+
+
+class _Sink(io.AudioOutput):
+    """A leaf that accepts audio and reports nothing of its own."""
+
+    def __init__(self) -> None:
+        super().__init__(label="test", capabilities=io.AudioOutputCapabilities(pause=False))
+
+    async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        await super().capture_frame(frame)
+
+    def flush(self) -> None:
+        super().flush()
+
+    def clear_buffer(self) -> None:
+        pass
+
+
+def _decode(path: Path) -> tuple[np.ndarray, int]:
+    with av.open(str(path)) as container:
+        rate = container.streams.audio[0].rate
+        blocks = [f.to_ndarray() for f in container.decode(audio=0)]
+    pcm = np.concatenate(blocks, axis=1)
+    return (pcm.reshape(-1, 2).T if pcm.shape[0] == 1 else pcm), rate
+
+
+def _energy_bins(channel: np.ndarray, rate: int, width: float = 0.25) -> list[bool]:
+    step = int(rate * width)
+    return [
+        bool(np.max(np.abs(channel[i : i + step])) > 0.01) for i in range(0, len(channel), step)
+    ]
+
+
+async def test_a_recording_matches_when_each_channel_happened(tmp_path: Path) -> None:
+    """A stalled agent and a muted microphone both record as themselves.
+
+    The agent speaks 0.5s, goes quiet for 0.5s, speaks 0.5s. The microphone delivers for the
+    first second, then stops. Neither hole may be filled by moving the audio around it.
+    """
+    now = 1000.0
+    path = tmp_path / "session.ogg"
+
+    with patch(_CLOCK, side_effect=lambda: now):
+        source, sink = _Source(), _Sink()
+        recorder = RecorderIO(agent_session=MagicMock(), sample_rate=RATE)
+        audio_in = recorder.record_input(source)
+        audio_out = recorder.record_output(sink)
+        await recorder.start(output_path=path)
+        t0 = now
+
+        # a microphone that delivers for one second, then goes quiet
+        for _ in range(10):
+            now += 0.1
+            source.frames.append(_tone(0.1, level=8000))
+            await audio_in.__anext__()
+
+        # the agent speaks, stalls, then speaks again
+        await audio_out.capture_frame(_tone(1.0, level=8000))
+        audio_out.flush()
+        audio_out.on_playback_started(created_at=t0 + 1.5)
+        audio_out.on_playback_progressed(started_at=t0 + 1.5, offset=0.0, duration=0.5)
+        audio_out.on_playback_progressed(started_at=t0 + 2.5, offset=0.5, duration=0.5)
+        now = t0 + 3.0
+        audio_out.on_playback_finished(playback_position=1.0, interrupted=False)
+
+        await recorder.aclose()
+
+    pcm, rate = _decode(path)
+    assert pcm.shape[1] / rate == pytest.approx(3.0, abs=0.1)
+
+    # the microphone's first second is there, and its silence is silence
+    assert _energy_bins(pcm[0], rate) == [
+        True,
+        True,
+        True,
+        True,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+    ]
+    # the agent's two utterances sit either side of the stall, not packed together
+    assert _energy_bins(pcm[1], rate) == [
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+        True,
+        False,
+        False,
+        True,
+        True,
+    ]
+
+
+async def test_the_writer_waits_on_the_agent_but_not_on_a_quiet_source() -> None:
+    """A segment in flight holds the timeline; a microphone that went quiet does not."""
+    now = 1000.0
+    with patch(_CLOCK, side_effect=lambda: now):
+        recorder = RecorderIO(agent_session=MagicMock(), sample_rate=RATE)
+        recorder.record_input(_Source())
+        audio_out = recorder.record_output(_Sink())
+        recorder._t0 = recorder._input_settled = now
+        recorder._started = True
+
+        flushed: list[float] = []
+        recorder._q.put_nowait = lambda item: flushed.append(item.until)  # type: ignore[method-assign]
+
+        with patch.object(recorder_module, "WRITE_INTERVAL", 0):
+            task = asyncio.create_task(recorder._write_task())
+
+            now += 5.0  # the source has delivered nothing for five seconds
+            for _ in range(3):
+                await asyncio.sleep(0)
+            assert flushed[-1] == pytest.approx(now - recorder_module.INPUT_STALL_TIMEOUT)
+
+            await audio_out.capture_frame(_tone(0.2))  # a segment opens
+            segment_began = audio_out.pending_since
+            now += 5.0
+            for _ in range(3):
+                await asyncio.sleep(0)
+            assert flushed[-1] == pytest.approx(segment_began)
+
+            task.cancel()

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -8,10 +8,8 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
-import numpy as np
 import pytest
 
-from livekit import rtc
 from livekit.agents import Agent, AgentSession
 from livekit.agents.telemetry.traces import _upload_session_report
 from livekit.agents.voice.agent_session import (
@@ -19,7 +17,6 @@ from livekit.agents.voice.agent_session import (
     _RECORDING_ALL_ON,
     RecordingOptions,
 )
-from livekit.agents.voice.recorder_io.recorder_io import RecorderAudioOutput, _split_frame
 from livekit.protocol import metrics as proto_metrics
 
 from .fake_io import FakeAudioInput, FakeAudioOutput, FakeTextOutput
@@ -626,147 +623,3 @@ async def test_recorder_io_not_created_when_audio_false() -> None:
 
     assert session._recorder_io is None
     await _cleanup(session)
-
-
-# ---------------------------------------------------------------------------
-# Group 5: RecorderAudioOutput pause alignment
-# ---------------------------------------------------------------------------
-
-
-async def test_recorder_output_drops_pauses_before_the_segment() -> None:
-    frame = rtc.AudioFrame(bytes(960 * 2), 48000, 1, 960)  # 20ms
-    recording_io = MagicMock(recording=True)
-    writes: list[list[rtc.AudioFrame]] = []
-    output = RecorderAudioOutput(
-        recording_io=recording_io,
-        audio_output=None,
-        write_fnc=writes.append,
-    )
-    now = 10.0
-
-    with patch("livekit.agents.voice.recorder_io.recorder_io.time.time", side_effect=lambda: now):
-        output.pause()
-        now = 10.5
-        output.resume()
-
-        now = 11.0
-        await output.capture_frame(frame)
-        output.flush()
-
-        now = 11.02
-        output.on_playback_finished(playback_position=frame.duration, interrupted=False)
-
-    assert len(writes) == 1
-    assert sum(f.samples_per_channel for f in writes[0]) == pytest.approx(
-        frame.samples_per_channel, abs=1
-    )
-
-
-async def test_recorder_output_clips_a_pause_that_overlaps_the_segment() -> None:
-    frame = rtc.AudioFrame(bytes(960 * 2), 48000, 1, 960)  # 20ms
-    recording_io = MagicMock(recording=True)
-    writes: list[list[rtc.AudioFrame]] = []
-    output = RecorderAudioOutput(
-        recording_io=recording_io,
-        audio_output=None,
-        write_fnc=writes.append,
-    )
-    now = 10.0
-
-    with patch("livekit.agents.voice.recorder_io.recorder_io.time.time", side_effect=lambda: now):
-        output.pause()
-
-        now = 10.5
-        await output.capture_frame(frame)
-
-        now = 10.7
-        output.resume()
-        output.flush()
-
-        now = 10.72
-        output.on_playback_finished(playback_position=frame.duration, interrupted=False)
-
-    assert len(writes) == 1
-    assert sum(f.samples_per_channel for f in writes[0]) == pytest.approx(10560, abs=1)
-
-
-async def test_recorder_output_keeps_trailing_silence_for_a_midsegment_pause() -> None:
-    frame = rtc.AudioFrame(bytes(4800 * 2), 48000, 1, 4800)  # 100ms
-    recording_io = MagicMock(recording=True)
-    writes: list[list[rtc.AudioFrame]] = []
-    output = RecorderAudioOutput(
-        recording_io=recording_io,
-        audio_output=None,
-        write_fnc=writes.append,
-    )
-    now = 10.0
-
-    with patch("livekit.agents.voice.recorder_io.recorder_io.time.time", side_effect=lambda: now):
-        await output.capture_frame(frame)
-
-        now = 10.05
-        output.pause()
-        output.flush()
-
-        now = 10.2
-        output.on_playback_finished(playback_position=0.05, interrupted=True)
-
-    assert len(writes) == 1
-    assert sum(f.samples_per_channel for f in writes[0]) == pytest.approx(9600, abs=1)
-
-
-# ---------------------------------------------------------------------------
-# Group 6: _split_frame (encode-path helper)
-# ---------------------------------------------------------------------------
-
-
-def _ramp_frame(num_samples: int, num_channels: int, sample_rate: int = 24000) -> rtc.AudioFrame:
-    """A frame whose samples are a monotonic ramp, so splits can be checked for alignment."""
-    arr = np.arange(num_samples * num_channels, dtype=np.int16)
-    return rtc.AudioFrame(
-        data=arr.tobytes(),
-        num_channels=num_channels,
-        samples_per_channel=num_samples,
-        sample_rate=sample_rate,
-    )
-
-
-@pytest.mark.parametrize("num_channels", [1, 2])
-@pytest.mark.parametrize("fraction", [0.25, 0.5, 0.75])
-def test_split_frame_is_consistent_and_lossless(num_channels: int, fraction: float) -> None:
-    """`rtc.AudioFrame.data` is a memoryview of int16 *samples*, not bytes.
-
-    A split must keep each half's data length in sync with its samples_per_channel and
-    must neither drop nor duplicate samples. This guards the regression where the helper
-    indexed the buffer in bytes and produced corrupt frames on interrupted/paused playback.
-    """
-    n = 240
-    frame = _ramp_frame(n, num_channels)
-    left, right = _split_frame(frame, frame.duration * fraction)
-
-    # each half is internally consistent
-    assert len(left.data) == left.samples_per_channel * left.num_channels
-    assert len(right.data) == right.samples_per_channel * right.num_channels
-
-    # no samples lost or duplicated across the split
-    assert left.samples_per_channel + right.samples_per_channel == n
-    recon = np.concatenate(
-        [
-            np.frombuffer(bytes(left.data), dtype=np.int16),
-            np.frombuffer(bytes(right.data), dtype=np.int16),
-        ]
-    )
-    assert np.array_equal(recon, np.arange(n * num_channels, dtype=np.int16))
-
-
-def test_split_frame_boundaries() -> None:
-    """Splitting at or beyond the edges returns an empty half and the original."""
-    frame = _ramp_frame(100, 1)
-
-    empty, whole = _split_frame(frame, 0.0)
-    assert empty.samples_per_channel == 0 and len(empty.data) == 0
-    assert whole.samples_per_channel == 100
-
-    whole2, empty2 = _split_frame(frame, frame.duration * 2)
-    assert whole2.samples_per_channel == 100
-    assert empty2.samples_per_channel == 0 and len(empty2.data) == 0


### PR DESCRIPTION
**Problem**

RecorderIO rebuilds the agent channel by inference. It collects the frames it forwarded, places them from the wall-clock moment `playback_finished` arrives, and pads the difference with silence. Nothing measures where the audio really went.

Four conditions break that inference: a sink that runs dry inside a segment, a late flush, audio discarded on `pause()`, and a microphone that stops delivering. Each one moves the audio, and none of them records the gap. A slow TTS or a muted participant may hit it.

**Fix**

A sink that owns its playback device now reports where its audio went. `AudioOutput` gains `playback_progressed` next to `playback_started` and `playback_finished`, and `_ParticipantAudioOutput` reports one run at a time off its own queue. Each report is past tense, so it is never revised, and a jump in its offset describes audio the sink discarded rather than played.

RecorderIO places both channels on one absolute timeline and leaves unwritten time silent. When a sink reports nothing, the recorder uses its segment endpoints instead, which is all a remote avatar worker can know. That removes the pause reconstruction, the end-anchored padding, and the `playback_position` truncation.
