### PR TITLE
sarvam: align TTS validation with the live Bulbul API

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -794,6 +794,20 @@ class TTS(tts.TTS):
         output_audio_codec: str | None = None,
     ) -> None:
         """Update TTS options with validation."""
+        # Validate the effective model/pace combination before mutating
+        # anything, so a rejected update never leaves partial state behind and
+        # an atomic `update_options(model=..., pace=...)` is accepted when the
+        # supplied pace is valid for the new model.
+        if model is not None or pace is not None:
+            effective_model = model if model is not None else self._opts.model
+            effective_pace = pace if pace is not None else self._opts.pace
+            low, high = _pace_range_for_model(effective_model)
+            if not low <= effective_pace <= high:
+                raise ValueError(
+                    f"Pace {effective_pace} is invalid for {effective_model}: "
+                    f"must be between {low} and {high}."
+                )
+
         if target_language_code is not None:
             if not target_language_code.strip():
                 raise ValueError("Target language code cannot be empty")
@@ -812,16 +826,6 @@ class TTS(tts.TTS):
                         f"Speaker '{self._opts.speaker}' incompatible with {self._opts.model}. "
                         f"Compatible speakers: {', '.join(compatible_speakers)}"
                     )
-            # The retained pace may be out of range for the new model (e.g. 2.5
-            # carried over from bulbul:v2 to bulbul:v3); revalidate it so the
-            # next request doesn't fail with an API error.
-            low, high = _pace_range_for_model(self._opts.model)
-            if not low <= self._opts.pace <= high:
-                raise ValueError(
-                    f"Pace {self._opts.pace} is invalid for {self._opts.model}: "
-                    f"must be between {low} and {high}. Call update_options(pace=...) "
-                    "with a valid value."
-                )
         if speaker is not None:
             if not speaker.strip():
                 raise ValueError("Speaker cannot be empty")

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -99,6 +99,22 @@ _CODEC_TO_MIME: dict[str, str] = {
 
 _TELEPHONY_CODECS: frozenset[str] = frozenset({"mulaw", "alaw"})
 
+# Sample rates accepted by bulbul:v3 via the REST API only. Both HTTP
+# streaming and WebSocket streaming are capped at 24 kHz.
+_REST_ONLY_SAMPLE_RATES: frozenset[int] = frozenset({32000, 44100, 48000})
+
+# `pace` range per model: 0.5-2.0 on v3/v3-beta, 0.3-3.0 on v2.
+_PACE_RANGE_BY_MODEL: dict[str, tuple[float, float]] = {
+    "bulbul:v2": (0.3, 3.0),
+    "bulbul:v3-beta": (0.5, 2.0),
+    "bulbul:v3": (0.5, 2.0),
+}
+_DEFAULT_PACE_RANGE: tuple[float, float] = (0.5, 2.0)
+
+
+def _pace_range_for_model(model: str) -> tuple[float, float]:
+    return _PACE_RANGE_BY_MODEL.get(model, _DEFAULT_PACE_RANGE)
+
 
 def _codec_to_mime_type(codec: str) -> str:
     """Map a Sarvam output_audio_codec value to the MIME type the framework decoder expects."""
@@ -216,6 +232,16 @@ SarvamTTSSpeakers = Literal[
     "tanya",
     "shruti",
     "kavitha",
+    # bulbul:v3 Male (extended set)
+    "anand",
+    "tarun",
+    "sunny",
+    "mani",
+    "gokul",
+    "vijay",
+    "mohit",
+    "rehan",
+    "soham",
 ]
 
 # Model-Speaker compatibility mapping
@@ -294,8 +320,6 @@ MODEL_SPEAKER_COMPATIBILITY = {
             "priya",
             "neha",
             "roopa",
-            "amelia",
-            "sophia",
             "suhani",
             "rupali",
             "tanya",
@@ -317,6 +341,15 @@ MODEL_SPEAKER_COMPATIBILITY = {
             "aayan",
             "ashutosh",
             "advait",
+            "anand",
+            "tarun",
+            "sunny",
+            "mani",
+            "gokul",
+            "vijay",
+            "mohit",
+            "rehan",
+            "soham",
         ],
         "all": [
             "shubh",
@@ -342,13 +375,20 @@ MODEL_SPEAKER_COMPATIBILITY = {
             "aayan",
             "ashutosh",
             "advait",
-            "amelia",
-            "sophia",
             "suhani",
             "rupali",
             "tanya",
             "shruti",
             "kavitha",
+            "anand",
+            "tarun",
+            "sunny",
+            "mani",
+            "gokul",
+            "vijay",
+            "mohit",
+            "rehan",
+            "soham",
         ],
     },
 }
@@ -389,7 +429,7 @@ class SarvamTTSOptions:
         text: The text to synthesize (will be provided by stream adapter)
         speaker: Voice to use for synthesis
         pitch: Voice pitch adjustment (-0.75 to 0.75)
-        pace: Speech rate multiplier (0.3 to 3.0)
+        pace: Speech rate multiplier (0.5 to 2.0 for v3/v3-beta, 0.3 to 3.0 for v2)
         loudness: Volume multiplier (0.5 to 2.0)
         temperature: Sampling temperature (0.01 to 2.0), used for v3 and v3-beta
         output_audio_bitrate: Output audio bitrate
@@ -441,7 +481,7 @@ class TTS(tts.TTS):
         speech_sample_rate: Audio sample rate in Hz
         num_channels: Number of audio channels (Sarvam outputs mono)
         pitch: Voice pitch adjustment (-0.75 to 0.75) - only supported in v2 for now
-        pace: Speech rate multiplier (0.3 to 3.0)
+        pace: Speech rate multiplier (0.5 to 2.0 for v3/v3-beta, 0.3 to 3.0 for v2)
         loudness: Volume multiplier (0.5 to 2.0) - only supported in v2 for now
         temperature: Sampling temperature (0.01 to 2.0), only used in v3 and v3-beta
         dict_id: Custom pronunciation dictionary ID (bulbul:v3 only)
@@ -514,8 +554,9 @@ class TTS(tts.TTS):
                 pitch,
             )
             pitch = max(-0.75, min(0.75, pitch))
-        if not 0.3 <= pace <= 3.0:
-            raise ValueError("Pace must be between 0.3 and 3.0")
+        if not _pace_range_for_model(model)[0] <= pace <= _pace_range_for_model(model)[1]:
+            low, high = _pace_range_for_model(model)
+            raise ValueError(f"Pace must be between {low} and {high} for {model}")
         if not 0.5 <= loudness <= 2.0:
             raise ValueError("Loudness must be between 0.5 and 2.0")
         if not 0.01 <= temperature <= 2.0:
@@ -795,8 +836,9 @@ class TTS(tts.TTS):
             self._opts.pitch = pitch
 
         if pace is not None:
-            if not 0.3 <= pace <= 3.0:
-                raise ValueError("Pace must be between 0.3 and 3.0")
+            low, high = _pace_range_for_model(self._opts.model)
+            if not low <= pace <= high:
+                raise ValueError(f"Pace must be between {low} and {high} for {self._opts.model}")
             self._opts.pace = pace
 
         if loudness is not None:
@@ -860,6 +902,12 @@ class TTS(tts.TTS):
         self, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS
     ) -> SynthesizeStream:
         """Create a streaming TTS session."""
+        if self._opts.speech_sample_rate in _REST_ONLY_SAMPLE_RATES:
+            raise ValueError(
+                f"speech_sample_rate {self._opts.speech_sample_rate} Hz is only supported by the "
+                "REST API; streaming supports 8000, 16000, 22050 and 24000 Hz. Use synthesize() "
+                "for this sample rate, or lower it for stream()."
+            )
         stream = SynthesizeStream(tts=self, conn_options=conn_options)
         self._streams.add(stream)
         return stream

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -812,6 +812,16 @@ class TTS(tts.TTS):
                         f"Speaker '{self._opts.speaker}' incompatible with {self._opts.model}. "
                         f"Compatible speakers: {', '.join(compatible_speakers)}"
                     )
+            # The retained pace may be out of range for the new model (e.g. 2.5
+            # carried over from bulbul:v2 to bulbul:v3); revalidate it so the
+            # next request doesn't fail with an API error.
+            low, high = _pace_range_for_model(self._opts.model)
+            if not low <= self._opts.pace <= high:
+                raise ValueError(
+                    f"Pace {self._opts.pace} is invalid for {self._opts.model}: "
+                    f"must be between {low} and {high}. Call update_options(pace=...) "
+                    "with a valid value."
+                )
         if speaker is not None:
             if not speaker.strip():
                 raise ValueError("Speaker cannot be empty")

--- a/tests/test_plugin_sarvam_tts.py
+++ b/tests/test_plugin_sarvam_tts.py
@@ -1,0 +1,73 @@
+"""Unit tests for Sarvam TTS plugin validation."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from livekit.plugins.sarvam import tts as sarvam_tts
+
+pytestmark = pytest.mark.unit
+
+
+def _tts(**kwargs: object) -> sarvam_tts.TTS:
+    return sarvam_tts.TTS(api_key="test-key", **kwargs)
+
+
+def test_v3_accepts_extended_speakers() -> None:
+    # Speakers documented by Bulbul v3 but previously rejected by the plugin.
+    for speaker in ("anand", "tarun", "sunny", "mani", "gokul", "vijay", "mohit", "rehan", "soham"):
+        assert _tts(model="bulbul:v3", speaker=speaker)._opts.speaker == speaker
+
+
+def test_v3_rejects_speakers_the_api_does_not_recognize() -> None:
+    with pytest.raises(ValueError, match="amelia"):
+        _tts(model="bulbul:v3", speaker="amelia")
+    with pytest.raises(ValueError, match="sophia"):
+        _tts(model="bulbul:v3", speaker="sophia")
+
+
+def test_v3_beta_still_accepts_international_speakers() -> None:
+    assert _tts(model="bulbul:v3-beta", speaker="amelia")._opts.speaker == "amelia"
+
+
+def test_pace_range_for_v2() -> None:
+    # 0.3-3.0 is valid on bulbul:v2
+    assert _tts(model="bulbul:v2", pace=0.3)._opts.pace == 0.3
+    assert _tts(model="bulbul:v2", pace=3.0)._opts.pace == 3.0
+
+
+def test_pace_range_for_v3() -> None:
+    # 0.5-2.0 on v3: values valid for v2 must be rejected before hitting the API
+    with pytest.raises(ValueError, match="between 0.5 and 2.0"):
+        _tts(model="bulbul:v3", pace=2.5)
+    with pytest.raises(ValueError, match="between 0.5 and 2.0"):
+        _tts(model="bulbul:v3-beta", pace=0.4)
+
+    assert _tts(model="bulbul:v3", pace=0.5)._opts.pace == 0.5
+    assert _tts(model="bulbul:v3", pace=2.0)._opts.pace == 2.0
+
+
+def test_update_options_validates_pace_per_model() -> None:
+    instance = _tts(model="bulbul:v3")
+    with pytest.raises(ValueError, match="between 0.5 and 2.0"):
+        instance.update_options(pace=2.5)
+
+
+def test_stream_rejects_rest_only_sample_rates() -> None:
+    # 32/44.1/48 kHz are REST-only; streaming must fail locally with a clear
+    # error instead of an opaque server error frame mid-session.
+    instance = _tts(model="bulbul:v3", speech_sample_rate=48000)
+    with pytest.raises(ValueError, match="REST API"):
+        instance.stream()
+
+
+def test_stream_allows_streaming_sample_rates() -> None:
+    async def _create_and_close(rate: int) -> None:
+        instance = _tts(model="bulbul:v3", speech_sample_rate=rate)
+        instance.stream()
+        await instance.aclose()
+
+    for rate in (8000, 16000, 22050, 24000):
+        asyncio.run(_create_and_close(rate))

--- a/tests/test_plugin_sarvam_tts.py
+++ b/tests/test_plugin_sarvam_tts.py
@@ -58,9 +58,9 @@ def test_update_options_validates_pace_per_model() -> None:
 def test_update_options_revalidates_retained_pace_on_model_change() -> None:
     # A pace valid for v2 must be rejected when switching to v3, otherwise the
     # next request fails with a 400 from the API.
-    instance = _tts(model="bulbul:v2", speaker="shubh", pace=2.5)
+    instance = _tts(model="bulbul:v2", pace=2.5)
     with pytest.raises(ValueError, match="Pace 2.5 is invalid for bulbul:v3"):
-        instance.update_options(model="bulbul:v3")
+        instance.update_options(model="bulbul:v3", speaker="shubh")
 
 
 def test_stream_rejects_rest_only_sample_rates() -> None:

--- a/tests/test_plugin_sarvam_tts.py
+++ b/tests/test_plugin_sarvam_tts.py
@@ -55,6 +55,14 @@ def test_update_options_validates_pace_per_model() -> None:
         instance.update_options(pace=2.5)
 
 
+def test_update_options_revalidates_retained_pace_on_model_change() -> None:
+    # A pace valid for v2 must be rejected when switching to v3, otherwise the
+    # next request fails with a 400 from the API.
+    instance = _tts(model="bulbul:v2", speaker="shubh", pace=2.5)
+    with pytest.raises(ValueError, match="Pace 2.5 is invalid for bulbul:v3"):
+        instance.update_options(model="bulbul:v3")
+
+
 def test_stream_rejects_rest_only_sample_rates() -> None:
     # 32/44.1/48 kHz are REST-only; streaming must fail locally with a clear
     # error instead of an opaque server error frame mid-session.

--- a/tests/test_plugin_sarvam_tts.py
+++ b/tests/test_plugin_sarvam_tts.py
@@ -63,6 +63,26 @@ def test_update_options_revalidates_retained_pace_on_model_change() -> None:
         instance.update_options(model="bulbul:v3", speaker="shubh")
 
 
+def test_update_options_allows_atomic_model_and_pace_change() -> None:
+    # A combined update with a pace valid for the new model must succeed even
+    # though the retained pace was out of range for it.
+    instance = _tts(model="bulbul:v2", pace=2.5)
+    instance.update_options(model="bulbul:v3", speaker="shubh", pace=1.0)
+
+    assert instance._opts.model == "bulbul:v3"
+    assert instance._opts.pace == 1.0
+
+
+def test_update_options_rejection_leaves_state_untouched() -> None:
+    instance = _tts(model="bulbul:v2", pace=1.0)
+    with pytest.raises(ValueError):
+        instance.update_options(model="bulbul:v3", speaker="shubh", pace=2.5)
+
+    assert instance._opts.model == "bulbul:v2"
+    assert instance._opts.pace == 1.0
+    assert instance._opts.speaker == "anushka"
+
+
 def test_stream_rejects_rest_only_sample_rates() -> None:
     # 32/44.1/48 kHz are REST-only; streaming must fail locally with a clear
     # error instead of an opaque server error frame mid-session.


### PR DESCRIPTION
## Summary
Three fixes for divergences between the plugin's validation and what the Bulbul API actually accepts ([docs](https://docs.sarvam.ai/api/getting-started/models/bulbul)):

1. **`bulbul:v3` speakers**: accept the 9 documented voices that were previously rejected by `validate_model_speaker_compatibility` (`anand, tarun, sunny, mani, gokul, vijay, mohit, rehan, soham`) and stop offering `amelia`/`sophia`, which the API rejects with "Speaker 'amelia' is not recognized" (they remain available on `v3-beta`, where they work).
2. **REST-only sample rates**: 32000/44100/48000 Hz are REST-only per the docs; `stream()` now fails locally with a clear error instead of an opaque server error frame mid-session. `synthesize()` still accepts them.
3. **Per-model `pace` range**: validated as 0.5–2.0 on v3/v3-beta and 0.3–3.0 on v2 (both in the constructor and `update_options()\)), instead of applying the v2 range everywhere and letting `pace=2.5` on v3 fail with a 400 at request time.

Fixes #6774

## Testing
- New unit tests in `tests/test_plugin_sarvam_tts.py` covering all three behaviors.
- `uv run pytest tests/test_plugin_sarvam_tts.py` — 8 passed
- `ruff format/check` and `mypy` clean