### PR TITLE
fix(voice): agent and user state while a tool runs

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2766,8 +2766,12 @@ class AgentActivity(RecognitionHooks):
                 # stacking copies, and an expressive-off turn removes it again
                 update_expressive_instructions(chat_ctx, text=text)
 
+    @property
+    def _no_pending_speech(self) -> bool:
+        return not self._speech_q and (not self._current_speech or self._current_speech.done())
+
     def _on_pipeline_reply_done(self, _: asyncio.Task[None]) -> None:
-        if not self._speech_q and (not self._current_speech or self._current_speech.done()):
+        if self._no_pending_speech:
             # a speech awaiting its tool executions keeps the agent busy: stay in
             # "thinking" so the user-away timer isn't armed mid-tool (#6904)
             self._session._update_agent_state(
@@ -3503,7 +3507,7 @@ class AgentActivity(RecognitionHooks):
             speech_handle._item_added([msg])
             current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, forwarded_text)
 
-        if not speech_handle.interrupted and (len(tool_output.output) > 0 or not exe_task.done()):
+        if not speech_handle.interrupted and len(tool_output.output) > 0:
             self._session._update_agent_state("thinking")
             if self._audio_recognition:
                 self._audio_recognition._on_end_of_agent_speech(
@@ -3512,7 +3516,9 @@ class AgentActivity(RecognitionHooks):
             if self.interruption_enabled:
                 self._restore_interruption_by_audio_activity()
         elif self._session.agent_state == "speaking":
-            self._session._update_agent_state("listening")
+            # a running tool keeps the agent busy; "listening" would arm the away timer
+            tool_running = not speech_handle.interrupted and not exe_task.done()
+            self._session._update_agent_state("thinking" if tool_running else "listening")
             if self._audio_recognition:
                 self._audio_recognition._on_end_of_agent_speech(
                     ignore_user_transcript_until=time.time()
@@ -4058,7 +4064,9 @@ class AgentActivity(RecognitionHooks):
         await process_msg_task
 
         if audio_output is not None:
-            self._session._update_agent_state("listening")
+            self._session._update_agent_state(
+                "thinking" if self._background_speeches else "listening"
+            )
             if self._audio_recognition:
                 self._audio_recognition._on_end_of_agent_speech(
                     ignore_user_transcript_until=time.time()
@@ -4214,6 +4222,7 @@ class AgentActivity(RecognitionHooks):
 
         # important: no agent output should be used after this point
 
+        tool_reply_expected = False
         if len(tool_output.output) > 0:
             speech_handle._num_steps += 1
 
@@ -4308,10 +4317,8 @@ class AgentActivity(RecognitionHooks):
                             self._pending_auto_tool_reply_fut = None
                         auto_reply_fut.set_result(None)
 
-            if (
-                fnc_executed_ev.has_tool_reply
-                and not self._rt_session.capabilities.auto_tool_reply_generation
-            ):
+            tool_reply_expected = fnc_executed_ev.has_tool_reply
+            if tool_reply_expected and not self._rt_session.capabilities.auto_tool_reply_generation:
                 self._rt_session.interrupt()
 
                 self._create_speech_task(
@@ -4332,6 +4339,12 @@ class AgentActivity(RecognitionHooks):
                 self._schedule_speech(
                     speech_handle, SpeechHandle.SPEECH_PRIORITY_NORMAL, force=True
                 )
+
+        # no reply follows, so nothing else clears the "thinking" the tool asserted
+        if not tool_reply_expected and self._no_pending_speech:
+            self._session._update_agent_state(
+                "thinking" if self._background_speeches else "listening"
+            )
 
     def _update_paused_speech(self, speech_handle: SpeechHandle, timeout: float) -> None:
         """Record that ``speech_handle`` is paused.

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2768,7 +2768,11 @@ class AgentActivity(RecognitionHooks):
 
     def _on_pipeline_reply_done(self, _: asyncio.Task[None]) -> None:
         if not self._speech_q and (not self._current_speech or self._current_speech.done()):
-            self._session._update_agent_state("listening")
+            # a speech awaiting its tool executions keeps the agent busy: stay in
+            # "thinking" so the user-away timer isn't armed mid-tool (#6904)
+            self._session._update_agent_state(
+                "thinking" if self._background_speeches else "listening"
+            )
             if self._audio_recognition:
                 self._audio_recognition._on_end_of_agent_speech(
                     ignore_user_transcript_until=time.time()
@@ -3001,7 +3005,9 @@ class AgentActivity(RecognitionHooks):
             self._session._conversation_item_added(msg)
 
         if self._session.agent_state == "speaking":
-            self._session._update_agent_state("listening")
+            self._session._update_agent_state(
+                "thinking" if self._background_speeches else "listening"
+            )
             if self._audio_recognition:
                 self._audio_recognition._on_end_of_agent_speech(
                     ignore_user_transcript_until=time.time()
@@ -3497,7 +3503,7 @@ class AgentActivity(RecognitionHooks):
             speech_handle._item_added([msg])
             current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, forwarded_text)
 
-        if not speech_handle.interrupted and len(tool_output.output) > 0:
+        if not speech_handle.interrupted and (len(tool_output.output) > 0 or not exe_task.done()):
             self._session._update_agent_state("thinking")
             if self._audio_recognition:
                 self._audio_recognition._on_end_of_agent_speech(

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -58,6 +58,8 @@ from .events import (
     CloseReason,
     ConversationItemAddedEvent,
     EventTypes,
+    ToolCallEnded,
+    ToolExecutionUpdatedEvent,
     UserInputTranscribedEvent,
     UserState,
     UserStateChangedEvent,
@@ -74,7 +76,7 @@ from .recorder_io import RecorderIO
 from .remote_session import RoomSessionTransport, SessionHost, SessionTransport
 from .run_result import RunOutputOptions, RunResult
 from .speech_handle import InputDetails, SpeechHandle
-from .tool_executor import ToolHandlingOptions, _resolve_async_tool_options
+from .tool_executor import ToolHandlingOptions, _resolve_async_tool_options, _RunningTasks
 from .turn import (
     EndpointingOptions,
     InterruptionOptions,
@@ -1875,6 +1877,10 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         if self._opts.user_away_timeout is None:
             return
 
+        if _RunningTasks.get(self):
+            # a tool in flight will speak when it lands; the window restarts then (#6883)
+            return
+
         if (
             (room_io := self._room_io)
             and room_io.subscribed_fut
@@ -2057,6 +2063,17 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
     def _tool_items_added(self, items: Sequence[llm.FunctionCall | llm.FunctionCallOutput]) -> None:
         self._chat_ctx.insert(items)
+
+    def _tool_execution_updated(self, ev: ToolExecutionUpdatedEvent) -> None:
+        if (
+            isinstance(ev.update, ToolCallEnded)
+            and self._user_state == "listening"
+            and self._agent_state == "listening"
+        ):
+            # tools hold the window off, so the last one to land restarts it (#6883)
+            self._set_user_away_timer()
+
+        self.emit("tool_execution_updated", ev)
 
     def _config_update_added(self, item: llm.AgentConfigUpdate) -> None:
         self._chat_ctx.insert(item)

--- a/livekit-agents/livekit/agents/voice/events.py
+++ b/livekit-agents/livekit/agents/voice/events.py
@@ -222,8 +222,7 @@ class RunContext(Generic[Userdata_T]):
         if self._executor is None:
             return  # standalone — no executor, so no tool lifecycle to report
 
-        self._session.emit(
-            "tool_execution_updated",
+        self._session._tool_execution_updated(
             ToolExecutionUpdatedEvent(
                 update=ToolCallUpdated(
                     id=pair[0].call_id,

--- a/livekit-agents/livekit/agents/voice/tool_executor.py
+++ b/livekit-agents/livekit/agents/voice/tool_executor.py
@@ -424,8 +424,7 @@ class _ToolExecutor:
         session = run_ctx.session
         _RunningTasks.setdefault(session, {})[call_id] = running_task
 
-        session.emit(
-            "tool_execution_updated",
+        session._tool_execution_updated(
             ToolExecutionUpdatedEvent(update=ToolCallStarted(function_call=run_ctx.function_call)),
         )
 
@@ -460,8 +459,7 @@ class _ToolExecutor:
                 status, message = "done", str(output)
 
             entry_id = call_id + "_final" if run_ctx._updates else call_id
-            session.emit(
-                "tool_execution_updated",
+            session._tool_execution_updated(
                 ToolExecutionUpdatedEvent(
                     update=ToolCallEnded(
                         id=entry_id, call_id=call_id, message=message, status=status
@@ -601,8 +599,7 @@ class _ToolExecutor:
             tool_choice="none",
             chat_ctx=chat_ctx,
         )
-        session.emit(
-            "tool_execution_updated",
+        session._tool_execution_updated(
             ToolExecutionUpdatedEvent(
                 update=ToolReplyUpdated(
                     update_ids=call_ids, status="scheduled", speech_id=speech.id
@@ -639,8 +636,7 @@ class _ToolExecutor:
                 )
                 # TODO(long): reschedule interrupted replies?
 
-            session.emit(
-                "tool_execution_updated",
+            session._tool_execution_updated(
                 ToolExecutionUpdatedEvent(
                     update=ToolReplyUpdated(
                         update_ids=call_ids, status=reply_status, speech_id=speech.id

--- a/tests/fake_realtime.py
+++ b/tests/fake_realtime.py
@@ -60,6 +60,7 @@ class FakeRealtimeSession(RealtimeSession):
         self.say_calls: list[str | AsyncIterable[str]] = []
         self.user_activity_started = False
         self._reply_futs: list[asyncio.Future[GenerationCreatedEvent]] = []
+        self.say_futs: list[asyncio.Future[GenerationCreatedEvent]] = []
         # test hooks to pause or fail aclose() mid-swap
         self.aclose_entered = asyncio.Event()
         self.block_aclose: asyncio.Event | None = None
@@ -131,7 +132,9 @@ class FakeRealtimeSession(RealtimeSession):
 
     def say(self, text: str | AsyncIterable[str]) -> asyncio.Future[GenerationCreatedEvent]:
         self.say_calls.append(text)
-        return asyncio.get_event_loop().create_future()
+        fut: asyncio.Future[GenerationCreatedEvent] = asyncio.get_event_loop().create_future()
+        self.say_futs.append(fut)
+        return fut
 
     async def aclose(self) -> None:
         self.aclose_entered.set()

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -48,6 +48,7 @@ from livekit.agents.voice.audio_recognition import AudioRecognition, _EndOfTurnI
 from livekit.agents.voice.endpointing import BaseEndpointing
 from livekit.agents.voice.events import FunctionToolsExecutedEvent
 from livekit.agents.voice.io import PlaybackFinishedEvent
+from livekit.agents.voice.tool_executor import UPDATE_TEMPLATE
 
 from .fake_session import FakeActions, create_session, run_session
 
@@ -435,6 +436,136 @@ async def test_slow_tool_keeps_agent_thinking_after_filler() -> None:
     speaking_ends = [ev.new_state for ev in agent_state_events if ev.old_state == "speaking"]
     assert speaking_ends == ["thinking", "thinking", "listening"]
     assert all(ev.new_state != "away" for ev in user_state_events)
+
+
+async def test_tool_without_a_reply_returns_the_agent_to_listening() -> None:
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Look up my order")
+    actions.add_llm(
+        content="Let me check.",
+        tool_calls=[FunctionToolCall(name="silent_lookup", arguments="{}", call_id="1")],
+    )
+    actions.add_tts(2.0)
+
+    class SilentToolAgent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="You are a helpful assistant.")
+
+        @function_tool
+        async def silent_lookup(self, context: RunContext) -> None:
+            """A slow tool that returns nothing, so no reply follows it."""
+            await asyncio.sleep(8.0)
+
+    session = create_session(actions, extra_kwargs={"user_away_timeout": 3.0})
+
+    agent_state_events: list[AgentStateChangedEvent] = []
+    session.on("agent_state_changed", agent_state_events.append)
+
+    await asyncio.wait_for(
+        run_session(session, SilentToolAgent(), drain_delay=20), timeout=SESSION_TIMEOUT
+    )
+
+    # the tool holds the agent in "thinking", and nothing follows it to hand the turn back
+    transitions = [(ev.old_state, ev.new_state) for ev in agent_state_events]
+    assert transitions[-2:] == [("speaking", "thinking"), ("thinking", "listening")]
+
+
+async def test_async_tool_defers_user_away_until_its_reply_lands() -> None:
+    """A background tool speaks for itself, so "away" must wait for that reply (#6883)."""
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Look up my order")
+    actions.add_llm(
+        content="Let me check.",
+        tool_calls=[FunctionToolCall(name="async_lookup", arguments="{}", call_id="1")],
+    )
+    actions.add_tts(2.0)
+    actions.add_llm(
+        content="I'm looking it up.",
+        input=UPDATE_TEMPLATE.format(
+            function_name="async_lookup", call_id="1", message="looking it up"
+        ),
+    )
+    actions.add_tts(1.0)
+
+    tool_returned_at = 0.0
+
+    class AsyncToolAgent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="You are a helpful assistant.")
+
+        @function_tool
+        async def async_lookup(self, context: RunContext) -> str:
+            """Look an order up in the background."""
+            nonlocal tool_returned_at
+            await context.update("looking it up")
+            await asyncio.sleep(20.0)
+            tool_returned_at = time.time()
+            return "order 42 shipped"
+
+    session = create_session(actions, extra_kwargs={"user_away_timeout": 3.0})
+
+    away_times: list[float] = []
+    session.on(
+        "user_state_changed",
+        lambda ev: away_times.append(time.time()) if ev.new_state == "away" else None,
+    )
+
+    await asyncio.wait_for(
+        run_session(session, AsyncToolAgent(), drain_delay=40), timeout=SESSION_TIMEOUT
+    )
+
+    # the agent is genuinely listening while the tool runs, so nothing but the tool holds
+    # the window off; landing restarts it in full rather than firing on what was left
+    assert len(away_times) == 1
+    assert away_times[0] >= tool_returned_at + 3.0
+
+
+async def test_async_tool_without_a_reply_still_restarts_the_away_window() -> None:
+    """A tool returning ``None`` after an update files no reply, so nothing else can
+    restart the window it held off."""
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Look up my order")
+    actions.add_llm(
+        content="Let me check.",
+        tool_calls=[FunctionToolCall(name="async_lookup", arguments="{}", call_id="1")],
+    )
+    actions.add_tts(2.0)
+    actions.add_llm(
+        content="I'm looking it up.",
+        input=UPDATE_TEMPLATE.format(
+            function_name="async_lookup", call_id="1", message="looking it up"
+        ),
+    )
+    actions.add_tts(1.0)
+
+    tool_returned_at = 0.0
+
+    class AsyncToolAgent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="You are a helpful assistant.")
+
+        @function_tool
+        async def async_lookup(self, context: RunContext) -> None:
+            """Look an order up in the background and say nothing more."""
+            nonlocal tool_returned_at
+            await context.update("looking it up")
+            await asyncio.sleep(20.0)
+            tool_returned_at = time.time()
+
+    session = create_session(actions, extra_kwargs={"user_away_timeout": 3.0})
+
+    away_times: list[float] = []
+    session.on(
+        "user_state_changed",
+        lambda ev: away_times.append(time.time()) if ev.new_state == "away" else None,
+    )
+
+    await asyncio.wait_for(
+        run_session(session, AsyncToolAgent(), drain_delay=40), timeout=SESSION_TIMEOUT
+    )
+
+    assert len(away_times) == 1
+    assert away_times[0] >= tool_returned_at + 3.0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -23,6 +23,7 @@ from livekit.agents import (
     MetricsCollectedEvent,
     ModelSettings,
     NotGivenOr,
+    RunContext,
     TurnHandlingOptions,
     UserInputTranscribedEvent,
     UserStateChangedEvent,
@@ -394,6 +395,46 @@ async def test_tool_call() -> None:
     assert chat_ctx_items[6].type == "message"
     assert chat_ctx_items[6].role == "assistant"
     assert chat_ctx_items[6].text_content == "The weather in Tokyo is sunny today."
+
+
+async def test_slow_tool_keeps_agent_thinking_after_filler() -> None:
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Look up my order")
+    actions.add_llm(
+        content="Let me check.",
+        tool_calls=[FunctionToolCall(name="lookup_order", arguments="{}", call_id="1")],
+    )
+    actions.add_tts(2.0)
+    actions.add_tts(1.0, input="Just a moment.")
+    actions.add_llm(content="Order 42 is on the way.", input="order 42 shipped")
+    actions.add_tts(1.0)
+
+    class SlowToolAgent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="You are a helpful assistant.")
+
+        @function_tool
+        async def lookup_order(self, context: RunContext) -> str:
+            async with context.with_filler("Just a moment.", delay=0.5):
+                await asyncio.sleep(8.0)
+            return "order 42 shipped"
+
+    session = create_session(actions, extra_kwargs={"user_away_timeout": 3.0})
+
+    agent_state_events: list[AgentStateChangedEvent] = []
+    user_state_events: list[UserStateChangedEvent] = []
+    session.on("agent_state_changed", agent_state_events.append)
+    session.on("user_state_changed", user_state_events.append)
+
+    await asyncio.wait_for(
+        run_session(session, SlowToolAgent(), drain_delay=10), timeout=SESSION_TIMEOUT
+    )
+
+    # both the reply and the filler end while the tool is still running, so each
+    # must hand back "thinking", not "listening" (which arms the user-away timer)
+    speaking_ends = [ev.new_state for ev in agent_state_events if ev.old_state == "speaking"]
+    assert speaking_ends == ["thinking", "thinking", "listening"]
+    assert all(ev.new_state != "away" for ev in user_state_events)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_realtime_agent_state_during_tool.py
+++ b/tests/test_realtime_agent_state_during_tool.py
@@ -1,0 +1,237 @@
+"""Agent state around a realtime tool call.
+
+A generation that ends while a tool is still running must stay "thinking":
+`ctx.with_filler()` speaks through `session.say()`, and a realtime model that advertises
+`supports_say` serves that from `_realtime_generation_task` instead of the TTS path, where
+the reset to "listening" armed the user-away timer mid-tool (#6904).
+
+The turn also has to hand the state back once the tool ends, which the realtime path never
+did for a tool that asks for no reply.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+
+import pytest
+
+from livekit import rtc
+from livekit.agents import Agent, AgentSession, function_tool, utils
+from livekit.agents.llm import FunctionCall, GenerationCreatedEvent, MessageGeneration
+
+from .fake_io import FakeAudioOutput
+from .fake_realtime import FakeRealtimeModel, fake_capabilities
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+_SAMPLE_RATE = 24000
+
+
+def _generation(
+    *,
+    response_id: str,
+    text: str,
+    audio_duration: float,
+    function_calls: Sequence[FunctionCall] = (),
+) -> GenerationCreatedEvent:
+    """A single-message generation carrying `audio_duration` seconds of silence."""
+    message_ch = utils.aio.Chan[MessageGeneration]()
+    function_ch = utils.aio.Chan[FunctionCall]()
+    text_ch = utils.aio.Chan[str]()
+    audio_ch = utils.aio.Chan[rtc.AudioFrame]()
+    modalities = asyncio.Future[list[str]]()
+    modalities.set_result(["audio", "text"])
+
+    message_ch.send_nowait(
+        MessageGeneration(
+            message_id=f"{response_id}-message",
+            text_stream=text_ch,
+            audio_stream=audio_ch,
+            modalities=modalities,
+        )
+    )
+    message_ch.close()
+    text_ch.send_nowait(text)
+    text_ch.close()
+    samples = int(_SAMPLE_RATE * audio_duration)
+    audio_ch.send_nowait(
+        rtc.AudioFrame(
+            data=b"\x00\x01" * samples,
+            sample_rate=_SAMPLE_RATE,
+            num_channels=1,
+            samples_per_channel=samples,
+        )
+    )
+    audio_ch.close()
+    for fnc_call in function_calls:
+        function_ch.send_nowait(fnc_call)
+    function_ch.close()
+
+    return GenerationCreatedEvent(
+        message_stream=message_ch,
+        function_stream=function_ch,
+        user_initiated=True,
+        response_id=response_id,
+    )
+
+
+async def _wait_for_agent_state(session: AgentSession, state: str) -> None:
+    for _ in range(500):
+        if session.agent_state == state:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"agent_state stuck at {session.agent_state!r}, expected {state!r}")
+
+
+async def test_realtime_say_during_tool_keeps_agent_thinking() -> None:
+    model = FakeRealtimeModel(capabilities=fake_capabilities())
+    tool_started = asyncio.Event()
+    release_tool = asyncio.Event()
+
+    class SlowToolAgent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="You are a helpful assistant.")
+
+        @function_tool
+        async def lookup_order(self) -> str:
+            """Look up an order, slowly."""
+            tool_started.set()
+            await release_tool.wait()
+            return "order 42 shipped"
+
+    async with AgentSession(llm=model, user_away_timeout=2.0) as session:
+        session.output.audio = FakeAudioOutput()
+        await session.start(SlowToolAgent())
+
+        user_states: list[str] = []
+        session.on("user_state_changed", lambda ev: user_states.append(ev.new_state))
+
+        reply = session.generate_reply()
+        for _ in range(500):
+            if model.active_session._reply_futs:
+                break
+            await asyncio.sleep(0)
+        model.active_session._reply_futs[0].set_result(
+            _generation(
+                response_id="reply",
+                text="let me check",
+                audio_duration=1.0,
+                function_calls=[FunctionCall(call_id="1", name="lookup_order", arguments="{}")],
+            )
+        )
+        await asyncio.wait_for(tool_started.wait(), timeout=5)
+
+        try:
+            # the reply plays out while the tool runs; only the tool keeps the turn open after
+            await _wait_for_agent_state(session, "thinking")
+
+            filler = session.say("just a moment")
+            for _ in range(500):
+                if model.active_session.say_futs:
+                    break
+                await asyncio.sleep(0)
+            model.active_session.say_futs[0].set_result(
+                _generation(response_id="filler", text="just a moment", audio_duration=0.5)
+            )
+            await asyncio.wait_for(filler.wait_for_playout(), timeout=5)
+
+            # the filler ended, the tool did not: "listening" here would arm the away timer
+            assert session.agent_state == "thinking"
+
+            await asyncio.sleep(4.0)  # longer than user_away_timeout
+            assert session.agent_state == "thinking"
+            assert "away" not in user_states
+        finally:
+            # a held tool would otherwise block the session teardown on any failure
+            release_tool.set()
+
+        await asyncio.wait_for(reply.wait_for_playout(), timeout=10)
+
+
+async def test_realtime_tool_without_a_reply_returns_the_agent_to_listening() -> None:
+    model = FakeRealtimeModel(capabilities=fake_capabilities())
+    tool_started = asyncio.Event()
+    release_tool = asyncio.Event()
+
+    class SilentToolAgent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="You are a helpful assistant.")
+
+        @function_tool
+        async def silent_lookup(self) -> None:
+            """Look something up and return nothing, so no reply follows."""
+            tool_started.set()
+            await release_tool.wait()
+
+    async with AgentSession(llm=model, user_away_timeout=2.0) as session:
+        session.output.audio = FakeAudioOutput()
+        await session.start(SilentToolAgent())
+
+        reply = session.generate_reply()
+        for _ in range(500):
+            if model.active_session._reply_futs:
+                break
+            await asyncio.sleep(0)
+        model.active_session._reply_futs[0].set_result(
+            _generation(
+                response_id="reply",
+                text="let me check",
+                audio_duration=1.0,
+                function_calls=[FunctionCall(call_id="1", name="silent_lookup", arguments="{}")],
+            )
+        )
+        await asyncio.wait_for(tool_started.wait(), timeout=5)
+        await _wait_for_agent_state(session, "thinking")
+
+        release_tool.set()
+        await asyncio.wait_for(reply.wait_for_playout(), timeout=10)
+
+        # nothing speaks after the tool, so this turn is what has to hand the state back
+        await _wait_for_agent_state(session, "listening")
+
+
+async def test_realtime_tool_reply_from_the_server_keeps_the_agent_thinking() -> None:
+    """With ``auto_tool_reply_generation`` the reply is server-side, so no local task marks
+    the agent busy — the turn must hand back "thinking", not "listening"."""
+    model = FakeRealtimeModel(capabilities=fake_capabilities())
+    assert model.capabilities.auto_tool_reply_generation
+
+    class ToolAgent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="You are a helpful assistant.")
+
+        @function_tool
+        async def lookup_order(self) -> str:
+            """Look up an order, so a reply is required."""
+            await asyncio.sleep(1.0)
+            return "order 42 shipped"
+
+    async with AgentSession(llm=model, user_away_timeout=2.0) as session:
+        session.output.audio = FakeAudioOutput()
+        await session.start(ToolAgent())
+
+        user_states: list[str] = []
+        session.on("user_state_changed", lambda ev: user_states.append(ev.new_state))
+
+        reply = session.generate_reply()
+        for _ in range(500):
+            if model.active_session._reply_futs:
+                break
+            await asyncio.sleep(0)
+        model.active_session._reply_futs[0].set_result(
+            _generation(
+                response_id="reply",
+                text="let me check",
+                audio_duration=1.0,
+                function_calls=[FunctionCall(call_id="1", name="lookup_order", arguments="{}")],
+            )
+        )
+        await asyncio.wait_for(reply.wait_for_playout(), timeout=10)
+
+        # the server is still composing the reply; dropping to "listening" here would kill
+        # the client's busy indicator and arm the user-away timer over that reply
+        assert session.agent_state == "thinking"
+        await asyncio.sleep(4.0)  # longer than user_away_timeout
+        assert session.agent_state == "thinking"
+        assert "away" not in user_states

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1964,15 +1964,14 @@ class TestAgentSessionWaitForIdle:
 
 
 def _emitted_items(session: Any) -> list[Any]:
-    """Updates carried by tool_execution_updated events emitted on a mocked session."""
+    """Updates carried by tool_execution_updated events reported on a mocked session."""
     from livekit.agents.voice.events import ToolExecutionUpdatedEvent
 
     items = []
-    for call in session.emit.call_args_list:
-        name, ev = call.args
-        if name == "tool_execution_updated":
-            assert isinstance(ev, ToolExecutionUpdatedEvent)
-            items.append(ev.update)
+    for call in session._tool_execution_updated.call_args_list:
+        (ev,) = call.args
+        assert isinstance(ev, ToolExecutionUpdatedEvent)
+        items.append(ev.update)
     return items
 
 


### PR DESCRIPTION
**Problem**

A long tool call marks the user away, so the app asks "are you still there?" over the agent's own reply. The away timer arms whenever the agent and the user are both listening, and a tool call does not stop it. Filler speech ends in "listening" (livekit/agents#6904), and an async tool leaves the agent listening for its whole run (livekit/agents#6883). After the user is away, nothing restarts the window, so no further `user_state_changed` event fires in that session.

**Fix**

The away timer no longer arms while a tool runs, and the last tool to land restarts the window in full. The user never enters "away" during a tool call, so the state cannot stick there and livekit/agents#6883 needs no new API. Agent state separates the two cases: a blocking tool holds "thinking", and an async tool stays "listening" because the user can still speak. The realtime path also gains the state resets the pipeline already had, so a tool that asks for no reply hands the state back.

Based on livekit/agents#6908 by @VihaanAgarwal, with the review comments folded in.

close #6904 and close #6883 