### PR TITLE
speechmatics: expose end_of_turn_config and vad_config options

### DIFF
--- a/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
+++ b/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
@@ -38,10 +38,12 @@ from speechmatics.voice import (
     AdditionalVocabEntry,
     AgentServerMessageType,
     AudioEncoding,
+    EndOfTurnConfig,
     OperatingPoint,
     SpeakerFocusConfig,
     SpeakerFocusMode,
     SpeakerIdentifier,
+    VoiceActivityConfig,
     VoiceAgentClient,
     VoiceAgentConfig,
     VoiceAgentConfigPreset,
@@ -109,6 +111,8 @@ class STTOptions:
     max_delay: float | None = None
     end_of_utterance_silence_trigger: float | None = None
     end_of_utterance_max_delay: float | None = None
+    end_of_turn_config: EndOfTurnConfig | None = None
+    vad_config: VoiceActivityConfig | None = None
     punctuation_overrides: dict | None = None
     include_partials: bool | None = None
 
@@ -135,6 +139,8 @@ class STT(stt.STT):
         max_delay: NotGivenOr[float] = NOT_GIVEN,
         end_of_utterance_silence_trigger: NotGivenOr[float] = NOT_GIVEN,
         end_of_utterance_max_delay: NotGivenOr[float] = NOT_GIVEN,
+        end_of_turn_config: NotGivenOr[EndOfTurnConfig] = NOT_GIVEN,
+        vad_config: NotGivenOr[VoiceActivityConfig] = NOT_GIVEN,
         additional_vocab: NotGivenOr[list[AdditionalVocabEntry]] = NOT_GIVEN,
         punctuation_overrides: NotGivenOr[dict] = NOT_GIVEN,
         speaker_sensitivity: NotGivenOr[float] = NOT_GIVEN,
@@ -199,6 +205,16 @@ class STT(stt.STT):
             end_of_utterance_max_delay: Maximum delay in seconds for end of utterance.
                 Must be greater than `end_of_utterance_silence_trigger`.
                 Overrides preset if provided. Optional.
+
+            end_of_turn_config: End-of-turn configuration, controlling the penalty
+                multipliers applied to the `end_of_utterance_silence_trigger`, the
+                minimum end-of-turn delay and forced end-of-utterance behaviour.
+                Replaces the preset's `EndOfTurnConfig` when provided. Optional.
+
+            vad_config: Client-side voice activity configuration used by the
+                `ADAPTIVE` and `SMART_TURN` presets (e.g. `silence_duration` and
+                `threshold`). Replaces the preset's `VoiceActivityConfig` when
+                provided. Optional.
 
             additional_vocab: List of additional vocabulary entries to increase the
                 weight of specific words in the transcription model. Defaults to [].
@@ -320,6 +336,8 @@ class STT(stt.STT):
             max_delay=_set(max_delay),
             end_of_utterance_silence_trigger=_set(end_of_utterance_silence_trigger),
             end_of_utterance_max_delay=_set(end_of_utterance_max_delay),
+            end_of_turn_config=end_of_turn_config if is_given(end_of_turn_config) else None,
+            vad_config=vad_config if is_given(vad_config) else None,
             punctuation_overrides=_set(punctuation_overrides),
             include_partials=_set(include_partials),
             enable_diarization=_set(enable_diarization),
@@ -473,6 +491,7 @@ class STT(stt.STT):
             "enable_diarization",
             "end_of_utterance_max_delay",
             "end_of_utterance_silence_trigger",
+            "end_of_turn_config",
             "include_partials",
             "max_delay",
             "max_speakers",
@@ -480,6 +499,7 @@ class STT(stt.STT):
             "prefer_current_speaker",
             "punctuation_overrides",
             "speaker_sensitivity",
+            "vad_config",
         ]
 
         # Override preset parameters if provided

--- a/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
+++ b/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
@@ -289,6 +289,25 @@ class STT(stt.STT):
             )
             turn_detection_mode = TurnDetectionMode.EXTERNAL
 
+        # An enabled client-side VAD config must not be combined with an
+        # external VAD: in EXTERNAL mode the external VAD (or manual
+        # finalize()) drives turn boundaries while the client-side VAD would
+        # also endpoint the same audio, producing premature or duplicate
+        # boundaries. Validate before the Silero auto-load below so callers get
+        # this configuration error instead of an unrelated Silero ImportError.
+        resolved_vad_config = vad_config if is_given(vad_config) else None
+        if (
+            resolved_vad_config is not None
+            and resolved_vad_config.enabled
+            and turn_detection_mode == TurnDetectionMode.EXTERNAL
+        ):
+            raise ValueError(
+                "vad_config with enabled=True cannot be combined with "
+                "turn_detection_mode=EXTERNAL: the external VAD (or manual finalize()) "
+                "already controls turn boundaries. Use the built-in endpointing modes "
+                "(ADAPTIVE or SMART_TURN) with vad_config instead."
+            )
+
         # In EXTERNAL mode the STT does not endpoint on its own. Auto-load Silero
         # so finalize() is wired up, unless the caller explicitly passed `vad=None`
         # to opt out (they'll drive finalize() themselves).
@@ -305,24 +324,6 @@ class STT(stt.STT):
 
         # Normalize NOT_GIVEN -> None for downstream storage.
         self._vad = vad if is_given(vad) else None
-
-        # An enabled client-side VAD config must not be combined with an
-        # external VAD: in EXTERNAL mode the external VAD (or manual
-        # finalize()) drives turn boundaries while the client-side VAD would
-        # also endpoint the same audio, producing premature or duplicate
-        # boundaries.
-        resolved_vad_config = vad_config if is_given(vad_config) else None
-        if (
-            resolved_vad_config is not None
-            and resolved_vad_config.enabled
-            and turn_detection_mode == TurnDetectionMode.EXTERNAL
-        ):
-            raise ValueError(
-                "vad_config with enabled=True cannot be combined with "
-                "turn_detection_mode=EXTERNAL: the external VAD (or manual finalize()) "
-                "already controls turn boundaries. Use the built-in endpointing modes "
-                "(ADAPTIVE or SMART_TURN) with vad_config instead."
-            )
 
         # Set default values for optional parameters
         super().__init__(

--- a/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
+++ b/livekit-plugins/livekit-plugins-speechmatics/livekit/plugins/speechmatics/stt.py
@@ -214,7 +214,9 @@ class STT(stt.STT):
             vad_config: Client-side voice activity configuration used by the
                 `ADAPTIVE` and `SMART_TURN` presets (e.g. `silence_duration` and
                 `threshold`). Replaces the preset's `VoiceActivityConfig` when
-                provided. Optional.
+                provided. Cannot be combined with `turn_detection_mode=EXTERNAL`
+                when enabled, since the external VAD already controls turn
+                boundaries. Optional.
 
             additional_vocab: List of additional vocabulary entries to increase the
                 weight of specific words in the transcription model. Defaults to [].
@@ -303,6 +305,24 @@ class STT(stt.STT):
 
         # Normalize NOT_GIVEN -> None for downstream storage.
         self._vad = vad if is_given(vad) else None
+
+        # An enabled client-side VAD config must not be combined with an
+        # external VAD: in EXTERNAL mode the external VAD (or manual
+        # finalize()) drives turn boundaries while the client-side VAD would
+        # also endpoint the same audio, producing premature or duplicate
+        # boundaries.
+        resolved_vad_config = vad_config if is_given(vad_config) else None
+        if (
+            resolved_vad_config is not None
+            and resolved_vad_config.enabled
+            and turn_detection_mode == TurnDetectionMode.EXTERNAL
+        ):
+            raise ValueError(
+                "vad_config with enabled=True cannot be combined with "
+                "turn_detection_mode=EXTERNAL: the external VAD (or manual finalize()) "
+                "already controls turn boundaries. Use the built-in endpointing modes "
+                "(ADAPTIVE or SMART_TURN) with vad_config instead."
+            )
 
         # Set default values for optional parameters
         super().__init__(

--- a/tests/test_plugin_speechmatics_stt.py
+++ b/tests/test_plugin_speechmatics_stt.py
@@ -60,6 +60,28 @@ def test_options_store_configs() -> None:
     assert instance._stt_options.vad_config is vad_cfg
 
 
+def test_enabled_vad_config_rejected_with_external_mode() -> None:
+    # The external VAD (or manual finalize()) already controls turn boundaries;
+    # an enabled client-side VAD would endpoint the same audio a second time.
+    with pytest.raises(ValueError, match="turn_detection_mode=EXTERNAL"):
+        speechmatics_stt.STT(
+            api_key="test-key",
+            turn_detection_mode=TurnDetectionMode.EXTERNAL,
+            vad=None,
+            vad_config=VoiceActivityConfig(enabled=True, silence_duration=0.3),
+        )
+
+
+def test_disabled_vad_config_allowed_with_external_mode() -> None:
+    instance = speechmatics_stt.STT(
+        api_key="test-key",
+        turn_detection_mode=TurnDetectionMode.EXTERNAL,
+        vad=None,
+        vad_config=VoiceActivityConfig(enabled=False, threshold=0.5),
+    )
+    assert instance._stt_options.vad_config is not None
+
+
 def test_omitted_configs_change_nothing_for_existing_users() -> None:
     # A default-constructed STT must produce exactly the preset values.
     config = _stt()._prepare_config()

--- a/tests/test_plugin_speechmatics_stt.py
+++ b/tests/test_plugin_speechmatics_stt.py
@@ -1,0 +1,69 @@
+"""Unit tests for Speechmatics STT plugin configuration."""
+
+from __future__ import annotations
+
+import pytest
+from speechmatics.voice import (
+    EndOfTurnConfig,
+    VoiceActivityConfig,
+    VoiceAgentConfigPreset,
+)
+
+from livekit.plugins.speechmatics import stt as speechmatics_stt
+from livekit.plugins.speechmatics.stt import TurnDetectionMode
+
+pytestmark = pytest.mark.plugin("speechmatics")
+
+
+def _stt(**kwargs: object) -> speechmatics_stt.STT:
+    return speechmatics_stt.STT(api_key="test-key", **kwargs)
+
+
+def _adaptive_config(**kwargs: object) -> object:
+    return _stt(turn_detection_mode=TurnDetectionMode.ADAPTIVE, **kwargs)._prepare_config()
+
+
+def test_end_of_turn_config_defaults_to_preset() -> None:
+    config = _adaptive_config()
+    preset = VoiceAgentConfigPreset.load(TurnDetectionMode.ADAPTIVE.value)
+
+    assert config.end_of_turn_config == preset.end_of_turn_config  # type: ignore[attr-defined]
+
+
+def test_vad_config_defaults_to_preset() -> None:
+    config = _adaptive_config()
+
+    assert config.vad_config.enabled is True  # type: ignore[attr-defined]
+    assert config.vad_config.silence_duration == pytest.approx(0.18)  # type: ignore[attr-defined]
+
+
+def test_end_of_turn_config_overrides_preset() -> None:
+    eou = EndOfTurnConfig(min_end_of_turn_delay=0.15, use_forced_eou=True)
+    config = _adaptive_config(end_of_turn_config=eou)
+
+    assert config.end_of_turn_config is eou  # type: ignore[attr-defined]
+
+
+def test_vad_config_overrides_preset() -> None:
+    vad_cfg = VoiceActivityConfig(enabled=True, silence_duration=0.3)
+    config = _adaptive_config(vad_config=vad_cfg)
+
+    assert config.vad_config is vad_cfg  # type: ignore[attr-defined]
+
+
+def test_options_store_configs() -> None:
+    eou = EndOfTurnConfig(min_end_of_turn_delay=0.15)
+    vad_cfg = VoiceActivityConfig(silence_duration=0.3)
+    instance = _stt(end_of_turn_config=eou, vad_config=vad_cfg)
+
+    assert instance._stt_options.end_of_turn_config is eou
+    assert instance._stt_options.vad_config is vad_cfg
+
+
+def test_omitted_configs_change_nothing_for_existing_users() -> None:
+    # A default-constructed STT must produce exactly the preset values.
+    config = _stt()._prepare_config()
+    preset = VoiceAgentConfigPreset.load(TurnDetectionMode.EXTERNAL.value)
+
+    assert config.end_of_turn_config == preset.end_of_turn_config
+    assert config.vad_config == preset.vad_config


### PR DESCRIPTION
## Summary
- Adds `end_of_turn_config: NotGivenOr[EndOfTurnConfig]` and `vad_config: NotGivenOr[VoiceActivityConfig]` constructor kwargs to the Speechmatics STT plugin (both types are already public exports of `speechmatics-voice`).
- Both are stored in `STTOptions` and added to the `advanced_params` override whitelist in `_prepare_config()`, so a provided value replaces the preset's object and an omitted kwarg changes nothing — no behavior change for existing users.

This makes adaptive endpointing tunable again: with the preset defaults, effective pause tolerance is ~0.25–0.45s regardless of `end_of_utterance_silence_trigger` (the ×0.2 VAD-stop penalty and `min_end_of_turn_delay` floor were unreachable), which splits natural mid-sentence pauses on phone calls into multiple turns. Previously the only workaround was subclassing `STT` and mutating private internals.

Fixes #6924

## Testing
- New unit tests in `tests/test_plugin_speechmatics_stt.py`: presets are used when kwargs omitted, provided objects replace the preset's, options stored.
- `uv run pytest tests/test_plugin_speechmatics_stt.py` — 6 passed
- `ruff format/check` and `mypy` clean