### PR TITLE
fix: raise the shared http session total timeout to 900s

### DIFF
--- a/livekit-agents/livekit/agents/utils/http_context.py
+++ b/livekit-agents/livekit/agents/utils/http_context.py
@@ -14,6 +14,11 @@ from ..log import logger
 _ClientFactory = Callable[[], aiohttp.ClientSession]
 _ContextVar = contextvars.ContextVar[_ClientFactory | None]("agent_http_session")
 
+# aiohttp's total is cumulative over the whole operation, body consumption included,
+# so a still-flowing streaming response is cancelled once it's reached. sock_connect is
+# restated because a bare ClientTimeout(total=...) drops aiohttp's 30s default to None.
+_DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=900, sock_connect=30)
+
 
 def _has_system_trust_store() -> bool:
     """Whether OpenSSL's default verify paths resolve to something on disk.
@@ -82,7 +87,9 @@ def _new_session_ctx() -> _ClientFactory:
                 keepalive_timeout=120,  # the default is only 15s
                 ssl=_create_ssl_context(),
             )
-            g_session = aiohttp.ClientSession(proxy=http_proxy, connector=connector)
+            g_session = aiohttp.ClientSession(
+                proxy=http_proxy, connector=connector, timeout=_DEFAULT_TIMEOUT
+            )
         return g_session
 
     _ContextVar.set(_new_session)

--- a/tests/test_http_context_helper.py
+++ b/tests/test_http_context_helper.py
@@ -67,6 +67,12 @@ async def test_open_isolated_per_task() -> None:
     assert sess_a.closed and sess_b.closed
 
 
+async def test_shared_session_total_timeout_exceeds_aiohttp_default() -> None:
+    async with http_context.open() as session:
+        assert session.timeout.total == 900
+        assert session.timeout.sock_connect == 30
+
+
 async def test_http_session_error_message_points_to_helper() -> None:
     with pytest.raises(RuntimeError) as exc_info:
         http_context.http_session()


### PR DESCRIPTION
`http_session()` passed no `timeout`, so it inherited aiohttp's `ClientTimeout(total=300)`, which is shorter than worse case scenario for redaction (~15mins).

Raised `total` to 900s. `sock_connect=30` is restated because a bare `ClientTimeout(total=...)` drops aiohttp's connect guard to `None`.

WebSocket transports were never affected and are unchanged: `_ws_connect` reads through a `WebSocketDataQueue` that holds no request timer, so the armed handle cancels nothing.

Addresses AGT-3354

<details>
<summary>Initial prompt and agent context</summary>

**Model:** Claude Opus 5

> I believe we have a default timeout from aiohttp? aiohttp.ClientSession(proxy=http_proxy, connector=connector) this would timeout after the default 300s?

> can you create a PR to bump it to 300 * 3 instead?

</details>