### PR TITLE
fix: restore endpointing overlap when agent speech resumes

### DIFF
--- a/livekit-agents/livekit/agents/voice/endpointing.py
+++ b/livekit-agents/livekit/agents/voice/endpointing.py
@@ -128,6 +128,21 @@ class DynamicEndpointing(BaseEndpointing):
         )
 
     def on_start_of_agent_speech(self, started_at: float) -> None:
+        # VAD interrupt by audio activity is triggered before end of speech is detected
+        # adjust the utterance ended time to be just before the agent speech started
+        if (
+            self._agent_speech_started_at is None
+            and self._speaking
+            and self._utterance_started_at is not None
+            and self._utterance_ended_at is not None
+            and self._utterance_ended_at < self._utterance_started_at
+        ):
+            self._utterance_ended_at = started_at - 1e-3
+            logger.trace(
+                "utterance ended at adjusted: %s",
+                self._utterance_ended_at,
+            )
+
         self._agent_speech_started_at = started_at
         self._agent_speech_ended_at = None
         self._overlapping = self._speaking
@@ -147,21 +162,6 @@ class DynamicEndpointing(BaseEndpointing):
         if self._overlapping:
             # duplicate calls from _interrupt_by_audio_activity and on_start_of_speech
             return
-
-        # VAD interrupt by audio activity is triggered before end of speech is detected
-        # adjust the utterance ended time to be just before the agent speech started
-        if (
-            self._utterance_started_at is not None
-            and self._utterance_ended_at is not None
-            and self._agent_speech_started_at is not None
-            and self._utterance_ended_at < self._utterance_started_at
-            and overlapping
-        ):
-            self._utterance_ended_at = self._agent_speech_started_at - 1e-3
-            logger.trace(
-                "utterance ended at adjusted: %s",
-                self._utterance_ended_at,
-            )
 
         self._utterance_started_at = started_at
         self._overlapping = overlapping

--- a/livekit-agents/livekit/agents/voice/endpointing.py
+++ b/livekit-agents/livekit/agents/voice/endpointing.py
@@ -130,7 +130,7 @@ class DynamicEndpointing(BaseEndpointing):
     def on_start_of_agent_speech(self, started_at: float) -> None:
         self._agent_speech_started_at = started_at
         self._agent_speech_ended_at = None
-        self._overlapping = False
+        self._overlapping = self._speaking
 
     def on_end_of_agent_speech(self, ended_at: float) -> None:
         # Keep the agent speech timestamps until the next user utterance ends so

--- a/livekit-agents/livekit/agents/voice/endpointing.py
+++ b/livekit-agents/livekit/agents/voice/endpointing.py
@@ -128,8 +128,9 @@ class DynamicEndpointing(BaseEndpointing):
         )
 
     def on_start_of_agent_speech(self, started_at: float) -> None:
-        # VAD interrupt by audio activity is triggered before end of speech is detected
-        # adjust the utterance ended time to be just before the agent speech started
+        # Agent speech started before the current user utterance ended, so the stored
+        # end still belongs to the previous utterance. Move it just before agent speech
+        # to exclude this overlap from dynamic endpointing statistics.
         if (
             self._agent_speech_started_at is None
             and self._speaking

--- a/tests/test_endpointing.py
+++ b/tests/test_endpointing.py
@@ -262,10 +262,10 @@ class TestDynamicEndpointing:
         assert ep.min_delay == pytest.approx(0.3, rel=1e-5)
         assert ep.max_delay == pytest.approx(1.0, rel=1e-5)
 
-    def test_agent_start_while_user_speaks_preserves_utterance_timestamps(self) -> None:
-        ep = DynamicEndpointing(min_delay=0.06, max_delay=1.0, alpha=1.0)
+    def test_agent_start_while_user_speaks_backdates_stale_utterance_end(self) -> None:
+        ep = DynamicEndpointing(min_delay=0.3, max_delay=1.0, alpha=0.5)
 
-        ep.on_end_of_speech(ended_at=99.0)
+        ep.on_end_of_speech(ended_at=99.5)
         ep.on_start_of_speech(started_at=100.0)
         ep.on_start_of_agent_speech(started_at=100.2)
 
@@ -274,7 +274,10 @@ class TestDynamicEndpointing:
 
         assert ep._overlapping is True
         assert ep._utterance_started_at == 100.0
-        assert ep._utterance_ended_at == 99.0
+        assert ep._utterance_ended_at == pytest.approx(100.2, rel=1e-3)
+
+        ep.on_end_of_speech(ended_at=100.5)
+        assert ep.min_delay == pytest.approx(0.3, rel=1e-5)
 
     def test_update_options_preserves_filter_alpha(self) -> None:
         """Changing delays should not overwrite the EMA smoothing coefficient."""
@@ -407,6 +410,7 @@ class TestDynamicEndpointing:
     def test_agent_speech_resume_restores_overlap_while_user_speaks(self) -> None:
         ep = DynamicEndpointing(min_delay=0.3, max_delay=1.0)
 
+        ep.on_end_of_speech(ended_at=99.5)
         ep.on_start_of_agent_speech(started_at=100.0)
         ep.on_start_of_speech(started_at=100.1, overlapping=True)
         ep.on_end_of_agent_speech(ended_at=100.2)
@@ -415,6 +419,7 @@ class TestDynamicEndpointing:
 
         assert ep._overlapping is True
         assert ep._utterance_started_at == 100.1
+        assert ep._utterance_ended_at == 99.5
 
     def test_agent_speech_resume_does_not_restore_overlap_after_user_ends(self) -> None:
         ep = DynamicEndpointing(min_delay=0.3, max_delay=1.0)

--- a/tests/test_endpointing.py
+++ b/tests/test_endpointing.py
@@ -262,20 +262,19 @@ class TestDynamicEndpointing:
         assert ep.min_delay == pytest.approx(0.3, rel=1e-5)
         assert ep.max_delay == pytest.approx(1.0, rel=1e-5)
 
-    def test_interruption_adjusts_stale_utterance_end_time(self) -> None:
-        """Interruption path should adjust stale utterance end timestamp before delay updates."""
+    def test_agent_start_while_user_speaks_preserves_utterance_timestamps(self) -> None:
         ep = DynamicEndpointing(min_delay=0.06, max_delay=1.0, alpha=1.0)
 
-        # Simulate stale ordering where end timestamp still belongs to a previous utterance.
         ep.on_end_of_speech(ended_at=99.0)
         ep.on_start_of_speech(started_at=100.0)
-
         ep.on_start_of_agent_speech(started_at=100.2)
+
+        # A later audio-activity notification for the same speech must not replace its onset.
         ep.on_start_of_speech(started_at=100.25, overlapping=True)
 
-        assert ep._utterance_ended_at == pytest.approx(100.2, rel=1e-3)
-        assert ep.min_delay == pytest.approx(0.06, rel=1e-5)
-        assert ep.max_delay == pytest.approx(1.0, rel=1e-5)
+        assert ep._overlapping is True
+        assert ep._utterance_started_at == 100.0
+        assert ep._utterance_ended_at == 99.0
 
     def test_update_options_preserves_filter_alpha(self) -> None:
         """Changing delays should not overwrite the EMA smoothing coefficient."""
@@ -403,6 +402,30 @@ class TestDynamicEndpointing:
         # _agent_speech_started_at is intentionally preserved so that
         # between_turn_delay can be computed in the normal end-of-speech path
         assert ep._agent_speech_started_at == 100.0
+        assert ep._overlapping is False
+
+    def test_agent_speech_resume_restores_overlap_while_user_speaks(self) -> None:
+        ep = DynamicEndpointing(min_delay=0.3, max_delay=1.0)
+
+        ep.on_start_of_agent_speech(started_at=100.0)
+        ep.on_start_of_speech(started_at=100.1, overlapping=True)
+        ep.on_end_of_agent_speech(ended_at=100.2)
+
+        ep.on_start_of_agent_speech(started_at=100.3)
+
+        assert ep._overlapping is True
+        assert ep._utterance_started_at == 100.1
+
+    def test_agent_speech_resume_does_not_restore_overlap_after_user_ends(self) -> None:
+        ep = DynamicEndpointing(min_delay=0.3, max_delay=1.0)
+
+        ep.on_start_of_agent_speech(started_at=100.0)
+        ep.on_start_of_speech(started_at=100.1, overlapping=True)
+        ep.on_end_of_agent_speech(ended_at=100.2)
+        ep.on_end_of_speech(ended_at=100.25)
+
+        ep.on_start_of_agent_speech(started_at=100.3)
+
         assert ep._overlapping is False
 
     def test_overlapping_inferred_from_agent_speech(self) -> None:


### PR DESCRIPTION
Dynamic endpointing cleared its overlap state when paused agent speech resumed while the user was still speaking. Restore overlap from the existing user-speaking state so endpointing follows the reopened adaptive overlap without replacing the original user speech timestamp.

Addresses AGT-3352

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> dynamic endpointing can restore overlap from its existing speaking state, right?
>
> yes please

</details>