### PR TITLE
feat(speechmatics): expose end_of_turn_config and vad_config STT options

### DIFF
--- a/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
+++ b/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
@@ -38,10 +38,12 @@ from speechmatics.voice import (
     AdditionalVocabEntry,
     AgentServerMessageType,
     AudioEncoding,
+    EndOfTurnConfig,
     OperatingPoint,
     SpeakerFocusConfig,
     SpeakerFocusMode,
     SpeakerIdentifier,
+    VoiceActivityConfig,
     VoiceAgentClient,
     VoiceAgentConfig,
     VoiceAgentConfigPreset,
@@ -112,6 +114,10 @@ class STTOptions:
     punctuation_overrides: dict | None = None
     include_partials: bool | None = None
 
+    # Turn detection / VAD
+    end_of_turn_config: EndOfTurnConfig | None = None
+    vad_config: VoiceActivityConfig | None = None
+
     # Diarization
     enable_diarization: bool | None = None
     speaker_sensitivity: float | None = None
@@ -135,6 +141,8 @@ class STT(stt.STT):
         max_delay: NotGivenOr[float] = NOT_GIVEN,
         end_of_utterance_silence_trigger: NotGivenOr[float] = NOT_GIVEN,
         end_of_utterance_max_delay: NotGivenOr[float] = NOT_GIVEN,
+        end_of_turn_config: NotGivenOr[EndOfTurnConfig] = NOT_GIVEN,
+        vad_config: NotGivenOr[VoiceActivityConfig] = NOT_GIVEN,
         additional_vocab: NotGivenOr[list[AdditionalVocabEntry]] = NOT_GIVEN,
         punctuation_overrides: NotGivenOr[dict] = NOT_GIVEN,
         speaker_sensitivity: NotGivenOr[float] = NOT_GIVEN,
@@ -199,6 +207,17 @@ class STT(stt.STT):
             end_of_utterance_max_delay: Maximum delay in seconds for end of utterance.
                 Must be greater than `end_of_utterance_silence_trigger`.
                 Overrides preset if provided. Optional.
+
+            end_of_turn_config: Advanced end-of-turn tuning for `ADAPTIVE` and
+                `SMART_TURN` modes: annotation penalty multipliers, base multiplier,
+                minimum end-of-turn delay and forced end-of-utterance behaviour.
+                Replaces the preset's end-of-turn configuration entirely if
+                provided. Optional.
+
+            vad_config: Client-side voice activity detection settings (enabled,
+                silence_duration, threshold) used to schedule end-of-turn
+                predictions in `ADAPTIVE` and `SMART_TURN` modes. Replaces the
+                preset's VAD configuration entirely if provided. Optional.
 
             additional_vocab: List of additional vocabulary entries to increase the
                 weight of specific words in the transcription model. Defaults to [].
@@ -320,6 +339,8 @@ class STT(stt.STT):
             max_delay=_set(max_delay),
             end_of_utterance_silence_trigger=_set(end_of_utterance_silence_trigger),
             end_of_utterance_max_delay=_set(end_of_utterance_max_delay),
+            end_of_turn_config=_set(end_of_turn_config),
+            vad_config=_set(vad_config),
             punctuation_overrides=_set(punctuation_overrides),
             include_partials=_set(include_partials),
             enable_diarization=_set(enable_diarization),
@@ -471,6 +492,7 @@ class STT(stt.STT):
         # Override preset parameters if provided
         advanced_params = [
             "enable_diarization",
+            "end_of_turn_config",
             "end_of_utterance_max_delay",
             "end_of_utterance_silence_trigger",
             "include_partials",
@@ -480,6 +502,7 @@ class STT(stt.STT):
             "prefer_current_speaker",
             "punctuation_overrides",
             "speaker_sensitivity",
+            "vad_config",
         ]
 
         # Override preset parameters if provided

--- a/tests/test_plugin_speechmatics_stt.py
+++ b/tests/test_plugin_speechmatics_stt.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.plugin("speechmatics")
+
+
+def _make_stt(**kwargs):
+    from livekit.plugins import speechmatics
+    from livekit.plugins.speechmatics.stt import TurnDetectionMode
+
+    # ADAPTIVE avoids the EXTERNAL-mode Silero auto-load; no connection is opened.
+    kwargs.setdefault("turn_detection_mode", TurnDetectionMode.ADAPTIVE)
+    return speechmatics.STT(api_key="fake-api-key", **kwargs)
+
+
+def test_end_of_turn_config_passthrough():
+    from speechmatics.voice import EndOfTurnConfig
+
+    eot = EndOfTurnConfig(
+        base_multiplier=1.5,
+        min_end_of_turn_delay=0.2,
+        use_forced_eou=True,
+    )
+    config = _make_stt(end_of_turn_config=eot)._prepare_config()
+
+    assert config.end_of_turn_config.base_multiplier == 1.5
+    assert config.end_of_turn_config.min_end_of_turn_delay == 0.2
+    assert config.end_of_turn_config.use_forced_eou is True
+
+
+def test_vad_config_passthrough():
+    from speechmatics.voice import VoiceActivityConfig
+
+    vad_config = VoiceActivityConfig(enabled=True, silence_duration=0.35, threshold=0.5)
+    config = _make_stt(vad_config=vad_config)._prepare_config()
+
+    assert config.vad_config.enabled is True
+    assert config.vad_config.silence_duration == 0.35
+    assert config.vad_config.threshold == 0.5
+
+
+def test_preset_defaults_kept_when_not_given():
+    config = _make_stt()._prepare_config()
+
+    # ADAPTIVE preset values must be untouched when the new kwargs are omitted.
+    assert config.vad_config is not None and config.vad_config.enabled is True
+    assert config.vad_config.silence_duration == pytest.approx(0.18)
+    assert config.end_of_turn_config.use_forced_eou is True
+    assert config.end_of_turn_config.min_end_of_turn_delay == pytest.approx(0.01)


### PR DESCRIPTION
Addresses #6924

## Problem

In `ADAPTIVE` and `SMART_TURN` modes, the effective end-of-turn wait is not the configured `end_of_utterance_silence_trigger`: it is the trigger multiplied by the `EndOfTurnConfig` penalty table, minus recent TTFB, floored at `min_end_of_turn_delay` (`speechmatics.voice._client.VoiceAgentClient._calculate_finalize_delay`). The SDK-default penalties make this collapse far below any configured value:

- The preset-enabled client-side Silero VAD reports `speech_ended` after only 0.18s of silence (`VoiceActivityConfig.silence_duration` default).
- With Smart Turn not enabled (`ADAPTIVE`), every VAD stop matches the `VAD_STOPPED + SMART_TURN_INACTIVE` penalty: **×0.2**.
- A fragment the STT itself punctuated as sentence-final matches `ENDS_WITH_FINAL + ENDS_WITH_EOS`: **×0.5**, and simultaneously loses the ×2.0 "not end-of-sentence" protection.

With `end_of_utterance_silence_trigger=0.6`, the effective wait after the VAD fires is `0.6 × 0.2 × 0.5 = 0.06s` (punctuated) or `0.6 × 0.2 × 2.0 = 0.24s` (unpunctuated), then floored as low as `min_end_of_turn_delay=0.01s` after TTFB subtraction. Total real-world pause tolerance is roughly **0.25-0.45s**, regardless of the configured trigger (even 1.5s yields ≤0.6s). On telephony this splits normal mid-sentence pauses (a caller recalling a date of birth or spelling out an email address) into multiple committed user turns, with the agent replying to each fragment.

Because the trigger only scales the base linearly, **no currently exposed plugin parameter can prevent this**: `EndOfTurnConfig` and `VoiceActivityConfig` are not in the constructor and not in `_prepare_config()`'s `advanced_params` whitelist.

## Change

Expose both objects through the existing preset-override mechanism, exactly like the other advanced parameters:

- `STT(...)` gains typed optional kwargs `end_of_turn_config: NotGivenOr[EndOfTurnConfig]` and `vad_config: NotGivenOr[VoiceActivityConfig]` (both types are already public exports of `speechmatics-voice`, which this plugin already depends on).
- Both are stored on `STTOptions` and added to the `advanced_params` whitelist in `_prepare_config()`, so a provided value replaces the preset's object entirely and an omitted kwarg changes nothing.
- Docstrings added per the project's pdoc conventions.

No behavior change for existing users: both kwargs default to `NOT_GIVEN`.

## Usage example

```python
from speechmatics.voice import EndOfTurnConfig, VoiceActivityConfig
from livekit.plugins import speechmatics
from livekit.plugins.speechmatics.stt import TurnDetectionMode

stt = speechmatics.STT(
    turn_detection_mode=TurnDetectionMode.ADAPTIVE,
    end_of_utterance_silence_trigger=0.6,
    # soften the silence fast-path for telephony
    end_of_turn_config=EndOfTurnConfig(min_end_of_turn_delay=0.15, use_forced_eou=True),
    vad_config=VoiceActivityConfig(enabled=True, silence_duration=0.3),
)
```

## Testing

`tests/test_plugin_speechmatics_stt.py` (marked `pytest.mark.plugin("speechmatics")`, hermetic, no network):

- `test_end_of_turn_config_passthrough`: a provided `EndOfTurnConfig` reaches the prepared `VoiceAgentConfig`.
- `test_vad_config_passthrough`: same for `VoiceActivityConfig`.
- `test_preset_defaults_kept_when_not_given`: omitting both kwargs leaves the ADAPTIVE preset's values untouched.

`ruff check` and `ruff format` pass on both files.

## Notes

Happy to adjust the API shape if maintainers prefer granular kwargs over passing the config objects.
