### PR TITLE
fix(elevenlabs): don't forward re-sent partial transcripts

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -390,6 +390,7 @@ class SpeechStream(stt.SpeechStream):
         self._session = http_session
         self._reconnect_event = asyncio.Event()
         self._speaking = False  # Track if we're currently in a speech segment
+        self._last_partial_text = ""
         self._audio_duration_collector = PeriodicCollector(
             callback=self._on_audio_duration_report,
             duration=5.0,
@@ -538,6 +539,7 @@ class SpeechStream(stt.SpeechStream):
         while True:
             try:
                 ws = await self._connect_ws()
+                self._last_partial_text = ""
                 if self._opts.previous_text:
                     # Must be the first input_audio_chunk on the connection.
                     await ws.send_str(
@@ -676,7 +678,9 @@ class SpeechStream(stt.SpeechStream):
         if message_type == "partial_transcript":
             logger.debug("Received message type partial_transcript: %s", data)
 
-            if text:
+            if text and text != self._last_partial_text:
+                self._last_partial_text = text
+
                 # Send START_OF_SPEECH if we're not already speaking
                 if not self._speaking:
                     self._event_ch.send_nowait(
@@ -697,6 +701,8 @@ class SpeechStream(stt.SpeechStream):
         ):
             # Final committed transcripts - these are sent to the LLM/TTS layer in LiveKit agents
             # and trigger agent responses (unlike partial transcripts which are UI-only)
+            self._last_partial_text = ""
+
             if text:
                 # Send START_OF_SPEECH if we're not already speaking
                 if not self._speaking:

--- a/tests/test_plugin_elevenlabs_stt.py
+++ b/tests/test_plugin_elevenlabs_stt.py
@@ -50,6 +50,7 @@ def _new_stream(*, server_vad=NOT_GIVEN) -> elevenlabs_stt.SpeechStream:
     stream._language = None
     stream._event_ch = _EventSink()
     stream._speaking = False
+    stream._last_partial_text = ""
     stream._start_time_offset = 0.0
     return stream
 
@@ -64,6 +65,60 @@ def _committed_transcript(text: str) -> dict:
         if text
         else [],
     }
+
+
+def _partial_transcript(text: str) -> dict:
+    return {"message_type": "partial_transcript", "text": text, "words": []}
+
+
+def _interim_texts(stream: elevenlabs_stt.SpeechStream) -> list[str]:
+    return [
+        event.alternatives[0].text
+        for event in stream._event_ch.events
+        if event.type == stt.SpeechEventType.INTERIM_TRANSCRIPT
+    ]
+
+
+def test_advancing_partial_transcripts_are_forwarded() -> None:
+    stream = _new_stream(server_vad={"vad_silence_threshold_secs": 0.5})
+
+    stream._process_stream_event(_partial_transcript("yeah"))
+    stream._process_stream_event(_partial_transcript("yeah please"))
+
+    assert _interim_texts(stream) == ["yeah", "yeah please"]
+
+
+def test_re_sent_partial_transcript_is_dropped() -> None:
+    stream = _new_stream(server_vad={"vad_silence_threshold_secs": 0.5})
+
+    for _ in range(5):
+        stream._process_stream_event(_partial_transcript("yeah please"))
+
+    assert _interim_texts(stream) == ["yeah please"]
+    assert [event.type for event in stream._event_ch.events] == [
+        stt.SpeechEventType.START_OF_SPEECH,
+        stt.SpeechEventType.INTERIM_TRANSCRIPT,
+    ]
+
+
+def test_the_same_words_after_a_commit_are_forwarded_again() -> None:
+    stream = _new_stream(server_vad={"vad_silence_threshold_secs": 0.5})
+
+    stream._process_stream_event(_partial_transcript("right"))
+    stream._process_stream_event(_committed_transcript("right"))
+    stream._process_stream_event(_partial_transcript("right"))
+
+    assert _interim_texts(stream) == ["right", "right"]
+
+
+def test_the_same_words_after_an_empty_commit_are_forwarded_again() -> None:
+    stream = _new_stream(server_vad=None)
+
+    stream._process_stream_event(_partial_transcript("right"))
+    stream._process_stream_event(_committed_transcript(""))
+    stream._process_stream_event(_partial_transcript("right"))
+
+    assert _interim_texts(stream) == ["right", "right"]
 
 
 def test_server_vad_commit_emits_end_of_speech() -> None:


### PR DESCRIPTION
## The behaviour

Scribe streams the open segment roughly **once a second whether or not its words grew**, so a segment it holds open produces a run of byte-identical `INTERIM_TRANSCRIPT` events. The 1Hz cadence is not a keepalive — it is Scribe's normal partial rate; measured over 6h of production traffic, partials whose text *changed* arrive with the same median gap (1.01s) as ones that did not. What is abnormal is only that the words stop advancing while the stream keeps ticking.

The framework itself is indifferent: `audio_recognition.py` stores a partial with a plain assignment (`self._audio_interim_transcript = ev.alternatives[0].text`), and since the interim → `_interrupt_by_audio_activity()` path is guarded by `self.vad is None`, a VAD-based pipeline does nothing with the extra events either.

Application code is not indifferent. Every re-send is emitted as `user_input_transcribed`, so anything that treats an interim as evidence the user is still talking receives that evidence at 1Hz for as long as the segment stays open — a hold that should last one window lasts the whole stall. We hit this with a reply gate of our own and fixed it on our side, then found a second consumer with the same assumption, which is what prompted moving the fix to where the events are produced.

## How often, measured

6h of production traffic, 1599 sessions, 343k interim events:

| | |
| --- | --- |
| partials that repeat the previous one | 1.95% |
| sessions with ≥1 repeat | 67.8% |
| sessions with a run ≥5 | 9.0% |
| sessions with a run ≥10 | 3.1% |
| run length ×2 (a single duplicate) | 87.9% |
| seconds stuck per run: median / p90 / max | 1.01s / 2.26s / 33.59s |

So 88% of the time this is one harmless extra event. The tail is what bites: the longest runs were 30–35 partials in a row, covering up to 33s of a single segment Scribe never committed. A separate session we traced had 25 identical partials across 24.9s.

## The change

Forward a partial only when its text differs from the last one, and clear the stored text whenever the segment it belonged to ends:

| ends by | why it must clear |
| --- | --- |
| a commit with text | the normal path — the same words next are a new utterance |
| an empty commit | closes the segment without producing a final |
| a reconnect | a fresh connection transcribes from scratch |

Nothing else changes: the first partial of a segment, every advancing partial, `START_OF_SPEECH`, finals and `END_OF_SPEECH` are all emitted exactly as before.

## Behaviour worth calling out

For pipelines with **no VAD** (`vad is None`), a re-sent partial currently keeps calling `_interrupt_by_audio_activity()` and re-arming the false-interruption resume timer (`false_interruption_timeout`, default 2.0s). Since re-sends arrive about every second, a paused agent turn can stay paused for as long as Scribe holds the segment open. After this change those re-sends no longer re-arm the timer, so such a turn resumes on schedule. I believe that is the intended behaviour — a re-send carries no new words — but it is a behaviour change for VAD-less setups and not just a noise reduction, so flagging it explicitly.

One residual case this does not cover: if Scribe drops a segment without ever committing it and the next utterance opens with the exact same words, its first partial is read as a re-send and dropped. The plugin cannot see the local VAD, so it has no signal for that boundary; the following partial (or the commit) still comes through, and adding a staleness timer felt worse than the case it would buy.

## Tests

`tests/test_plugin_elevenlabs_stt.py`, four new cases against the existing `_process_stream_event` harness, each pinned by a mutation only it catches:

| test | mutation it catches |
| --- | --- |
| `test_re_sent_partial_transcript_is_dropped` | drop `text != self._last_partial_text` |
| `test_advancing_partial_transcripts_are_forwarded` | over-eager filtering |
| `test_the_same_words_after_a_commit_are_forwarded_again` | drop the reset on a commit |
| `test_the_same_words_after_an_empty_commit_are_forwarded_again` | drop the reset on an empty commit |

`ruff format --check` · `ruff check` · `scripts/check_types.py` (mypy, 634 source files) · `pytest --unit` (1996 passed, 5 skipped) · `pytest --plugin elevenlabs` (29 passed) — all green on `main` at 5a36124.
