### PR TITLE
fix: avoid duplicate agent speech end

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2211,8 +2211,8 @@ class AgentActivity(RecognitionHooks):
         self._interrupt_by_audio_activity(
             ignore_user_transcript_until=ev.overlap_started_at or ev.detected_at
         )
-        # flush held transcripts again if possible
-        if self._audio_recognition:
+        # flush held transcripts if the pause path did not already end agent speech
+        if self._audio_recognition and self._paused_speech is None:
             self._audio_recognition._on_end_of_agent_speech(
                 ignore_user_transcript_until=ev.overlap_started_at or ev.detected_at
             )

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -316,6 +316,30 @@ async def test_interrupting_paused_speech_does_not_end_agent_twice(
     activity._audio_recognition._on_end_of_agent_speech.assert_not_called()
 
 
+async def test_interruption_event_does_not_end_agent_again_after_pausing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = _session()
+    session.options.interruption["resume_false_interruption"] = True
+    session.options.interruption["false_interruption_timeout"] = FALSE_INTERRUPTION_TIMEOUT
+    activity, handle = _paused_activity(session)
+    handle._generations = []
+    activity._paused_speech = None
+    activity._audio_recognition = MagicMock()
+    event = MagicMock(overlap_started_at=1.0, detected_at=2.0)
+
+    activity.on_interruption(event)
+    assert activity._paused_speech is not None
+    await session.aclose()
+
+    activity._audio_recognition._on_end_of_agent_speech.assert_called_once_with(
+        ignore_user_transcript_until=1.0
+    )
+
+
 async def test_handing_over_a_paused_speech_does_not_end_the_agent_turn(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
**Why:** Pausing agent playout already ends active agent speech. A confirmed adaptive interruption then ended it again and sent a redundant detector reset.

**Behavior:** Skip the event-level speech-end call when the pause path already handled it. Non-pause interruptions keep the existing transcript flush.

Addresses AGT-3351

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> the interruption path sends on agent speech end twice after the pause and on interruption event. We should guard the interruption event with a paused speech check before sending. And just to be sure, double end does not impact really, right?
>
> create a PR please

</details>