### PR TITLE
aws: omit temperature/topP for Bedrock models that reject them

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -82,6 +82,7 @@ class LLM(llm.LLM):
         additional_request_fields: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
         cache_system: bool = False,
         cache_tools: bool = False,
+        supports_sampling_params: NotGivenOr[bool] = NOT_GIVEN,
         session: AioSession | aioboto3.Session | None = None,
     ) -> None:
         """
@@ -107,6 +108,11 @@ class LLM(llm.LLM):
             additional_request_fields (dict[str, Any], optional): Additional request fields to send to the AWS Bedrock Converse API. Defaults to None.
             cache_system (bool, optional): Caches system messages to reduce token usage. Defaults to False.
             cache_tools (bool, optional): Caches tool definitions to reduce token usage. Defaults to False.
+            supports_sampling_params (bool, optional): Explicit override for whether the model accepts
+                'temperature'/'top_p'. By default the plugin detects known-rejecting models from the
+                model ID, which cannot cover application inference-profile ARNs that hide the
+                underlying model name — set False for those profiles to have sampling parameters
+                dropped instead of triggering a ValidationException. Defaults to NOT_GIVEN (auto-detect).
             session (AioSession, optional): Optional aiobotocore session to use. Passing a legacy
                 aioboto3.Session is deprecated but still accepted.
         """  # noqa: E501
@@ -136,6 +142,11 @@ class LLM(llm.LLM):
             additional_request_fields=additional_request_fields,
             cache_system=cache_system,
             cache_tools=cache_tools,
+        )
+        self._supports_sampling_params = (
+            supports_sampling_params
+            if is_given(supports_sampling_params)
+            else not _model_rejects_sampling_params(bedrock_model)
         )
 
     @property
@@ -214,20 +225,22 @@ class LLM(llm.LLM):
         inference_config: dict[str, Any] = {}
         if is_given(self._opts.max_output_tokens):
             inference_config["maxTokens"] = self._opts.max_output_tokens
-        if _model_rejects_sampling_params(self._opts.model):
-            temperature = temperature if is_given(temperature) else self._opts.temperature
+        temperature = temperature if is_given(temperature) else self._opts.temperature
+        if not self._supports_sampling_params:
             if is_given(temperature) or is_given(self._opts.top_p):
                 # chat() runs once per turn: warn only the first time to avoid
-                # flooding the logs over a long conversation.
+                # flooding the logs over a long conversation. The model ID can
+                # contain customer data (e.g. an application inference-profile
+                # ARN), so it goes into a structured attribute, not the message.
                 if not self._sampling_params_warned:
                     logger.warning(
-                        "aws bedrock llm: model %s does not support 'temperature'/'top_p'; "
-                        "ignoring them to avoid a ValidationException",
-                        self._opts.model,
+                        "aws bedrock llm: this model does not support "
+                        "'temperature'/'top_p'; ignoring them to avoid a "
+                        "ValidationException",
+                        extra={"lk.pii.model": self._opts.model},
                     )
                     self._sampling_params_warned = True
         else:
-            temperature = temperature if is_given(temperature) else self._opts.temperature
             if is_given(temperature):
                 inference_config["temperature"] = temperature
             if is_given(self._opts.top_p):

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -39,6 +39,21 @@ if TYPE_CHECKING:
 
 DEFAULT_TEXT_MODEL = "amazon.nova-2-lite-v1:0"
 
+# Model IDs that reject ``temperature``/``topP`` in the Converse API's
+# ``inferenceConfig`` with a ValidationException ("... is deprecated for this
+# model"). Matched as case-insensitive substrings so region-prefixed IDs and
+# inference profile ARNs containing the model name are covered too.
+_MODELS_REJECTING_SAMPLING_PARAMS = (
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-sonnet-5",
+)
+
+
+def _model_rejects_sampling_params(model_id: str) -> bool:
+    lowered = model_id.lower()
+    return any(name in lowered for name in _MODELS_REJECTING_SAMPLING_PARAMS)
+
 
 @dataclass
 class _LLMOptions:
@@ -84,6 +99,8 @@ class LLM(llm.LLM):
             api_secret(str, optional): AWS secret access key
             region (str, optional): The region to use for AWS API requests. Defaults value is "us-east-1".
             temperature (float, optional): Sampling temperature for response generation. Defaults to 0.8.
+                Ignored (with a warning) for models that reject sampling parameters, e.g. Claude
+                Opus 4.7/4.8 and Sonnet 5.
             max_output_tokens (int, optional): Maximum number of tokens to generate in the output. Defaults to None.
             top_p (float, optional): The nucleus sampling probability for response generation. Defaults to None.
             tool_choice (ToolChoice, optional): Specifies whether to use tools during response generation. Defaults to "auto".
@@ -196,11 +213,20 @@ class LLM(llm.LLM):
         inference_config: dict[str, Any] = {}
         if is_given(self._opts.max_output_tokens):
             inference_config["maxTokens"] = self._opts.max_output_tokens
-        temperature = temperature if is_given(temperature) else self._opts.temperature
-        if is_given(temperature):
-            inference_config["temperature"] = temperature
-        if is_given(self._opts.top_p):
-            inference_config["topP"] = self._opts.top_p
+        if _model_rejects_sampling_params(self._opts.model):
+            temperature = temperature if is_given(temperature) else self._opts.temperature
+            if is_given(temperature) or is_given(self._opts.top_p):
+                logger.warning(
+                    "aws bedrock llm: model %s does not support 'temperature'/'top_p'; "
+                    "ignoring them to avoid a ValidationException",
+                    self._opts.model,
+                )
+        else:
+            temperature = temperature if is_given(temperature) else self._opts.temperature
+            if is_given(temperature):
+                inference_config["temperature"] = temperature
+            if is_given(self._opts.top_p):
+                inference_config["topP"] = self._opts.top_p
 
         opts["inferenceConfig"] = inference_config
         if is_given(self._opts.additional_request_fields):

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -52,6 +52,13 @@ _MODELS_REJECTING_SAMPLING_PARAMS = (
 
 def _model_rejects_sampling_params(model_id: str) -> bool:
     lowered = model_id.lower()
+    # Application inference profiles hide the underlying model behind a
+    # user-chosen name, so a substring match would both miss rejecting models
+    # and misclassify profiles merely named after one (e.g.
+    # ".../claude-opus-4-7-prod" targeting a supporting model). Never guess for
+    # those; callers can use the explicit supports_sampling_params override.
+    if "application-inference-profile" in lowered:
+        return False
     return any(name in lowered for name in _MODELS_REJECTING_SAMPLING_PARAMS)
 
 

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -46,7 +46,9 @@ DEFAULT_TEXT_MODEL = "amazon.nova-2-lite-v1:0"
 _MODELS_REJECTING_SAMPLING_PARAMS = (
     "claude-opus-4-7",
     "claude-opus-4-8",
+    "claude-opus-5",
     "claude-sonnet-5",
+    "claude-fable-5",
 )
 
 
@@ -108,7 +110,7 @@ class LLM(llm.LLM):
             region (str, optional): The region to use for AWS API requests. Defaults value is "us-east-1".
             temperature (float, optional): Sampling temperature for response generation. Defaults to 0.8.
                 Ignored (with a warning) for models that reject sampling parameters, e.g. Claude
-                Opus 4.7/4.8 and Sonnet 5.
+                Opus 4.7/4.8, Opus 5, Sonnet 5 and Fable 5.
             max_output_tokens (int, optional): Maximum number of tokens to generate in the output. Defaults to None.
             top_p (float, optional): The nucleus sampling probability for response generation. Defaults to None.
             tool_choice (ToolChoice, optional): Specifies whether to use tools during response generation. Defaults to "auto".

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -112,6 +112,7 @@ class LLM(llm.LLM):
         """  # noqa: E501
         super().__init__()
 
+        self._sampling_params_warned = False
         self._session = _resolve_session(session)
         if session is None:
             if is_given(api_key) and api_key and is_given(api_secret) and api_secret:
@@ -216,11 +217,15 @@ class LLM(llm.LLM):
         if _model_rejects_sampling_params(self._opts.model):
             temperature = temperature if is_given(temperature) else self._opts.temperature
             if is_given(temperature) or is_given(self._opts.top_p):
-                logger.warning(
-                    "aws bedrock llm: model %s does not support 'temperature'/'top_p'; "
-                    "ignoring them to avoid a ValidationException",
-                    self._opts.model,
-                )
+                # chat() runs once per turn: warn only the first time to avoid
+                # flooding the logs over a long conversation.
+                if not self._sampling_params_warned:
+                    logger.warning(
+                        "aws bedrock llm: model %s does not support 'temperature'/'top_p'; "
+                        "ignoring them to avoid a ValidationException",
+                        self._opts.model,
+                    )
+                    self._sampling_params_warned = True
         else:
             temperature = temperature if is_given(temperature) else self._opts.temperature
             if is_given(temperature):

--- a/tests/test_plugin_aws_llm.py
+++ b/tests/test_plugin_aws_llm.py
@@ -1,0 +1,49 @@
+"""Unit tests for the AWS Bedrock LLM plugin."""
+
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents.llm import ChatContext
+from livekit.plugins.aws import LLM as BedrockLLM
+
+pytestmark = pytest.mark.plugin("aws")
+
+
+async def _inference_config(model: str, **kwargs: object) -> dict:
+    instance = BedrockLLM(model=model, **kwargs)
+    stream = instance.chat(chat_ctx=ChatContext())
+    opts = stream._opts["inferenceConfig"]
+    await stream.aclose()
+    return opts
+
+
+async def test_temperature_sent_for_supporting_models() -> None:
+    config = await _inference_config("us.anthropic.claude-sonnet-4-6", temperature=0.5, top_p=0.9)
+
+    assert config["temperature"] == 0.5
+    assert config["topP"] == 0.9
+
+
+async def test_temperature_omitted_for_opus_4_7(caplog: pytest.LogCaptureFixture) -> None:
+    # Claude Opus 4.7 rejects `temperature` with a ValidationException
+    # ("`temperature` is deprecated for this model").
+    config = await _inference_config("us.anthropic.claude-opus-4-7", temperature=0.5, top_p=0.9)
+
+    assert "temperature" not in config
+    assert "topP" not in config
+
+
+async def test_temperature_omitted_for_region_prefix_and_arn() -> None:
+    for model in (
+        "anthropic.claude-opus-4-8",
+        "eu.anthropic.claude-opus-4-7",
+        "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-5",
+    ):
+        config = await _inference_config(model, temperature=0.5)
+        assert "temperature" not in config
+
+
+async def test_default_model_still_receives_temperature() -> None:
+    config = await _inference_config("amazon.nova-2-lite-v1:0", temperature=0.7)
+    assert config["temperature"] == 0.7

--- a/tests/test_plugin_aws_llm.py
+++ b/tests/test_plugin_aws_llm.py
@@ -51,9 +51,10 @@ async def test_sampling_params_warning_logged_once(caplog: pytest.LogCaptureFixt
 
 
 async def test_explicit_override_for_opaque_inference_profiles() -> None:
-    # An application inference-profile ARN can hide the underlying model name,
-    # so auto-detection can't cover it and sampling params are sent by default;
-    # supports_sampling_params=False forces them to be dropped.
+    # An application inference-profile ARN can hide the underlying model name;
+    # auto-detection deliberately never guesses for those (the profile name may
+    # merely reference a model, or target an unrelated one), so sampling params
+    # are sent by default and supports_sampling_params=False forces them out.
     arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-agent-llm"
     config = await _inference_config(arn, temperature=0.5, top_p=0.9)
     assert config["temperature"] == 0.5
@@ -70,6 +71,16 @@ async def test_explicit_override_for_opaque_inference_profiles() -> None:
         temperature=0.5,
         supports_sampling_params=True,
     )
+    assert config["temperature"] == 0.5
+
+
+async def test_application_profile_named_after_model_is_not_misclassified() -> None:
+    # A supporting-model application profile that merely references a rejecting
+    # model name must keep its explicitly configured sampling parameters.
+    arn = (
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/claude-opus-4-7-prod"
+    )
+    config = await _inference_config(arn, temperature=0.5)
     assert config["temperature"] == 0.5
 
 

--- a/tests/test_plugin_aws_llm.py
+++ b/tests/test_plugin_aws_llm.py
@@ -34,6 +34,18 @@ async def test_temperature_omitted_for_opus_4_7(caplog: pytest.LogCaptureFixture
     assert "topP" not in config
 
 
+async def test_sampling_params_warning_logged_once(caplog: pytest.LogCaptureFixture) -> None:
+    # chat() runs once per turn; the warning must not repeat every turn.
+    with caplog.at_level("WARNING"):
+        instance = BedrockLLM(model="us.anthropic.claude-opus-4-8", temperature=0.5)
+        for _ in range(3):
+            stream = instance.chat(chat_ctx=ChatContext())
+            await stream.aclose()
+
+    warnings = [r for r in caplog.records if "does not support" in r.message]
+    assert len(warnings) == 1
+
+
 async def test_temperature_omitted_for_region_prefix_and_arn() -> None:
     for model in (
         "anthropic.claude-opus-4-8",

--- a/tests/test_plugin_aws_llm.py
+++ b/tests/test_plugin_aws_llm.py
@@ -1,4 +1,4 @@
-"""Unit tests for the AWS Bedrock LLM plugin."""
+"""Hermetic unit tests for the AWS Bedrock LLM plugin (no AWS access needed)."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import pytest
 from livekit.agents.llm import ChatContext
 from livekit.plugins.aws import LLM as BedrockLLM
 
-pytestmark = pytest.mark.plugin("aws")
+pytestmark = pytest.mark.unit
 
 
 async def _inference_config(model: str, **kwargs: object) -> dict:
@@ -44,6 +44,33 @@ async def test_sampling_params_warning_logged_once(caplog: pytest.LogCaptureFixt
 
     warnings = [r for r in caplog.records if "does not support" in r.message]
     assert len(warnings) == 1
+    # the model ID may contain customer data (inference-profile ARNs) and must
+    # stay out of the message body
+    assert "claude-opus-4-8" not in warnings[0].getMessage()
+    assert warnings[0].__dict__.get("lk.pii.model") == "us.anthropic.claude-opus-4-8"
+
+
+async def test_explicit_override_for_opaque_inference_profiles() -> None:
+    # An application inference-profile ARN can hide the underlying model name,
+    # so auto-detection can't cover it and sampling params are sent by default;
+    # supports_sampling_params=False forces them to be dropped.
+    arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-agent-llm"
+    config = await _inference_config(arn, temperature=0.5, top_p=0.9)
+    assert config["temperature"] == 0.5
+
+    config = await _inference_config(
+        arn, temperature=0.5, top_p=0.9, supports_sampling_params=False
+    )
+    assert "temperature" not in config
+    assert "topP" not in config
+
+    # an explicit True keeps them even for known-rejecting models
+    config = await _inference_config(
+        "us.anthropic.claude-opus-4-7",
+        temperature=0.5,
+        supports_sampling_params=True,
+    )
+    assert config["temperature"] == 0.5
 
 
 async def test_temperature_omitted_for_region_prefix_and_arn() -> None:


### PR DESCRIPTION
## Summary

Claude Opus 4.7/4.8 and Sonnet 5 on Bedrock reject any Converse request whose `inferenceConfig` contains `temperature` or `topP` with:

```
ValidationException: `temperature` is deprecated for this model.
```

The plugin now detects these models (case-insensitive substring match, so region-prefixed IDs like `us.anthropic.claude-opus-4-7` and inference profile ARNs containing the model name are covered) and omits both sampling parameters, logging a warning when values were explicitly configured. Other models are unaffected.

Fixes livekit/agents#6581

## Testing

* New unit tests in `tests/test_plugin_aws_llm.py`: temperature/topP sent for supporting models, omitted for opus-4-7/4-8 and sonnet-5 across ID forms, default model unaffected.
* `uv run pytest tests/test_plugin_aws_llm.py` — 4 passed
* `ruff format/check` clean; `mypy -p livekit.plugins.aws` shows only a pre-existing missing-import note on clean main (unrelated file)