### PR TITLE
feat(amd): optionally process SIP early media

### DIFF
--- a/livekit-agents/livekit/agents/voice/amd/detector.py
+++ b/livekit-agents/livekit/agents/voice/amd/detector.py
@@ -107,10 +107,11 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
     the pre-answer phase. If the call ends before audio arrives, AMD settles
     immediately with an ``uncertain`` verdict (``reason="participant_missing"``).
 
-    For SIP participants, the no-speech timer and
-    audio/transcript processing are deferred until ``sip.callStatus ==
-    "active"`` so pre-answer audio (ringback, carrier early media, dialtone)
-    does not poison the classifier or burn the no-speech budget.
+    For SIP participants, the no-speech timer and audio/transcript processing
+    are deferred by default until ``sip.callStatus == "active"`` so pre-answer
+    audio (ringback, carrier early media, dialtone) does not poison the
+    classifier or burn the no-speech budget. Set ``wait_until_answered=False``
+    to process early media from the subscribed audio track instead.
 
     The recommended pattern is the async context manager::
 
@@ -135,6 +136,13 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
             audio track, and settles immediately if that participant
             disconnects before publishing audio. If omitted, the first remote
             audio track wins and the publisher is resolved from the track sid.
+        wait_until_answered: For SIP participants, whether to defer detection
+            timers and audio/transcript processing until ``sip.callStatus ==
+            "active"``. Defaults to ``True``. Set to ``False`` to process
+            early media, including ringback, carrier announcements, and
+            dialtone. To consume a verdict before the call is answered, also
+            set ``wait_until_answered=False`` on the SIP participant request.
+            Has no effect on non-SIP participants.
         stt: STT used for transcript generation. Accepts an :class:`STT`
             instance or an inference model string (e.g.
             ``"cartesia/ink-whisper"``). When omitted, AMD auto-selects:
@@ -174,6 +182,7 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
         interrupt_on_machine: bool = True,
         ivr_detection: bool = True,
         participant_identity: NotGivenOr[str] = NOT_GIVEN,
+        wait_until_answered: bool = True,
         suppress_compatibility_warning: bool = False,
         detection_options: NotGivenOr[DetectionOptions] = NOT_GIVEN,
         wait_until_finished: bool = True,
@@ -197,6 +206,7 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
         self._session: AgentSession = session
         self._interrupt_on_machine = interrupt_on_machine
         self._ivr_detection = ivr_detection
+        self._wait_until_answered = wait_until_answered
         self._wait_until_finished = wait_until_finished
         self._suppress_compatibility_warning = suppress_compatibility_warning
         self._participant_identity: NotGivenOr[str] = participant_identity
@@ -438,7 +448,10 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
                 self._settle_participant_missing("participant disappeared after track subscription")
                 return
 
-            if publisher.kind == rtc.ParticipantKind.PARTICIPANT_KIND_SIP:
+            if (
+                publisher.kind == rtc.ParticipantKind.PARTICIPANT_KIND_SIP
+                and self._wait_until_answered
+            ):
                 self._sip_answer_task = asyncio.create_task(
                     self._wait_for_sip_answer(room, publisher.identity),
                     name="amd_sip_answer",

--- a/tests/test_amd_classifier.py
+++ b/tests/test_amd_classifier.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from livekit import rtc
 from livekit.agents.llm import FunctionToolCall
 from livekit.agents.types import NOT_GIVEN
 from livekit.agents.voice.amd import detector as amd_detector
@@ -65,6 +66,35 @@ class _RecordingClassifier:
 
     def settle(self, category: AMDCategory, reason: str) -> None:
         self.settled.append((category, reason))
+
+
+def _make_sip_detector(
+    *, wait_until_answered: bool | None = None
+) -> tuple[AMD, _AMDClassifier, SimpleNamespace]:
+    llm = FakeLLM()
+    publisher = SimpleNamespace(
+        kind=rtc.ParticipantKind.PARTICIPANT_KIND_SIP,
+        identity="callee",
+        track_publications={"track_sid": object()},
+    )
+    session = SimpleNamespace(
+        llm=llm,
+        _activity=None,
+        _amd=None,
+        _room_io=SimpleNamespace(room=SimpleNamespace(remote_participants={"callee": publisher})),
+    )
+    kwargs = {"wait_until_answered": wait_until_answered} if wait_until_answered is not None else {}
+    detector = AMD(  # type: ignore[arg-type]
+        session,
+        llm=llm,
+        participant_identity="callee",
+        suppress_compatibility_warning=True,
+        **kwargs,
+    )
+    detector._stt = NOT_GIVEN
+    classifier = _make_classifier()
+    detector._classifier = classifier
+    return detector, classifier, session
 
 
 def _machine_vm_response(transcript: str = "voicemail greeting") -> FakeLLMResponse:
@@ -783,6 +813,155 @@ class TestAMDClassifier:
         assert classifier.timer_calls == 1
         assert classifier.listening is True
         assert classifier.settled == []
+
+    async def test_sip_setup_waits_for_answer_by_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        answer_wait_started = asyncio.Event()
+        answered = asyncio.Event()
+
+        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
+            return SimpleNamespace(sid="track_sid")
+
+        async def fake_wait_for_participant_attribute(*_: object, **__: object) -> None:
+            answer_wait_started.set()
+            await answered.wait()
+
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_track_publication",
+            fake_wait_for_track_publication,
+        )
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_participant_attribute",
+            fake_wait_for_participant_attribute,
+        )
+
+        detector, classifier, session = _make_sip_detector()
+        audio_ch = amd_detector.aio.Chan[rtc.AudioFrame]()
+        detector._audio_ch = audio_ch
+        early_frame = rtc.AudioFrame(bytes(2), 48000, 1, 1)
+
+        await detector._setup(session)  # type: ignore[arg-type]
+        await answer_wait_started.wait()
+
+        answer_task = detector._sip_answer_task
+        assert answer_task is not None
+        assert classifier.listening is False
+        assert classifier._detection_timeout_timer is None
+        assert classifier._no_speech_timer is None
+
+        detector._on_transcript("ringback")
+        detector.push_audio(early_frame)
+        assert classifier._transcript == ""
+        assert audio_ch.empty()
+
+        answered.set()
+        await answer_task
+
+        assert classifier.listening is True
+        assert classifier._detection_timeout_timer is not None
+        assert classifier._no_speech_timer is not None
+
+        answered_frame = rtc.AudioFrame(bytes(2), 48000, 1, 1)
+        detector._on_transcript("hello")
+        detector.push_audio(answered_frame)
+        assert classifier._transcript == "hello"
+        assert audio_ch.recv_nowait() is answered_frame
+
+        audio_ch.close()
+        await classifier.close()
+
+    async def test_sip_setup_processes_early_media_when_answer_wait_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
+            return SimpleNamespace(sid="track_sid")
+
+        async def fail_wait_for_participant_attribute(*_: object, **__: object) -> None:
+            raise AssertionError("SIP answer gate must not run when disabled")
+
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_track_publication",
+            fake_wait_for_track_publication,
+        )
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_participant_attribute",
+            fail_wait_for_participant_attribute,
+        )
+
+        detector, classifier, session = _make_sip_detector(wait_until_answered=False)
+        audio_ch = amd_detector.aio.Chan[rtc.AudioFrame]()
+        detector._audio_ch = audio_ch
+
+        await detector._setup(session)  # type: ignore[arg-type]
+
+        assert detector._sip_answer_task is None
+        assert classifier.listening is True
+        assert classifier._detection_timeout_timer is not None
+        assert classifier._no_speech_timer is not None
+
+        early_frame = rtc.AudioFrame(bytes(2), 48000, 1, 1)
+        detector._on_transcript("voicemail greeting")
+        detector.push_audio(early_frame)
+        assert classifier._transcript == "voicemail greeting"
+        assert audio_ch.recv_nowait() is early_frame
+
+        audio_ch.close()
+        await classifier.close()
+
+    async def test_close_cancels_pending_sip_answer_wait(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        answer_wait_started = asyncio.Event()
+        answer_wait_cancelled = asyncio.Event()
+
+        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
+            return SimpleNamespace(sid="track_sid")
+
+        async def fake_wait_for_participant_attribute(*_: object, **__: object) -> None:
+            answer_wait_started.set()
+            try:
+                await asyncio.Future[None]()
+            except asyncio.CancelledError:
+                answer_wait_cancelled.set()
+                raise
+
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_track_publication",
+            fake_wait_for_track_publication,
+        )
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_participant_attribute",
+            fake_wait_for_participant_attribute,
+        )
+
+        detector, classifier, session = _make_sip_detector()
+        classifier.on("amd_prediction", detector._on_amd_prediction)
+        session._amd = detector
+        detector._setup_task = asyncio.create_task(
+            detector._setup(session),  # type: ignore[arg-type]
+            name="amd_setup_test",
+        )
+
+        await answer_wait_started.wait()
+        answer_task = detector._sip_answer_task
+        assert answer_task is not None
+
+        await detector.aclose()
+
+        assert answer_wait_cancelled.is_set()
+        assert answer_task.cancelled()
+        assert detector._sip_answer_task is None
+        assert detector._setup_task is None
+        assert detector._classifier is None
+        assert classifier.closed
+        assert session._amd is None
 
     async def test_setup_settles_when_participant_disconnects_before_track(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

- add `wait_until_answered` to `AMD`, defaulting to `True`
- when disabled for a SIP participant, start detection timers and process audio and transcripts from track subscription
- preserve the existing answer-gated behavior by default
- cover the default, opt-in, and pending-answer cleanup paths

## Why

Some carriers deliver voicemail greetings or announcements through `183 Session Progress` early media before `sip.callStatus` becomes `active`. AMD currently discards that audio while waiting for the answered state.

This gives integrations an explicit opt-in without changing the safer default for calls where early media contains only ringback or dialtone. Callers that need a verdict before answer must also disable `wait_until_answered` on the SIP participant request.

## Testing

- `uv run pytest tests/test_amd_classifier.py -q` — 37 passed
- `uv run ruff check livekit-agents/livekit/agents/voice/amd/detector.py tests/test_amd_classifier.py`
- `uv run ruff format --check livekit-agents/livekit/agents/voice/amd/detector.py tests/test_amd_classifier.py`
- scoped mypy for `livekit.agents` — 207 source files passed

Closes #6895
