### PR TITLE
feat(voice): add pre-execution tool policy hook

### DIFF
--- a/livekit-agents/livekit/agents/llm/async_toolset.py
+++ b/livekit-agents/livekit/agents/llm/async_toolset.py
@@ -4,8 +4,10 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from ..log import logger
+from ..types import NOT_GIVEN
 from ..utils.misc import is_given
 from ..voice.tool_executor import (
+    BeforeExecuteCallback,
     ToolHandlingOptions,
     _resolve_async_tool_options,
     _ToolExecutor,
@@ -70,6 +72,11 @@ class AsyncToolset(Toolset):
             )
 
         super().__init__(id=id, tools=tools)
+        self._before_execute_override = (
+            tool_handling.get("before_execute", NOT_GIVEN)
+            if tool_handling is not None
+            else NOT_GIVEN
+        )
         self._async_tool_options_override = (
             tool_handling.get("async_options") if tool_handling is not None else None
         )
@@ -79,6 +86,16 @@ class AsyncToolset(Toolset):
         """Bind this toolset to a scope. ``activity=None`` makes it session-scoped
         (replies survive handoff); otherwise replies stay with ``activity``'s agent."""
         self._executor.set_owning_activity(activity)
+
+        if is_given(self._before_execute_override):
+            before_execute: BeforeExecuteCallback | None = self._before_execute_override
+        elif activity is not None and is_given(
+            agent_before_execute := getattr(activity._agent, "_before_execute", NOT_GIVEN)
+        ):
+            before_execute = agent_before_execute
+        else:
+            before_execute = getattr(session, "_before_execute", None)
+        self._executor.set_before_execute(before_execute)
 
         if self._async_tool_options_override is not None:
             resolved = _resolve_async_tool_options(self._async_tool_options_override)

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -110,7 +110,10 @@ class Agent:
         self._max_endpointing_delay = endpointing.get("max_delay", NOT_GIVEN)
         self._turn_handling = turn_handling
         # stored unresolved so the resolution chain can tell "set on agent" from "fall
-        # back to session"; async_options absent on a given tool_handling means NOT_GIVEN
+        # back to session"; absent tool-handling keys mean NOT_GIVEN
+        self._before_execute = (
+            tool_handling.get("before_execute", NOT_GIVEN) if is_given(tool_handling) else NOT_GIVEN
+        )
         self._async_tool_options = (
             tool_handling.get("async_options", NOT_GIVEN) if is_given(tool_handling) else NOT_GIVEN
         )

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -260,8 +260,15 @@ class AgentActivity(RecognitionHooks):
             activity_options = _resolve_async_tool_options(self._agent._async_tool_options)
         else:
             activity_options = self._session._async_tool_options
+        before_execute = (
+            self._agent._before_execute
+            if is_given(self._agent._before_execute)
+            else self._session._before_execute
+        )
         self._tool_executor = _ToolExecutor(
-            owning_activity=self, async_tool_options=activity_options
+            owning_activity=self,
+            async_tool_options=activity_options,
+            before_execute=before_execute,
         )
 
         self._user_turn_exceeded_atask: asyncio.Task[None] | None = None

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -434,7 +434,10 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
             tools (list[llm.FunctionTool | llm.RawFunctionTool], optional): List of
                 tools shared by every agent in the agent session.
             tool_handling (ToolHandlingOptions, optional): Tool handling configuration.
-                ``tool_handling["async_options"]`` holds prompt templates for ``ctx.update()`` /
+                ``tool_handling["before_execute"]`` can asynchronously allow or reject
+                a resolved function call immediately before its body runs; raise
+                ``ToolError`` from the hook to reject it. ``tool_handling["async_options"]``
+                holds prompt templates for ``ctx.update()`` /
                 duplicate-handling / coalesced replies. Unspecified keys keep their defaults;
                 can be overridden per-``Agent`` or per-``AsyncToolset``.
             mcp_servers (list[mcp.MCPServer], optional): List of MCP servers
@@ -630,6 +633,9 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                 "and will be removed in a future version. Use `MCPToolset` instead."
             )
         self._tools = tools if is_given(tools) else []
+        self._before_execute = (
+            tool_handling.get("before_execute") if is_given(tool_handling) else None
+        )
         self._async_tool_options = _resolve_async_tool_options(
             tool_handling.get("async_options") if is_given(tool_handling) else None
         )

--- a/livekit-agents/livekit/agents/voice/tool_executor.py
+++ b/livekit-agents/livekit/agents/voice/tool_executor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import weakref
-from collections.abc import Callable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -114,6 +114,18 @@ class AsyncToolOptions(TypedDict, total=False):
     """Instruction for the deferred reply when newer items came after the pending update."""
 
 
+BeforeExecuteCallback = Callable[
+    ["RunContext", FunctionTool | RawFunctionTool, dict[str, Any]], Awaitable[None]
+]
+"""Async policy callback invoked immediately before a function tool runs.
+
+The callback receives the run context, the resolved function tool, and a copy of the
+parsed JSON arguments. Return normally to allow execution. Raise :class:`ToolError`
+to reject the call (or raise another exception to report a policy failure); the
+underlying tool is not invoked when the callback raises.
+"""
+
+
 class ToolHandlingOptions(TypedDict, total=False):
     """Configuration for the tool handling system.
 
@@ -126,6 +138,15 @@ class ToolHandlingOptions(TypedDict, total=False):
         )
 
     Set on ``AgentSession``, ``Agent``, or ``AsyncToolset`` (most specific wins).
+    """
+
+    before_execute: BeforeExecuteCallback | None
+    """Policy hook called after a tool call is resolved and before its body runs.
+
+    The hook receives ``(run_ctx, tool, arguments)``. Return ``None`` to proceed;
+    raise :class:`ToolError` to block the call. Hook exceptions are surfaced as the
+    tool error and never silently bypass the policy. Pass ``None`` on an agent or
+    toolset to explicitly disable an inherited hook.
     """
 
     async_options: AsyncToolOptions
@@ -271,6 +292,7 @@ class _ToolExecutor:
         *,
         owning_activity: AgentActivity | None = None,
         async_tool_options: AsyncToolOptions | None = None,
+        before_execute: BeforeExecuteCallback | None = None,
     ) -> None:
         self._running_tasks: dict[str, _RunningTask] = {}
         self._duplicate_check_lock = asyncio.Lock()
@@ -280,6 +302,7 @@ class _ToolExecutor:
 
         self._owning_activity: AgentActivity | None = owning_activity
         self._tool_options: AsyncToolOptions = _resolve_async_tool_options(async_tool_options)
+        self._before_execute = before_execute
 
     def set_owning_activity(self, activity: AgentActivity | None) -> None:
         self._owning_activity = activity
@@ -287,6 +310,10 @@ class _ToolExecutor:
     def set_tool_options(self, options: AsyncToolOptions) -> None:
         """Replace the async tool templates. Caller must pre-resolve defaults."""
         self._tool_options = options
+
+    def set_before_execute(self, callback: BeforeExecuteCallback | None) -> None:
+        """Set the policy hook used before each function tool invocation."""
+        self._before_execute = callback
 
     @property
     def has_running_tasks(self) -> bool:
@@ -347,6 +374,11 @@ class _ToolExecutor:
         # derives the call's single terminal entry from how the task ended
         async def _execute_tool() -> Any:
             try:
+                if self._before_execute is not None:
+                    # Policy hooks are observers in the first version: pass a copy so
+                    # argument transformation cannot accidentally change execution.
+                    await self._before_execute(run_ctx, tool, dict(raw_arguments))
+
                 fnc_args, fnc_kwargs = prepare_function_arguments(
                     fnc=tool, json_arguments=raw_arguments, call_ctx=run_ctx
                 )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1229,6 +1229,86 @@ class TestAsyncToolOptions:
         ts._attach_activity(activity=activity, session=session)
         assert ts._executor._tool_options["update_template"] == "session"
 
+    def test_toolset_before_execute_override_wins(self):
+        from livekit.agents.llm.async_toolset import AsyncToolset
+        from livekit.agents.voice.tool_executor import _resolve_async_tool_options
+
+        async def session_hook(_ctx, _tool, _arguments):
+            pass
+
+        async def agent_hook(_ctx, _tool, _arguments):
+            pass
+
+        async def toolset_hook(_ctx, _tool, _arguments):
+            pass
+
+        class _Session:
+            _async_tool_options = _resolve_async_tool_options({"update_template": "session"})
+            _before_execute = staticmethod(session_hook)
+
+        class _Agent:
+            _async_tool_options = {"update_template": "agent"}
+            _before_execute = staticmethod(agent_hook)
+
+        class _Activity:
+            _agent = _Agent()
+
+        ts = AsyncToolset(
+            id="t",
+            tools=[mock_tool_1],
+            tool_handling={"before_execute": toolset_hook},
+        )
+        ts._attach_activity(activity=_Activity(), session=_Session())
+        assert ts._executor._before_execute is toolset_hook
+
+    def test_toolset_inherits_agent_before_execute(self):
+        from livekit.agents.llm.async_toolset import AsyncToolset
+        from livekit.agents.voice.tool_executor import _resolve_async_tool_options
+
+        async def session_hook(_ctx, _tool, _arguments):
+            pass
+
+        async def agent_hook(_ctx, _tool, _arguments):
+            pass
+
+        class _Session:
+            _async_tool_options = _resolve_async_tool_options({"update_template": "session"})
+            _before_execute = staticmethod(session_hook)
+
+        class _Agent:
+            _async_tool_options = {"update_template": "agent"}
+            _before_execute = staticmethod(agent_hook)
+
+        class _Activity:
+            _agent = _Agent()
+
+        ts = AsyncToolset(id="t", tools=[mock_tool_1])
+        ts._attach_activity(activity=_Activity(), session=_Session())
+        assert ts._executor._before_execute is agent_hook
+
+    def test_toolset_inherits_session_before_execute(self):
+        from livekit.agents.llm.async_toolset import AsyncToolset
+        from livekit.agents.types import NOT_GIVEN
+        from livekit.agents.voice.tool_executor import _resolve_async_tool_options
+
+        async def session_hook(_ctx, _tool, _arguments):
+            pass
+
+        class _Session:
+            _async_tool_options = _resolve_async_tool_options({"update_template": "session"})
+            _before_execute = staticmethod(session_hook)
+
+        class _Agent:
+            _async_tool_options = {"update_template": "agent"}
+            _before_execute = NOT_GIVEN
+
+        class _Activity:
+            _agent = _Agent()
+
+        ts = AsyncToolset(id="t", tools=[mock_tool_1])
+        ts._attach_activity(activity=_Activity(), session=_Session())
+        assert ts._executor._before_execute is session_hook
+
     def test_session_scoped_toolset_skips_agent(self):
         # _attach_activity(activity=None) marks the toolset as session-scoped;
         # agent options are ignored even if present.
@@ -1283,6 +1363,15 @@ class TestAsyncToolOptions:
         # other keys fall back to defaults, not to anything else
         assert "{function_name}" in session._async_tool_options["duplicate_reject_template"]
 
+    def test_session_stores_before_execute_hook(self):
+        from livekit.agents.voice.agent_session import AgentSession
+
+        async def hook(_ctx, _tool, _arguments):
+            pass
+
+        session = AgentSession(tool_handling={"before_execute": hook})
+        assert session._before_execute is hook
+
     def test_agent_stores_raw_options(self):
         from livekit.agents.utils.misc import is_given
         from livekit.agents.voice.agent import Agent
@@ -1293,6 +1382,17 @@ class TestAsyncToolOptions:
         )
         assert is_given(agent._async_tool_options)
         assert agent._async_tool_options["update_template"] == "from-agent"
+
+    def test_agent_stores_before_execute_hook(self):
+        from livekit.agents.utils.misc import is_given
+        from livekit.agents.voice.agent import Agent
+
+        async def hook(_ctx, _tool, _arguments):
+            pass
+
+        agent = Agent(instructions="x", tool_handling={"before_execute": hook})
+        assert is_given(agent._before_execute)
+        assert agent._before_execute is hook
 
 
 # --- helpers for executor / RunContext tests ----------------------------------
@@ -1946,6 +2046,59 @@ class TestToolExecutorLifecycle:
         await _asyncio.sleep(0)  # let _on_done fire
         assert run_ctx._executor is None
         assert run_ctx._first_update_fut is None
+
+    @pytest.mark.asyncio
+    async def test_before_execute_hook_observes_call_without_mutating_arguments(self):
+        from livekit.agents.voice.tool_executor import _ToolExecutor
+
+        seen: dict[str, Any] = {}
+        body_calls: list[str] = []
+
+        @function_tool
+        async def gated(value: str) -> str:
+            """Return the value."""
+            body_calls.append(value)
+            return value
+
+        async def before_execute(ctx, tool, arguments):
+            seen.update(ctx=ctx, tool=tool, arguments=arguments)
+            arguments["value"] = "changed by policy"
+
+        executor = _ToolExecutor(before_execute=before_execute)
+        run_ctx = _make_run_context(call_id="policy-allow", name="gated")
+        result = await executor.execute(
+            tool=gated,
+            run_ctx=run_ctx,
+            raw_arguments={"value": "allowed"},
+        )
+
+        assert result == "allowed"
+        assert seen == {"ctx": run_ctx, "tool": gated, "arguments": {"value": "changed by policy"}}
+        assert body_calls == ["allowed"]
+
+    @pytest.mark.asyncio
+    async def test_before_execute_tool_error_blocks_body(self):
+        from livekit.agents.voice.tool_executor import _ToolExecutor
+
+        body_calls = 0
+
+        @function_tool
+        async def gated() -> str:
+            """Should not run when policy blocks it."""
+            nonlocal body_calls
+            body_calls += 1
+            return "unexpected"
+
+        async def before_execute(_ctx, _tool, _arguments):
+            raise ToolError("blocked by policy")
+
+        executor = _ToolExecutor(before_execute=before_execute)
+        run_ctx = _make_run_context(call_id="policy-block", name="gated")
+        with pytest.raises(ToolError, match="blocked by policy"):
+            await executor.execute(tool=gated, run_ctx=run_ctx, raw_arguments={})
+
+        await _drain_executor(executor)
+        assert body_calls == 0
 
 
 class TestAgentSessionWaitForIdle:


### PR DESCRIPTION
Closes #6951

## Summary
- add a provider-neutral async `before_execute` hook to `ToolHandlingOptions`
- resolve the hook from session to agent to `AsyncToolset`, with explicit `None` disabling inheritance
- invoke it after tool resolution and before argument preparation/tool execution; `ToolError` or other exceptions prevent the tool body from running
- pass a read-only-at-the-boundary copy of parsed JSON arguments and add lifecycle/inheritance tests

## Verification
- `PYTHONPATH=livekit-agents uv run --no-sync pytest tests/test_tools.py -q` (121 passed)
- `uv run --no-sync ruff check ...`
- `MYPYPATH=livekit-agents uv run --no-sync --group typing mypy --explicit-package-bases --platform linux -p livekit.agents` (207 files, no issues)

No provider or network dependency was added.