### PR TITLE
ElevenLabs STT: add secondary_languages support

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
+++ b/livekit-plugins/livekit-plugins-elevenlabs/livekit/plugins/elevenlabs/stt.py
@@ -95,6 +95,7 @@ class STTOptions:
     sample_rate: STTRealtimeSampleRates
     server_vad: NotGivenOr[VADOptions | None]
     keyterms: NotGivenOr[list[str]]
+    secondary_languages: NotGivenOr[list[str]]
     no_verbatim: bool
     enable_logging: bool
     previous_text: str | None
@@ -116,6 +117,7 @@ class STT(stt.STT):
         model: NotGivenOr[ElevenLabsSTTModels | str] = NOT_GIVEN,
         model_id: NotGivenOr[ElevenLabsSTTModels | str] = NOT_GIVEN,  # Deprecated
         keyterms: NotGivenOr[list[str]] = NOT_GIVEN,
+        secondary_languages: NotGivenOr[list[str]] = NOT_GIVEN,
         no_verbatim: NotGivenOr[bool] = NOT_GIVEN,
         enable_logging: bool = True,
         previous_text: NotGivenOr[str] = NOT_GIVEN,
@@ -141,6 +143,11 @@ class STT(stt.STT):
                 Supported for both Scribe v2 (batch) and Scribe v2 realtime. Batch accepts up to
                 1000 keyterms of at most 50 characters each; realtime accepts up to 50 keyterms of
                 at most 20 characters each. Usage incurs additional costs.
+            secondary_languages (NotGivenOr[list[str]]): A list of language codes to constrain
+                speech prediction to, in addition to `language_code`. Useful for bilingual
+                applications where the audio switches between a primary and a limited set of
+                secondary languages. Supported for Scribe v2 realtime. When omitted, the model
+                predicts from its full set of supported languages.
             no_verbatim (NotGivenOr[bool]): When True, the model removes filler words, false starts
                 and disfluencies from the transcript, producing cleaner output. Supported for both
                 Scribe v2 (batch) and Scribe v2 realtime. Default is False.
@@ -209,6 +216,7 @@ class STT(stt.STT):
             include_timestamps=include_timestamps,
             model_id=model,
             keyterms=keyterms,
+            secondary_languages=secondary_languages,
             no_verbatim=no_verbatim if is_given(no_verbatim) else False,
             enable_logging=enable_logging,
             previous_text=resolved_previous_text,
@@ -250,6 +258,9 @@ class STT(stt.STT):
         if is_given(self._opts.keyterms):
             for keyterm in self._opts.keyterms:
                 form.add_field("keyterms", keyterm)
+        if is_given(self._opts.secondary_languages):
+            for language in self._opts.secondary_languages:
+                form.add_field("secondary_languages", language)
         if self._opts.no_verbatim:
             form.add_field("no_verbatim", "true")
 
@@ -338,6 +349,7 @@ class STT(stt.STT):
         tag_audio_events: NotGivenOr[bool] = NOT_GIVEN,
         server_vad: NotGivenOr[VADOptions] = NOT_GIVEN,
         keyterms: NotGivenOr[list[str]] = NOT_GIVEN,
+        secondary_languages: NotGivenOr[list[str]] = NOT_GIVEN,
         no_verbatim: NotGivenOr[bool] = NOT_GIVEN,
     ) -> None:
         if is_given(tag_audio_events):
@@ -349,11 +361,19 @@ class STT(stt.STT):
         if is_given(keyterms):
             self._opts.keyterms = keyterms
 
+        if is_given(secondary_languages):
+            self._opts.secondary_languages = secondary_languages
+
         if is_given(no_verbatim):
             self._opts.no_verbatim = no_verbatim
 
         for stream in self._streams:
-            stream.update_options(server_vad=server_vad, no_verbatim=no_verbatim, keyterms=keyterms)
+            stream.update_options(
+                server_vad=server_vad,
+                no_verbatim=no_verbatim,
+                keyterms=keyterms,
+                secondary_languages=secondary_languages,
+            )
 
     def stream(
         self,
@@ -401,6 +421,7 @@ class SpeechStream(stt.SpeechStream):
         server_vad: NotGivenOr[VADOptions] = NOT_GIVEN,
         no_verbatim: NotGivenOr[bool] = NOT_GIVEN,
         keyterms: NotGivenOr[list[str]] = NOT_GIVEN,
+        secondary_languages: NotGivenOr[list[str]] = NOT_GIVEN,
     ) -> None:
         if is_given(server_vad):
             self._opts.server_vad = server_vad
@@ -410,6 +431,9 @@ class SpeechStream(stt.SpeechStream):
             self._reconnect_event.set()
         if is_given(keyterms):
             self._opts.keyterms = keyterms
+            self._reconnect_event.set()
+        if is_given(secondary_languages):
+            self._opts.secondary_languages = secondary_languages
             self._reconnect_event.set()
 
     def _on_audio_duration_report(self, duration: float) -> None:
@@ -617,6 +641,12 @@ class SpeechStream(stt.SpeechStream):
 
         if is_given(self._opts.keyterms):
             params.extend(f"keyterms={quote(keyterm)}" for keyterm in self._opts.keyterms)
+
+        if is_given(self._opts.secondary_languages):
+            params.extend(
+                f"secondary_languages={quote(language)}"
+                for language in self._opts.secondary_languages
+            )
 
         query_string = "&".join(params)
 

--- a/tests/test_plugin_elevenlabs_stt.py
+++ b/tests/test_plugin_elevenlabs_stt.py
@@ -17,6 +17,7 @@ from yarl import URL
 from livekit import rtc
 from livekit.agents import DEFAULT_API_CONNECT_OPTIONS, stt
 from livekit.agents.types import NOT_GIVEN
+from livekit.agents.utils import is_given
 from livekit.plugins.elevenlabs import stt as elevenlabs_stt
 from livekit.plugins.elevenlabs._utils import trace_id_from_headers
 
@@ -43,6 +44,7 @@ def _new_stream(*, server_vad=NOT_GIVEN) -> elevenlabs_stt.SpeechStream:
         sample_rate=16000,
         server_vad=server_vad,
         keyterms=NOT_GIVEN,
+        secondary_languages=NOT_GIVEN,
         no_verbatim=False,
         enable_logging=True,
         previous_text=None,
@@ -269,6 +271,31 @@ def test_stream_update_options_sets_keyterms_and_requests_reconnect() -> None:
 
     assert stream._opts.keyterms == ["nginx"]
     assert stream._reconnect_event.is_set()
+
+
+async def test_connect_ws_includes_secondary_languages() -> None:
+    # secondary_languages constrain prediction to a subset of languages for
+    # bilingual use and are sent as repeated query params on the connect URL.
+    stream = _new_stream()
+    stream._opts.secondary_languages = ["hi", "es"]
+
+    url = await _connect_ws_url(stream)
+
+    assert URL(url).query.getall("secondary_languages") == ["hi", "es"]
+
+
+async def test_connect_ws_omits_secondary_languages_when_not_given() -> None:
+    url = await _connect_ws_url(_new_stream())
+
+    assert "secondary_languages=" not in url
+
+
+def test_secondary_languages_defaults_to_not_given() -> None:
+    assert not is_given(_stt()._opts.secondary_languages)
+
+
+def test_secondary_languages_can_be_set() -> None:
+    assert _stt(secondary_languages=["hi", "es"])._opts.secondary_languages == ["hi", "es"]
 
 
 class _FakeWS:


### PR DESCRIPTION
## Summary
- Adds a `secondary_languages: NotGivenOr[list[str]]` option to the ElevenLabs STT plugin, letting bilingual applications constrain speech prediction to a limited set of languages alongside `language_code`.
- Forwarded as repeated form fields for batch requests and repeated `secondary_languages` query params for Scribe v2 realtime sessions (mirroring how `keyterms` are handled).
- Supported in the constructor, `update_options()` (with reconnect propagation to live realtime streams), and both `STTOptions`.

Fixes #6920

## Testing
- New unit tests in `tests/test_plugin_elevenlabs_stt.py`: connect URL includes repeated `secondary_languages` params, omitted when NOT_GIVEN, defaults, and option updates.
- `uv run pytest tests/test_plugin_elevenlabs_stt.py` — 29 passed
- `ruff format/check` and `mypy` clean