### PR TITLE
fix(openai realtime): keep derived capabilities in sync with update_options

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -303,16 +303,22 @@ def _server_turn_taking_enabled(
     turn_detection: RealtimeAudioInputTurnDetection | None,
 ) -> bool:
     """Whether the server both detects turns and answers them."""
-    if turn_detection is None:
-        return False
-    if turn_detection.create_response is False:
-        if turn_detection.interrupt_response is not False:
-            logger.warning(
-                "create_response=False hands turn taking to the client, but the server still "
-                "cancels its response on user speech, pass interrupt_response=False as well"
-            )
-        return False
-    return True
+    return turn_detection is not None and turn_detection.create_response is not False
+
+
+def _warn_on_half_disabled_turn_taking(
+    turn_detection: RealtimeAudioInputTurnDetection | None,
+) -> None:
+    """Warn when the caller hands turn taking to the client but leaves interruption on the server."""
+    if (
+        turn_detection is not None
+        and turn_detection.create_response is False
+        and turn_detection.interrupt_response is not False
+    ):
+        logger.warning(
+            "create_response=False hands turn taking to the client, but the server still "
+            "cancels its response on user speech, pass interrupt_response=False as well"
+        )
 
 
 class RealtimeModel(llm.RealtimeModel):
@@ -470,6 +476,7 @@ class RealtimeModel(llm.RealtimeModel):
 
         modalities = modalities if is_given(modalities) else ["text", "audio"]
         resolved_turn_detection = to_turn_detection(turn_detection)
+        _warn_on_half_disabled_turn_taking(resolved_turn_detection)
         super().__init__(
             capabilities=llm.RealtimeCapabilities(
                 message_truncation=True,
@@ -745,6 +752,8 @@ class RealtimeModel(llm.RealtimeModel):
             self._capabilities.turn_detection = _server_turn_taking_enabled(
                 self._opts.turn_detection
             )
+            # only the model warns: it re-runs the update on every session it owns
+            _warn_on_half_disabled_turn_taking(self._opts.turn_detection)
 
         if is_given(tool_choice):
             self._opts.tool_choice = tool_choice

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -299,6 +299,22 @@ def _is_fatal_error(error: object | None) -> bool:
     return isinstance(code, str) and code in _FATAL_ERROR_CODES
 
 
+def _server_turn_taking_enabled(
+    turn_detection: RealtimeAudioInputTurnDetection | None,
+) -> bool:
+    """Whether the server both detects turns and answers them."""
+    if turn_detection is None:
+        return False
+    if turn_detection.create_response is False:
+        if turn_detection.interrupt_response is not False:
+            logger.warning(
+                "create_response=False hands turn taking to the client, but the server still "
+                "cancels its response on user speech, pass interrupt_response=False as well"
+            )
+        return False
+    return True
+
+
 class RealtimeModel(llm.RealtimeModel):
     @overload
     def __init__(
@@ -454,22 +470,10 @@ class RealtimeModel(llm.RealtimeModel):
 
         modalities = modalities if is_given(modalities) else ["text", "audio"]
         resolved_turn_detection = to_turn_detection(turn_detection)
-        if (
-            resolved_turn_detection is not None
-            and resolved_turn_detection.create_response is False
-            and resolved_turn_detection.interrupt_response is not False
-        ):
-            logger.warning(
-                "create_response=False hands turn taking to the client, but the server still "
-                "cancels its response on user speech, pass interrupt_response=False as well"
-            )
-
         super().__init__(
             capabilities=llm.RealtimeCapabilities(
                 message_truncation=True,
-                # create_response=False leaves the reply to the client: client-side turn taking
-                turn_detection=resolved_turn_detection is not None
-                and resolved_turn_detection.create_response is not False,
+                turn_detection=_server_turn_taking_enabled(resolved_turn_detection),
                 can_disable_turn_detection=not is_given(turn_detection),
                 user_transcription=input_audio_transcription is not None,
                 auto_tool_reply_generation=False,
@@ -736,13 +740,18 @@ class RealtimeModel(llm.RealtimeModel):
             self._opts.voice = voice
 
         if is_given(turn_detection):
+            # a derived capability has to follow the option it is derived from
             self._opts.turn_detection = to_turn_detection(turn_detection)
+            self._capabilities.turn_detection = _server_turn_taking_enabled(
+                self._opts.turn_detection
+            )
 
         if is_given(tool_choice):
             self._opts.tool_choice = tool_choice
 
         if is_given(input_audio_transcription):
             self._opts.input_audio_transcription = to_audio_transcription(input_audio_transcription)
+            self._capabilities.user_transcription = self._opts.input_audio_transcription is not None
 
         if is_given(input_audio_noise_reduction):
             self._opts.input_audio_noise_reduction = to_noise_reduction(input_audio_noise_reduction)
@@ -871,6 +880,13 @@ class RealtimeSession(
         self._opts = replace(
             realtime_model._opts,
             turn_detection=None if turn_detection_disabled else realtime_model._opts.turn_detection,
+        )
+        # this session's own copy: turn detection can be off here and on for the model
+        self._capabilities = replace(
+            realtime_model.capabilities,
+            turn_detection=False
+            if turn_detection_disabled
+            else realtime_model.capabilities.turn_detection,
         )
         self._tools = llm.ToolContext.empty()
         self._msg_ch = utils.aio.Chan[RealtimeClientEvent | dict[str, Any]]()
@@ -1319,6 +1335,10 @@ class RealtimeSession(
         )
 
     @property
+    def capabilities(self) -> llm.RealtimeCapabilities:
+        return self._capabilities
+
+    @property
     def chat_ctx(self) -> llm.ChatContext:
         return self._remote_chat_ctx.to_chat_ctx()
 
@@ -1394,12 +1414,14 @@ class RealtimeSession(
                 audio_input.turn_detection = turn_detection
                 has_audio_config = True
             self._opts.turn_detection = turn_detection
+            self._capabilities.turn_detection = _server_turn_taking_enabled(turn_detection)
 
         if is_given(input_audio_transcription):
             if self._opts.input_audio_transcription != input_audio_transcription:
                 audio_input.transcription = input_audio_transcription
                 has_audio_config = True
             self._opts.input_audio_transcription = input_audio_transcription
+            self._capabilities.user_transcription = input_audio_transcription is not None
 
         if is_given(input_audio_noise_reduction):
             input_audio_noise_reduction = to_noise_reduction(input_audio_noise_reduction)

--- a/tests/test_realtime/test_openai_realtime_model.py
+++ b/tests/test_realtime/test_openai_realtime_model.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import cast
 
@@ -12,6 +13,7 @@ from openai.types.realtime import (
     ConversationItemDeletedEvent,
     RealtimeErrorEvent,
 )
+from openai.types.realtime.audio_transcription import AudioTranscription
 from openai.types.realtime.realtime_audio_input_turn_detection import ServerVad
 
 from livekit.agents import llm
@@ -110,6 +112,75 @@ def test_create_response_false_warns_when_the_server_still_interrupts(
             ),
         )
     assert caplog.text == ""
+
+
+def test_update_options_keeps_derived_capabilities_in_sync() -> None:
+    # a stale capability reports the server owning the turn after the caller handed turn
+    # taking to the client, and AgentActivity then rejects allow_interruptions=False
+    model = RealtimeModel(api_key="fake", turn_detection=ServerVad(type="server_vad"))
+    assert model.capabilities.turn_detection is True
+    assert model.capabilities.user_transcription is True
+
+    model.update_options(
+        turn_detection=ServerVad(
+            type="server_vad", create_response=False, interrupt_response=False
+        ),
+        input_audio_transcription=None,
+    )
+    assert model.capabilities.turn_detection is False
+    assert model.capabilities.user_transcription is False
+
+    model.update_options(
+        turn_detection=ServerVad(type="server_vad"),
+        input_audio_transcription=AudioTranscription(model="whisper-1"),
+    )
+    assert model.capabilities.turn_detection is True
+    assert model.capabilities.user_transcription is True
+
+
+def test_update_options_leaves_derived_capabilities_alone_when_unset() -> None:
+    # an unrelated update must not resync a model that opted out of server-side turn taking
+    model = RealtimeModel(
+        api_key="fake",
+        turn_detection=ServerVad(
+            type="server_vad", create_response=False, interrupt_response=False
+        ),
+    )
+    model.update_options(voice="marin")
+    assert model.capabilities.turn_detection is False
+
+
+def _capabilities_session(model: RealtimeModel) -> RealtimeSession:
+    # only the state update_options touches; a real session would open a websocket
+    return cast(
+        RealtimeSession,
+        SimpleNamespace(
+            _opts=replace(model._opts),
+            _capabilities=replace(model.capabilities),
+            send_event=lambda event: None,
+            _wrap_session_update=lambda event_id, session: session,
+        ),
+    )
+
+
+def test_session_update_options_keeps_capabilities_on_the_session() -> None:
+    # turn detection is per session: one session handing turn taking to the client must not
+    # change what the model, or any other session on it, reports
+    model = RealtimeModel(api_key="fake", turn_detection=ServerVad(type="server_vad"))
+    session = _capabilities_session(model)
+
+    RealtimeSession.update_options(
+        session,
+        turn_detection=ServerVad(
+            type="server_vad", create_response=False, interrupt_response=False
+        ),
+        input_audio_transcription=None,
+    )
+
+    assert session._capabilities.turn_detection is False
+    assert session._capabilities.user_transcription is False
+    assert model.capabilities.turn_detection is True
+    assert model.capabilities.user_transcription is True
 
 
 def test_legacy_turn_detection_keeps_interrupt_response() -> None:


### PR DESCRIPTION
**Problem**

`capabilities.turn_detection` and `capabilities.user_transcription` come from constructor options, but `update_options` changed those options and left the capabilities alone.
A model switched to `create_response=False` does client-side turn taking (#6642), and the stale capability still reports that the server owns the turn.
`AgentActivity` then refuses `allow_interruptions=False`, and `_resolve_rt_turn_detection_enabled` selects the wrong mode for endpointing and for realtime-session reuse across a handoff.
Turn detection is also per session, because `session(turn_detection_disabled=True)` switches it off for one session, but the only capabilities object was on the model.

**Fix**

One function now derives server-side turn taking, and both the constructor and `update_options` call it, so the two cannot drift apart again.
`RealtimeSession` keeps its own capabilities copy and updates it from its own `update_options`.
One session can now hand turn taking to the client while the model and its other sessions stay unchanged.
The function also carries the `interrupt_response` warning, which `update_options` did not give before.

The `turn_detection_disabled` branch in the session constructor has no unit test, because a real session opens a websocket in `__init__`.
