### PR TITLE
fix(openai): read TTS response by content-type, not model name

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -47,6 +47,8 @@ RESPONSE_FORMATS = Literal["mp3", "opus", "aac", "flac", "wav", "pcm"] | str
 # Models that use audio stream format (character-based billing)
 AUDIO_STREAM_MODELS = {"tts-1", "tts-1-hd"}
 
+SSE_CONTENT_TYPE = "text/event-stream"
+
 
 @dataclass
 class _TTSOptions:
@@ -198,11 +200,7 @@ class TTS(tts.TTS):
     def synthesize(
         self, text: str, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
     ) -> tts.ChunkedStream:
-        # Use audio stream format for tts-1/tts-1-hd (character-based billing)
-        # Use SSE stream format for newer models like gpt-4o-mini-tts (token-based billing)
-        if self._opts.model in AUDIO_STREAM_MODELS:
-            return AudioChunkedStream(tts=self, input_text=text, conn_options=conn_options)
-        return SSEChunkedStream(tts=self, input_text=text, conn_options=conn_options)
+        return ChunkedStream(tts=self, input_text=text, conn_options=conn_options)
 
     def prewarm(self) -> None:
         async def _prewarm() -> None:
@@ -221,8 +219,13 @@ class TTS(tts.TTS):
             await self._client.close()
 
 
-class AudioChunkedStream(tts.ChunkedStream):
-    """ChunkedStream for tts-1 and tts-1-hd models using audio stream format."""
+class ChunkedStream(tts.ChunkedStream):
+    """ChunkedStream that reads the body according to what the server actually returned.
+
+    `stream_format` is an OpenAI-specific extension. OpenAI-compatible servers ignore it and
+    answer with the audio bytes of `response_format` rather than an SSE stream, so the response
+    `Content-Type` -- not the requested `stream_format` -- decides how the body is parsed.
+    """
 
     def __init__(self, *, tts: TTS, input_text: str, conn_options: APIConnectOptions) -> None:
         super().__init__(tts=tts, input_text=input_text, conn_options=conn_options)
@@ -237,7 +240,8 @@ class AudioChunkedStream(tts.ChunkedStream):
             response_format=self._opts.response_format,  # type: ignore
             speed=self._opts.speed,
             instructions=self._opts.instructions or openai.omit,
-            stream_format="audio",
+            # `sse` is not supported for tts-1/tts-1-hd (character-based billing)
+            stream_format="audio" if self._opts.model in AUDIO_STREAM_MODELS else "sse",
             timeout=httpx.Timeout(30, connect=self._conn_options.timeout),
         )
 
@@ -250,83 +254,45 @@ class AudioChunkedStream(tts.ChunkedStream):
                     mime_type=f"audio/{self._opts.response_format}",
                 )
 
-                async for data in stream.iter_bytes():
-                    output_emitter.push(data)
+                media_type = stream.headers.get("content-type", "").split(";")[0].strip().lower()
+                if media_type != SSE_CONTENT_TYPE:
+                    # An OpenAI-compatible server that ignored stream_format and returned the
+                    # audio bytes of response_format directly.
+                    async for chunk in stream.iter_bytes():
+                        output_emitter.push(chunk)
+                else:
+                    async for line in stream.iter_lines():
+                        if not line or not line.startswith("data: "):
+                            continue
 
-            output_emitter.flush()
+                        data = line[6:]  # Remove "data: " prefix
+                        if data == "[DONE]":
+                            break
 
-        except openai.APITimeoutError:
-            raise APITimeoutError() from None
-        except openai.APIStatusError as e:
-            raise APIStatusError(
-                e.message, status_code=e.status_code, request_id=e.request_id, body=e.body
-            ) from None
-        except Exception as e:
-            raise APIConnectionError() from e
+                        try:
+                            event = json.loads(data)
+                        except json.JSONDecodeError:
+                            continue
 
+                        event_type = event.get("type", "")
 
-class SSEChunkedStream(tts.ChunkedStream):
-    """ChunkedStream for gpt-4o-mini-tts and newer models using SSE stream format."""
+                        if event_type == "speech.audio.delta":
+                            # Decode base64 audio and push to emitter
+                            audio_b64 = event.get("delta", "") or event.get("audio", "")
+                            if audio_b64:
+                                audio_data = base64.b64decode(audio_b64)
+                                output_emitter.push(audio_data)
 
-    def __init__(self, *, tts: TTS, input_text: str, conn_options: APIConnectOptions) -> None:
-        super().__init__(tts=tts, input_text=input_text, conn_options=conn_options)
-        self._tts: TTS = tts
-        self._opts = replace(tts._opts)
-
-    async def _run(self, output_emitter: tts.AudioEmitter) -> None:
-        oai_stream = self._tts._client.audio.speech.with_streaming_response.create(
-            input=self.input_text,
-            model=self._opts.model,
-            voice=self._opts.voice,
-            response_format=self._opts.response_format,  # type: ignore
-            speed=self._opts.speed,
-            instructions=self._opts.instructions or openai.omit,
-            stream_format="sse",
-            timeout=httpx.Timeout(30, connect=self._conn_options.timeout),
-        )
-
-        try:
-            async with oai_stream as stream:
-                output_emitter.initialize(
-                    request_id=stream.request_id or "",
-                    sample_rate=SAMPLE_RATE,
-                    num_channels=NUM_CHANNELS,
-                    mime_type=f"audio/{self._opts.response_format}",
-                )
-
-                # Parse SSE events from the stream
-                async for line in stream.iter_lines():
-                    if not line or not line.startswith("data: "):
-                        continue
-
-                    data = line[6:]  # Remove "data: " prefix
-                    if data == "[DONE]":
-                        break
-
-                    try:
-                        event = json.loads(data)
-                    except json.JSONDecodeError:
-                        continue
-
-                    event_type = event.get("type", "")
-
-                    if event_type == "speech.audio.delta":
-                        # Decode base64 audio and push to emitter
-                        audio_b64 = event.get("delta", "") or event.get("audio", "")
-                        if audio_b64:
-                            audio_data = base64.b64decode(audio_b64)
-                            output_emitter.push(audio_data)
-
-                    elif event_type == "speech.audio.done":
-                        # Extract token usage from the done event
-                        usage = event.get("usage", {})
-                        input_tokens = usage.get("input_tokens", 0)
-                        output_tokens = usage.get("output_tokens", 0)
-                        if input_tokens or output_tokens:
-                            self._set_token_usage(
-                                input_tokens=input_tokens,
-                                output_tokens=output_tokens,
-                            )
+                        elif event_type == "speech.audio.done":
+                            # Extract token usage from the done event
+                            usage = event.get("usage", {})
+                            input_tokens = usage.get("input_tokens", 0)
+                            output_tokens = usage.get("output_tokens", 0)
+                            if input_tokens or output_tokens:
+                                self._set_token_usage(
+                                    input_tokens=input_tokens,
+                                    output_tokens=output_tokens,
+                                )
 
             output_emitter.flush()
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -49,6 +49,27 @@ AUDIO_STREAM_MODELS = {"tts-1", "tts-1-hd"}
 
 SSE_CONTENT_TYPE = "text/event-stream"
 
+# Content types `AudioEmitter` knows how to decode, mirroring the codecs decoder table.
+DECODABLE_CONTENT_TYPES = frozenset(
+    {
+        "audio/mpeg",
+        "audio/mp3",
+        "audio/x-mpeg",
+        "audio/aac",
+        "audio/x-aac",
+        "audio/flac",
+        "audio/x-flac",
+        "audio/wav",
+        "audio/wave",
+        "audio/x-wav",
+        "audio/opus",
+        "audio/ogg",
+        "audio/webm",
+        "audio/mp4",
+        "audio/pcm",
+    }
+)
+
 
 @dataclass
 class _TTSOptions:
@@ -247,14 +268,20 @@ class ChunkedStream(tts.ChunkedStream):
 
         try:
             async with oai_stream as stream:
+                media_type = stream.headers.get("content-type", "").split(";")[0].strip().lower()
+                # a server that ignored response_format still declares what it sent
+                mime_type = (
+                    media_type
+                    if media_type in DECODABLE_CONTENT_TYPES
+                    else f"audio/{self._opts.response_format}"
+                )
                 output_emitter.initialize(
                     request_id=stream.request_id or "",
                     sample_rate=SAMPLE_RATE,
                     num_channels=NUM_CHANNELS,
-                    mime_type=f"audio/{self._opts.response_format}",
+                    mime_type=mime_type,
                 )
 
-                media_type = stream.headers.get("content-type", "").split(";")[0].strip().lower()
                 if media_type != SSE_CONTENT_TYPE:
                     # An OpenAI-compatible server that ignored stream_format and returned the
                     # audio bytes of response_format directly.

--- a/tests/test_plugin_openai_tts.py
+++ b/tests/test_plugin_openai_tts.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import base64
+import json
+
+import httpx
+import openai
+import pytest
+
+from livekit.plugins.openai import TTS
+
+pytestmark = pytest.mark.unit
+
+PCM = b"\x00\x01" * 4800  # 200ms of 16-bit mono at 24kHz
+
+
+def _tts(handler, *, model: str, response_format: str = "pcm") -> TTS:
+    client = openai.AsyncClient(
+        api_key="test",
+        base_url="https://compatible.example.com/v1",
+        max_retries=0,
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    return TTS(model=model, client=client, response_format=response_format)
+
+
+async def _synthesize(tts: TTS) -> bytes:
+    audio = b""
+    async with tts.synthesize("hello") as stream:
+        async for ev in stream:
+            audio += ev.frame.data.tobytes()
+    return audio
+
+
+@pytest.mark.parametrize("model", ["hexgrad/Kokoro-82M", "gpt-4o-mini-tts"])
+async def test_audio_body_is_decoded_whatever_the_model(model: str) -> None:
+    """A compatible server ignores stream_format and answers with plain audio bytes."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=PCM, headers={"content-type": "audio/pcm"})
+
+    audio = await _synthesize(_tts(handler, model=model))
+
+    assert audio[: len(PCM)] == PCM
+
+
+async def test_sse_body_is_parsed() -> None:
+    """OpenAI answers stream_format="sse" with an event stream, which is still parsed."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        events = [
+            json.dumps({"type": "speech.audio.delta", "delta": base64.b64encode(PCM).decode()}),
+            json.dumps({"type": "speech.audio.done", "usage": {"input_tokens": 1}}),
+        ]
+        body = "".join(f"data: {e}\n\n" for e in events) + "data: [DONE]\n\n"
+        return httpx.Response(
+            200, content=body.encode(), headers={"content-type": "text/event-stream"}
+        )
+
+    audio = await _synthesize(_tts(handler, model="gpt-4o-mini-tts"))
+
+    assert audio[: len(PCM)] == PCM
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("tts-1", "audio"),
+        ("tts-1-hd", "audio"),
+        ("gpt-4o-mini-tts", "sse"),
+    ],
+)
+async def test_stream_format_requested_per_model(model: str, expected: str) -> None:
+    """`sse` is not supported for tts-1/tts-1-hd, so those must keep requesting `audio`."""
+    requests: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, content=PCM, headers={"content-type": "audio/pcm"})
+
+    await _synthesize(_tts(handler, model=model))
+
+    assert requests[0]["stream_format"] == expected

--- a/tests/test_plugin_openai_tts.py
+++ b/tests/test_plugin_openai_tts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import pathlib
 
 import httpx
 import openai
@@ -42,6 +43,19 @@ async def test_audio_body_is_decoded_whatever_the_model(model: str) -> None:
     audio = await _synthesize(_tts(handler, model=model))
 
     assert audio[: len(PCM)] == PCM
+
+
+async def test_declared_content_type_wins_over_requested_format() -> None:
+    """A server may ignore response_format; decode what it says it sent, not what we asked for."""
+    mp3 = pathlib.Path(__file__).parent.joinpath("long.mp3").read_bytes()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=mp3, headers={"content-type": "audio/mpeg"})
+
+    # response_format="wav" is requested, but the server answers with mp3
+    audio = await _synthesize(_tts(handler, model="kokoro", response_format="wav"))
+
+    assert audio
 
 
 async def test_sse_body_is_parsed() -> None:

--- a/tests/test_plugin_openai_tts.py
+++ b/tests/test_plugin_openai_tts.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import base64
+import io
 import json
-import pathlib
+import wave
 
 import httpx
 import openai
@@ -47,13 +48,19 @@ async def test_audio_body_is_decoded_whatever_the_model(model: str) -> None:
 
 async def test_declared_content_type_wins_over_requested_format() -> None:
     """A server may ignore response_format; decode what it says it sent, not what we asked for."""
-    mp3 = pathlib.Path(__file__).parent.joinpath("long.mp3").read_bytes()
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(24000)
+        w.writeframes(PCM)
+    wav = buf.getvalue()
 
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, content=mp3, headers={"content-type": "audio/mpeg"})
+        return httpx.Response(200, content=wav, headers={"content-type": "audio/wav"})
 
-    # response_format="wav" is requested, but the server answers with mp3
-    audio = await _synthesize(_tts(handler, model="kokoro", response_format="wav"))
+    # mp3 is requested, but the server answers with wav and says so
+    audio = await _synthesize(_tts(handler, model="kokoro", response_format="mp3"))
 
     assert audio
 


### PR DESCRIPTION
Pointing the OpenAI TTS plugin at an OpenAI-compatible endpoint produces no audio. The request succeeds, the provider bills it, and the turn fails with `no audio frames were pushed`. This has been reported twice on the forum without a root cause, most recently yesterday, so I dug into it.

### What happens

`synthesize()` picks the response parser from the model name:

```python
AUDIO_STREAM_MODELS = {"tts-1", "tts-1-hd"}

if self._opts.model in AUDIO_STREAM_MODELS:
    return AudioChunkedStream(...)
return SSEChunkedStream(...)
```

Anything outside those two names gets `SSEChunkedStream`, which sends `stream_format="sse"` and reads only lines beginning with `data: `. But `stream_format` is an OpenAI extension. A compatible server ignores the unknown field and replies with the audio bytes of `response_format`, so no line ever matches and `push()` is never called.

`pushed_duration()` is then 0, which raises `APIError("no audio frames were pushed")`. That error is retryable and `max_retry` defaults to 3, so the provider is called four times per utterance. Every call returns a valid 200 with real audio in the body, which is why this reads as a provider problem rather than a plugin one.

### The fix

Parse the body according to the response `Content-Type` instead of the model name. `text/event-stream` is read as SSE, anything else as raw audio bytes. Since both branches now share one request and one error path, the two near-identical stream classes collapse into a single `ChunkedStream`.

The request side is untouched: `tts-1`/`tts-1-hd` still ask for `stream_format="audio"`, everything else still asks for `"sse"`. Existing OpenAI users send byte-identical requests and take the same parsing path as before. The only behavioural difference is that a non-SSE response is now decoded rather than discarded.

@darryncampbell — on the forum I said I'd omit `stream_format` for unrecognised models. I dropped that idea while writing this. `gpt-4o-mini-tts-2025-12-15` isn't in either allowlist, and omitting the field would route it to the raw-audio branch, which is the only branch that doesn't call `_set_token_usage()`. Usage metrics would silently fall to zero for it and for every future model snapshot, with nothing to flag it. Content-Type alone fixes the reported bug and doesn't rot as the model catalogue grows. Happy to add the request-side change separately if you'd still like it.

`AudioChunkedStream` and `SSEChunkedStream` are gone rather than aliased. Neither was in `__all__` and nothing in the repo imports them.

### Reproducing

```python
from livekit.plugins.openai import TTS

tts = TTS(
    base_url="https://api.deepinfra.com/v1",
    api_key="<key>",
    model="hexgrad/Kokoro-82M",
    voice="af_bella",
)
```

Any compatible server does the same: DeepInfra, Kokoro-FastAPI, vLLM, LM Studio, Speaches. `curl` against the same endpoint returns valid audio.

### Tests

`tests/test_plugin_openai_tts.py` drives the public `TTS` API over `httpx.MockTransport`. Three of the six fail on `main` with the exact error from the reports. Serving the repo's own `tests/long.mp3` as `audio/mpeg` decodes to 46.6s of audio with this change and raises `no audio frames were pushed` without it.

### Prior reports

- https://community.livekit.io/t/openai-tts-plugin-returns-no-audio-frames-were-pushed-with-openai-compatible-endpoints-kokoro-deepinfra/1465 (June, auto-closed unanswered)
- https://community.livekit.io/t/livekit-openai-plugin-with-deepinfra-backend-api-returns-usage-logs-but-no-audio-output/1883
- https://community.livekit.io/t/openai-tts-sends-stream-format-sse-to-every-non-openai-backend-so-compatible-endpoints-return-audio-that-gets-thrown-away/1892
