### PR TITLE
fix(tts): ignore late streaming audio

### DIFF
--- a/livekit-agents/livekit/agents/tts/tts.py
+++ b/livekit-agents/livekit/agents/tts/tts.py
@@ -1267,6 +1267,9 @@ class AudioEmitter:
                         if isinstance(data, (AudioEmitter._EndSegment, AudioEmitter._FlushSegment)):
                             continue  # empty segment, ignore
 
+                        if isinstance(data, bytes):
+                            continue  # late audio from a reused connection, ignore
+
                         raise RuntimeError(
                             "start_segment() must be called before pushing audio data"
                         )

--- a/tests/test_audio_emitter.py
+++ b/tests/test_audio_emitter.py
@@ -186,6 +186,28 @@ async def test_streaming_transcripts_across_segments():
 
 
 @pytest.mark.asyncio
+async def test_streaming_ignores_late_audio_after_segment_end():
+    """Late bytes from a reused provider connection must not crash the emitter."""
+
+    def produce(e):
+        e.start_segment(segment_id="seg_0")
+        e.push(_make_pcm(SR, NC, 100))
+        e.end_segment()
+        e.push(_make_pcm(SR, NC, 100))
+
+        e.start_segment(segment_id="seg_1")
+        e.push(_make_pcm(SR, NC, 100))
+        e.end_segment()
+        e.end_input()
+
+    _, events = await _run_emitter(produce, stream=True, expect_finals=2)
+
+    assert len([event for event in events if event.is_final]) == 2
+    total = sum(event.frame.duration for event in events)
+    assert abs(total - 0.2) < 0.02
+
+
+@pytest.mark.asyncio
 async def test_pushed_duration_accurate():
     def produce(e):
         e.push(_make_pcm(SR, NC, 500))


### PR DESCRIPTION
## Summary
- ignore late audio bytes that arrive after a streaming TTS segment ends
- add a regression test covering a reused connection delivering late audio before the next segment

## Validation
- `uv run --no-sync ruff check livekit-agents/livekit/agents/tts/tts.py tests/test_audio_emitter.py` (passed)
- `uv run --no-sync ruff format --check livekit-agents/livekit/agents/tts/tts.py tests/test_audio_emitter.py` (passed)
- `git diff --check` (passed)
- `uv run pytest tests/test_audio_emitter.py -q --unit` could not run: the checkout's `.venv` has an inaccessible `lib64` link on Windows; a separate environment could not finish dependency installation because PyPI TLS handshakes failed.

Fixes #6929