### PR TITLE
fix(soniox): keep source_texts when endpoint arrives before translation

### DIFF
--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/stt.py
@@ -449,49 +449,55 @@ class SpeechStream(stt.SpeechStream):
 
         def send_endpoint_transcript() -> None:
             nonlocal is_speaking
-            if final.text:
-                # Translation mode determines the role of each accumulator:
-                # when on, `final_original` carries the source side and
-                # `final` carries the target side -- even across flush windows
-                # where the originals were finalized in a prior message and
-                # only translation tokens land in this one. When translation
-                # is off, `final` IS the source side and `final_original`
-                # stays empty.
-                src_segs, tgt_segs = (
-                    (final_original._lang_segments, final._lang_segments)
-                    if is_translation_mode
-                    else (final._lang_segments, [])
-                )
-                source_languages, source_texts = _lang_segments_to_fields(src_segs)
-                target_languages, target_texts = _lang_segments_to_fields(tgt_segs)
-                self._event_ch.send_nowait(
-                    stt.SpeechEvent(
-                        type=SpeechEventType.FINAL_TRANSCRIPT,
-                        alternatives=[
-                            final.to_speech_data(
-                                self.start_time_offset,
-                                source_languages=source_languages,
-                                source_texts=source_texts,
-                                target_languages=target_languages,
-                                target_texts=target_texts,
-                            )
-                        ],
-                    )
-                )
-                self._event_ch.send_nowait(
-                    stt.SpeechEvent(
-                        type=SpeechEventType.END_OF_SPEECH,
-                    )
-                )
+            if not final.text:
+                # Keep `final_original`. In translation mode an <end>/<fin>
+                # can land between the source tokens and their translation;
+                # resetting here would drop `source_texts` from the pairing
+                # that the next frame is about to complete. Outside
+                # translation mode `final_original` stays empty, so this is
+                # a no-op.
+                return
 
-                # Reset buffers.
-                final.reset()
-                final_original.reset()
+            # Translation mode determines the role of each accumulator:
+            # when on, `final_original` carries the source side and
+            # `final` carries the target side -- even across flush windows
+            # where the originals were finalized in a prior message and
+            # only translation tokens land in this one. When translation
+            # is off, `final` IS the source side and `final_original`
+            # stays empty.
+            src_segs, tgt_segs = (
+                (final_original._lang_segments, final._lang_segments)
+                if is_translation_mode
+                else (final._lang_segments, [])
+            )
+            source_languages, source_texts = _lang_segments_to_fields(src_segs)
+            target_languages, target_texts = _lang_segments_to_fields(tgt_segs)
+            self._event_ch.send_nowait(
+                stt.SpeechEvent(
+                    type=SpeechEventType.FINAL_TRANSCRIPT,
+                    alternatives=[
+                        final.to_speech_data(
+                            self.start_time_offset,
+                            source_languages=source_languages,
+                            source_texts=source_texts,
+                            target_languages=target_languages,
+                            target_texts=target_texts,
+                        )
+                    ],
+                )
+            )
+            self._event_ch.send_nowait(
+                stt.SpeechEvent(
+                    type=SpeechEventType.END_OF_SPEECH,
+                )
+            )
 
-                # Reset speaking state, so the next transcript will send START_OF_SPEECH again.
-                is_speaking = False
-            else:
-                final_original.reset()
+            # Reset buffers.
+            final.reset()
+            final_original.reset()
+
+            # Reset speaking state, so the next transcript will send START_OF_SPEECH again.
+            is_speaking = False
 
         if not self._ws:
             return

--- a/tests/test_plugin_soniox_stt.py
+++ b/tests/test_plugin_soniox_stt.py
@@ -357,6 +357,60 @@ async def test_final_transcript_one_way_translation_single_target_run():
     assert sd.target_texts == ["Hola mundo."]
 
 
+# --- Endpoint marker between original and translation ----------------------
+
+
+FIN_TOKEN_FINAL: dict[str, Any] = {"text": "<fin>", "is_final": True}
+
+
+async def _run_translation_split_across_frames(gap_marker: dict[str, Any] | None):
+    """Original tokens in frame 1, translation (+ <end>) in frame 2.
+
+    `gap_marker` is appended to frame 1 to simulate an <end>/<fin> landing
+    before the translation has been produced.
+    """
+    from livekit.plugins.soniox.stt import TranslationConfig
+
+    stream = _make_stream(translation=TranslationConfig(type="one_way", target_language="es"))
+    first: list[dict[str, Any]] = [
+        _final_token("Hello world.", "en", translation_status="original")
+    ]
+    if gap_marker is not None:
+        first.append(gap_marker)
+    messages = [
+        {"tokens": first, "total_audio_proc_ms": 500},
+        {
+            "tokens": [
+                _final_token("Hola mundo.", "es", translation_status="translation"),
+                END_TOKEN_FINAL,
+            ],
+            "total_audio_proc_ms": 700,
+        },
+    ]
+    events = await _drive_recv(stream, messages, expect_events=4, timeout=2.0)
+    final = next(e for e in events if e.type == SpeechEventType.FINAL_TRANSCRIPT)
+    return final.alternatives[0]
+
+
+@pytest.mark.parametrize(
+    "gap_marker",
+    [None, END_TOKEN_FINAL, FIN_TOKEN_FINAL],
+    ids=["no-marker", "end", "fin"],
+)
+async def test_translation_keeps_source_when_endpoint_lands_in_the_gap(
+    gap_marker: dict[str, Any] | None,
+):
+    """An <end>/<fin> between the original and its translation must not drop
+    the pending source side. `send_endpoint_transcript()` used to reset
+    `final_original` whenever `final.text` was still empty."""
+    sd = await _run_translation_split_across_frames(gap_marker)
+    assert sd.text == "Hola mundo."
+    assert sd.source_languages == [LanguageCode("en")]
+    assert sd.source_texts == ["Hello world."]
+    assert sd.target_languages == [LanguageCode("es")]
+    assert sd.target_texts == ["Hola mundo."]
+
+
 # --- "none" untranslated chunk ---------------------------------------------
 
 


### PR DESCRIPTION
Fixes #6887.

**Problem**

In translation mode, `final_original` holds the source tokens and `final` holds the translation. That pairing is supposed to survive across frames when the originals are finalized first and the translation arrives later.

If an `<end>` or `<fin>` lands in that gap, `send_endpoint_transcript()` saw empty `final.text` and took the `else` branch, which reset `final_original`. The next frame still emitted `FINAL_TRANSCRIPT` for the translation, but `source_texts` / `source_languages` were gone.

Outside translation mode this was a no-op (`final_original` stays empty), so the reset only hurt the translated path.

**Fix**

Stop resetting `final_original` when there is nothing to emit yet. The pending source side is kept until the translation arrives and the two are paired as usual.

I went with this over emitting a source-only final, because a lagged translation would otherwise produce two finals for one utterance.

**Test**

Added a fake-WS case (same harness as the existing Soniox STT tests) for no marker / `<end>` / `<fin>` in the gap. All three now keep `source_texts=['Hello world.']` next to `target_texts=['Hola mundo.']`.

```
uv run pytest tests/test_plugin_soniox_stt.py --plugin soniox
# 31 passed
```