### PR TITLE
fix(telemetry): only shut down OTel providers the framework created

### DIFF
--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -278,6 +278,50 @@ def set_tracer_provider(
     tracer.set_provider(tracer_provider)
 
 
+class _FrameworkTelemetry:
+    """Tracks the OTel objects ``_setup_cloud_tracer`` created, so ``_shutdown_telemetry``
+    only tears down what the framework owns.
+
+    ``_shutdown_telemetry`` runs once per job (``JobContext._on_cleanup``), but worker
+    processes are reused across jobs, and a provider configured by the integrator —
+    once at process start, e.g. the Langfuse setup in our tracing docs, or Logfire /
+    dd-trace — has process lifetime. Shutting that provider down ends *their* export
+    for every later job in the process.
+
+    Ownership therefore decides the teardown:
+      * providers the framework created are shut down in full, as before;
+      * for a provider the framework adopted, only the processors the framework added
+        to it are shut down. That still flushes LiveKit Cloud's batch exporter at job
+        end, while leaving the integrator's own pipeline running.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._providers: list[Any] = []
+        self._processors: list[Any] = []
+
+    def add_provider(self, provider: Any) -> None:
+        """Record a provider the framework constructed (shut down in full)."""
+        with self._lock:
+            self._providers.append(provider)
+
+    def add_processor(self, processor: Any) -> None:
+        """Record a processor the framework attached to a provider it does not own."""
+        with self._lock:
+            self._processors.append(processor)
+
+    def take(self) -> list[Any]:
+        """Return everything tracked and reset, so the next job starts from clean state."""
+        with self._lock:
+            targets = [*self._providers, *self._processors]
+            self._providers = []
+            self._processors = []
+            return targets
+
+
+_framework_telemetry = _FrameworkTelemetry()
+
+
 def _setup_cloud_tracer(
     *,
     room_id: str,
@@ -344,12 +388,15 @@ def _setup_cloud_tracer(
         # below shows how the ProxyTracerProvider is returned when none have been setup
         # https://github.com/open-telemetry/opentelemetry-python/blob/0018c0030bac9bdce4487fe5fcb3ec6a542ec904/opentelemetry-api/src/opentelemetry/trace/__init__.py#L555
         tracer_provider: trace_api.TracerProvider
+        owns_tracer_provider = False
         if isinstance(
             tracer._tracer_provider,
             (trace_api.ProxyTracerProvider, trace_api.NoOpTracerProvider),
         ):
             tracer_provider = trace_sdk.TracerProvider(resource=resource)
             set_tracer_provider(tracer_provider)
+            owns_tracer_provider = True
+            _framework_telemetry.add_provider(tracer_provider)
         else:
             # attach the processor to the existing tracer provider
             tracer_provider = tracer._tracer_provider
@@ -364,14 +411,21 @@ def _setup_cloud_tracer(
 
         if isinstance(tracer_provider, trace_sdk.TracerProvider):
             tracer_provider.add_span_processor(_MetadataSpanProcessor(session_metadata))
-            tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+            span_processor = BatchSpanProcessor(span_exporter)
+            tracer_provider.add_span_processor(span_processor)
+            if not owns_tracer_provider:
+                # the provider outlives the job; shut down just our exporter.
+                _framework_telemetry.add_processor(span_processor)
 
     # Always set up the logger provider — it's needed for session reports,
     # evaluations, and chat history, not just Python log export.
     logger_provider = get_logger_provider()
+    owns_logger_provider = False
     if not isinstance(logger_provider, LoggerProvider):
         logger_provider = LoggerProvider()
         set_logger_provider(logger_provider)
+        owns_logger_provider = True
+        _framework_telemetry.add_provider(logger_provider)
 
     if enable_logs:
         log_exporter = OTLPLogExporter(
@@ -380,7 +434,11 @@ def _setup_cloud_tracer(
             session=session,
         )
         logger_provider.add_log_record_processor(_MetadataLogProcessor(session_metadata))
-        logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
+        log_processor = BatchLogRecordProcessor(log_exporter)
+        logger_provider.add_log_record_processor(log_processor)
+        if not owns_logger_provider:
+            # the provider outlives the job; shut down just our exporter.
+            _framework_telemetry.add_processor(log_processor)
 
         handler = _TraceLevelLoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
 
@@ -406,6 +464,7 @@ def _setup_cloud_tracer(
         reader = PeriodicExportingMetricReader(metric_exporter, export_interval_millis=30000)
         meter_provider = SdkMeterProvider(resource=resource, metric_readers=[reader])
         metrics_api.set_meter_provider(meter_provider)
+        _framework_telemetry.add_provider(meter_provider)
 
 
 def _chat_ctx_to_otel_events(chat_ctx: ChatContext) -> list[tuple[str, Attributes]]:
@@ -731,39 +790,39 @@ def _shutdown_telemetry(timeout: float = _TELEMETRY_SHUTDOWN_TIMEOUT) -> None:
     Any unfinished work stays on existing daemon threads and is discarded at
     process exit.
 
+    Only what ``_setup_cloud_tracer`` created is torn down — see
+    ``_FrameworkTelemetry``. A provider supplied by the integrator is left
+    running, because this function is called per job on a worker process that is
+    reused across jobs.
+
     Upstream context:
     - https://github.com/open-telemetry/opentelemetry-python/issues/4623
       (TracerProvider.shutdown() has no configurable timeout — still open)
     """
-    # Detach the OTLP LoggingHandler from the root logger — belt to the
-    # suspenders of the parallel shutdown below.
+    # Detach our OTLP LoggingHandler from the root logger — belt to the
+    # suspenders of the parallel shutdown below. Matched on the framework's own
+    # subclass: the integrator may have their own OTel LoggingHandler installed.
     root = logging.getLogger()
     for h in list(root.handlers):
-        if isinstance(h, LoggingHandler):
+        if isinstance(h, _TraceLevelLoggingHandler):
             root.removeHandler(h)
 
-    providers: list[Any] = []
-    if isinstance(lp := get_logger_provider(), LoggerProvider):
-        providers.append(lp)
-    if isinstance(tp := tracer._tracer_provider, trace_sdk.TracerProvider):
-        providers.append(tp)
-    if isinstance(mp := metrics_api.get_meter_provider(), SdkMeterProvider):
-        providers.append(mp)
+    targets = _framework_telemetry.take()
 
-    def _shutdown_one(provider: Any) -> None:
+    def _shutdown_one(target: Any) -> None:
         try:
-            provider.shutdown()
+            target.shutdown()
         except Exception:
             logger.exception("failed to shut down telemetry provider")
 
     threads = [
         threading.Thread(
             target=_shutdown_one,
-            args=(p,),
-            name=f"livekit-telemetry-shutdown-{type(p).__name__}",
+            args=(t,),
+            name=f"livekit-telemetry-shutdown-{type(t).__name__}",
             daemon=True,
         )
-        for p in providers
+        for t in targets
     ]
     for t in threads:
         t.start()

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import inspect
+import logging
 from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
@@ -682,6 +683,198 @@ def test_setup_cloud_tracer_omits_empty_deployment() -> None:
     )
     assert attrs["lk.cloud_agent_id"] == "CA_test123"
     assert "lk.deployment_id" not in attrs
+
+
+@contextlib.contextmanager
+def _restore_telemetry_state() -> Iterator[None]:
+    """_DynamicTracer and the ownership registry are process-wide; restore them.
+
+    _shutdown_telemetry() runs per job, so these tests deliberately touch state
+    that outlives a single job.
+    """
+    from livekit.agents.telemetry import traces as traces_mod
+
+    previous = traces_mod.tracer._tracer_provider
+    try:
+        yield
+    finally:
+        traces_mod.tracer.set_provider(previous)
+        traces_mod._framework_telemetry.take()
+        # a test that fails before _shutdown_telemetry() would leave the
+        # framework's OTLP handler attached to the root logger
+        root = logging.getLogger()
+        for handler in list(root.handlers):
+            if isinstance(handler, traces_mod._TraceLevelLoggingHandler):
+                root.removeHandler(handler)
+
+
+@contextlib.contextmanager
+def _stub_cloud_tracer_deps() -> Iterator[MagicMock]:
+    """Stub auth and the OTLP exporters. Yields the BatchSpanProcessor mock."""
+    with (
+        patch(f"{_TRACES_MOD}.api.AccessToken") as mock_at,
+        patch(f"{_TRACES_MOD}.OTLPSpanExporter"),
+        patch(f"{_TRACES_MOD}.OTLPLogExporter"),
+        patch(f"{_TRACES_MOD}.BatchSpanProcessor") as mock_bsp,
+        patch(f"{_TRACES_MOD}.BatchLogRecordProcessor"),
+    ):
+        mock_token = MagicMock()
+        mock_token.with_observability_grants.return_value = mock_token
+        mock_token.with_ttl.return_value = mock_token
+        mock_token.to_jwt.return_value = "test-jwt"
+        mock_at.return_value = mock_token
+        yield mock_bsp
+
+
+def test_shutdown_telemetry_keeps_integrator_providers_alive() -> None:
+    """Providers supplied by the integrator survive per-job teardown.
+
+    Worker processes are reused across jobs, so shutting down a provider that
+    was configured once at process start (Langfuse per the tracing docs, or
+    Logfire / dd-trace) would kill their export for every later job.
+    """
+    from opentelemetry.sdk._logs import LoggerProvider
+    from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+    from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+
+    from livekit.agents.telemetry.traces import (
+        _setup_cloud_tracer,
+        _shutdown_telemetry,
+        set_tracer_provider,
+    )
+
+    integrator_tracer = MagicMock(spec=SdkTracerProvider)
+    integrator_logger = MagicMock(spec=LoggerProvider)
+    integrator_meter = MagicMock(spec=SdkMeterProvider)
+
+    with _restore_telemetry_state():
+        set_tracer_provider(integrator_tracer)
+
+        with (
+            _stub_cloud_tracer_deps() as mock_bsp,
+            patch(f"{_TRACES_MOD}.get_logger_provider", return_value=integrator_logger),
+            patch(f"{_TRACES_MOD}.metrics_api.get_meter_provider", return_value=integrator_meter),
+        ):
+            _setup_cloud_tracer(
+                room_id="room-1",
+                job_id="job-1",
+                **_observability_endpoint_arg(_setup_cloud_tracer),
+                enable_traces=True,
+                enable_logs=True,
+            )
+
+            # sanity: the framework adopted the integrator's provider rather than
+            # replacing it, so this test is exercising the borrowed path.
+            from livekit.agents.telemetry import traces as traces_mod
+
+            assert traces_mod.tracer._tracer_provider is integrator_tracer
+
+            _shutdown_telemetry()
+
+    integrator_tracer.shutdown.assert_not_called()
+    integrator_logger.shutdown.assert_not_called()
+    integrator_meter.shutdown.assert_not_called()
+    # our own exporter is still torn down, so Cloud spans are flushed at job end
+    mock_bsp.return_value.shutdown.assert_called_once()
+
+
+def test_shutdown_telemetry_shuts_down_framework_created_provider() -> None:
+    """A provider the framework created itself is still shut down in full."""
+    from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+    from opentelemetry.trace import NoOpTracerProvider
+
+    from livekit.agents.telemetry import traces as traces_mod
+    from livekit.agents.telemetry.traces import (
+        _setup_cloud_tracer,
+        _shutdown_telemetry,
+        set_tracer_provider,
+    )
+
+    with _restore_telemetry_state():
+        # no integrator provider configured: the framework builds its own
+        set_tracer_provider(NoOpTracerProvider())
+
+        with (
+            _stub_cloud_tracer_deps(),
+            patch(f"{_TRACES_MOD}.get_logger_provider", return_value=MagicMock()),
+            patch(f"{_TRACES_MOD}.set_logger_provider"),
+            patch(f"{_TRACES_MOD}.logging"),
+        ):
+            _setup_cloud_tracer(
+                room_id="room-1",
+                job_id="job-1",
+                **_observability_endpoint_arg(_setup_cloud_tracer),
+                enable_traces=True,
+                enable_logs=False,
+            )
+
+            created = traces_mod.tracer._tracer_provider
+            assert isinstance(created, SdkTracerProvider)
+
+            with patch.object(created, "shutdown") as mock_shutdown:
+                _shutdown_telemetry()
+
+    mock_shutdown.assert_called_once()
+
+
+def test_shutdown_telemetry_is_idempotent_across_jobs() -> None:
+    """A second teardown without a second setup is a no-op.
+
+    The registry is emptied by the first _shutdown_telemetry(), so a provider is
+    never shut down twice.
+    """
+    from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+    from opentelemetry.trace import NoOpTracerProvider
+
+    from livekit.agents.telemetry import traces as traces_mod
+    from livekit.agents.telemetry.traces import (
+        _setup_cloud_tracer,
+        _shutdown_telemetry,
+        set_tracer_provider,
+    )
+
+    with _restore_telemetry_state():
+        set_tracer_provider(NoOpTracerProvider())
+
+        with (
+            _stub_cloud_tracer_deps(),
+            patch(f"{_TRACES_MOD}.get_logger_provider", return_value=MagicMock()),
+            patch(f"{_TRACES_MOD}.set_logger_provider"),
+            patch(f"{_TRACES_MOD}.logging"),
+        ):
+            _setup_cloud_tracer(
+                room_id="room-1",
+                job_id="job-1",
+                **_observability_endpoint_arg(_setup_cloud_tracer),
+                enable_traces=True,
+                enable_logs=False,
+            )
+
+            created = traces_mod.tracer._tracer_provider
+            assert isinstance(created, SdkTracerProvider)
+
+            with patch.object(created, "shutdown") as mock_shutdown:
+                _shutdown_telemetry()
+                _shutdown_telemetry()
+
+    mock_shutdown.assert_called_once()
+
+
+def test_shutdown_telemetry_leaves_foreign_log_handlers_attached() -> None:
+    """Only the framework's own OTel LoggingHandler is detached from root."""
+    from opentelemetry.sdk._logs import LoggingHandler
+
+    from livekit.agents.telemetry.traces import _shutdown_telemetry
+
+    foreign_handler = LoggingHandler(logger_provider=MagicMock())
+    root = logging.getLogger()
+    root.addHandler(foreign_handler)
+    try:
+        with _restore_telemetry_state():
+            _shutdown_telemetry()
+        assert foreign_handler in root.handlers
+    finally:
+        root.removeHandler(foreign_handler)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Problem

`_shutdown_telemetry()` runs once per job from `JobContext._on_cleanup`, but it shut down whichever tracer / logger / meter provider it found on the OTel globals — including a provider supplied by the integrator.

Worker processes are reused across jobs, and an integrator's provider is configured once at process start, so from the second job onward their exporters were already dead.

This is reachable from the setup in [the tracing docs](https://docs.livekit.io/deploy/observability/tracing/): the Langfuse example passes a plain `opentelemetry.sdk.trace.TracerProvider` to `set_tracer_provider`, `_setup_cloud_tracer` adopts it, and `_shutdown_telemetry` then calls `shutdown()` on it at the end of every job. It also affects providers that wrap at the OTel *API* level, such as Logfire and dd-trace.

### Change

`_setup_cloud_tracer` now records what it creates (`_FrameworkTelemetry`), and teardown follows ownership:

- providers the framework created are shut down in full, as before;
- for an adopted provider, only the processors the framework attached to it are shut down. LiveKit Cloud's batch exporter is still flushed at job end, while the integrator's pipeline keeps running.

The registry is emptied on teardown, so a provider is never shut down twice across jobs.

Root-logger cleanup is narrowed to the framework's own `_TraceLevelLoggingHandler` for the same reason — the previous `LoggingHandler` match would detach an integrator's OTel handler too. Happy to split that into its own commit if you'd rather keep this focused.

### Tests

Four tests in `tests/test_recording.py`. Each was checked by mutation — reverting the corresponding part of the fix makes it fail:

| Test | Fails without the fix because |
|---|---|
| `keeps_integrator_providers_alive` | integrator's tracer provider `shutdown()` called once |
| `shuts_down_framework_created_provider` | (guard against over-correcting; passes either way) |
| `is_idempotent_across_jobs` | provider `shutdown()` called twice across two teardowns |
| `leaves_foreign_log_handlers_attached` | a foreign OTel `LoggingHandler` is detached from root |

`ruff check` / `ruff format --check` clean; `scripts/check_types.py` shows only a pre-existing `boto3` stub error in the AWS plugin. `tests/test_recording.py` and `tests/test_telemetry_recording_disabled.py`: 53 passed.

### Not addressed here

Two adjacent things I left alone, happy to open issues if useful:

1. **Processor accumulation.** Each `_setup_cloud_tracer` adds a fresh `_MetadataSpanProcessor` / `BatchSpanProcessor` pair to an adopted provider, and the previous job's (now shut down) processors stay attached. Inert, but grows with jobs per process.
2. **Adopted provider after teardown.** A provider the framework created in job 1 is shut down at the end of it; in job 2 it is no longer `Proxy`/`NoOp`, so the `else` branch adopts the shut-down provider and spans are dropped. Pre-existing, and orthogonal to ownership — but it means the framework-created path may want to reset `tracer._tracer_provider` on teardown.
