### PR TITLE
fix(realtime): cancel the generation when a speech is interrupted

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3814,6 +3814,9 @@ class AgentActivity(RecognitionHooks):
                 # cancel the pending generation; the plugin emits response.cancel
                 if not generate_reply_fut.done():
                     generate_reply_fut.cancel()
+                else:
+                    # the response already landed, cancelling the future no longer reaches it
+                    self._rt_session.interrupt()
                 return
 
             try:
@@ -3909,6 +3912,41 @@ class AgentActivity(RecognitionHooks):
         )
         tool_ctx = llm.ToolContext(self.tools)
 
+        tasks: list[asyncio.Task[Any]] = []
+        tees: list[utils.aio.itertools.Tee[Any]] = []
+
+        msg_tee = utils.aio.itertools.tee(generation_ev.message_stream, 2)
+        msg_stream, msg_stream_to_drain = msg_tee
+        tees.append(msg_tee)
+
+        fnc_tee = utils.aio.itertools.tee(generation_ev.function_stream, 2)
+        fnc_stream, fnc_stream_for_tracing = fnc_tee
+        tees.append(fnc_tee)
+
+        function_calls: list[llm.FunctionCall] = []
+        generation_ended = False
+
+        async def _read_fnc_stream() -> None:
+            async for fnc in fnc_stream_for_tracing:
+                function_calls.append(fnc)
+
+        async def _drain_msg_stream() -> None:
+            async for _ in msg_stream_to_drain:
+                pass
+
+        async def _watch_generation_end() -> None:
+            # the provider closes both streams when it ends the response
+            nonlocal generation_ended
+            await asyncio.gather(_drain_msg_stream(), _read_fnc_stream())
+            generation_ended = True
+
+        tasks.append(
+            asyncio.create_task(
+                _watch_generation_end(),
+                name="AgentActivity.realtime_generation.watch_end",
+            )
+        )
+
         authorization_tasks: list[asyncio.Future[Any]] = [
             asyncio.ensure_future(speech_handle._wait_for_authorization()),
             asyncio.ensure_future(self._authorization_allowed.wait()),
@@ -3919,7 +3957,12 @@ class AgentActivity(RecognitionHooks):
         speech_handle._clear_authorization()
 
         if speech_handle.interrupted:
-            await utils.aio.cancel_and_wait(*authorization_tasks)
+            # nothing was played, but the response may still be generating server-side
+            if not generation_ended:
+                self._rt_session.interrupt()
+            await utils.aio.cancel_and_wait(*authorization_tasks, *tasks)
+            for tee in tees:
+                await tee.aclose()
             current_span.set_attribute(trace_types.ATTR_SPEECH_INTERRUPTED, True)
             return  # TODO(theomonnom): remove the message from the serverside history
 
@@ -3958,9 +4001,6 @@ class AgentActivity(RecognitionHooks):
                 self._audio_recognition._on_start_of_agent_speech(started_at=started_speaking_at)
             if self.interruption_enabled:
                 self._disable_vad_interruption_soon()
-
-        tasks: list[asyncio.Task[Any]] = []
-        tees: list[utils.aio.itertools.Tee[Any]] = []
 
         read_transcript_from_tts = False
 
@@ -4051,7 +4091,7 @@ class AgentActivity(RecognitionHooks):
 
         @utils.log_exceptions(logger=logger)
         async def _process_messages() -> None:
-            async for msg in generation_ev.message_stream:
+            async for msg in msg_stream:
                 if speech_handle.interrupted:
                     # remaining messages are left out of message_outputs so
                     # update_chat_ctx below removes them server-side.
@@ -4065,23 +4105,6 @@ class AgentActivity(RecognitionHooks):
             _process_messages(), name="AgentActivity.realtime_generation.process_messages"
         )
         tasks.append(process_msg_task)
-
-        # read function calls
-        fnc_tee = utils.aio.itertools.tee(generation_ev.function_stream, 2)
-        fnc_stream, fnc_stream_for_tracing = fnc_tee
-        tees.append(fnc_tee)
-        function_calls: list[llm.FunctionCall] = []
-
-        async def _read_fnc_stream() -> None:
-            async for fnc in fnc_stream_for_tracing:
-                function_calls.append(fnc)
-
-        tasks.append(
-            asyncio.create_task(
-                _read_fnc_stream(),
-                name="AgentActivity.realtime_generation.read_fnc_stream",
-            )
-        )
 
         # messages in RunResult are ordered by the `created_at` field
         def _tool_execution_started_cb(fnc_call: llm.FunctionCall) -> None:
@@ -4107,6 +4130,10 @@ class AgentActivity(RecognitionHooks):
         )
 
         await speech_handle.wait_if_not_interrupted([*tasks])
+
+        # the cancel is session-wide, so send it only while this response is still generating
+        if speech_handle.interrupted and not generation_ended:
+            self._rt_session.interrupt()
 
         current_span.set_attribute(trace_types.ATTR_SPEECH_INTERRUPTED, speech_handle.interrupted)
         current_span.set_attribute(

--- a/tests/test_realtime_interrupt_cancels_generation.py
+++ b/tests/test_realtime_interrupt_cancels_generation.py
@@ -1,0 +1,293 @@
+"""Interrupting a realtime speech must cancel the response the model is still generating.
+
+Every interrupt path counts, not only ``AgentActivity.interrupt()``: a bare
+``SpeechHandle.interrupt()`` releases ``wait_for_playout()``, so it has to reach the provider
+too. A pause is not an interruption, so a paused playout must leave the response alone. The
+cancel is session-wide, so a speech whose generation already finished must never send one:
+it would stop the reply that took its place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import pytest
+
+from livekit import rtc
+from livekit.agents import Agent, AgentSession, function_tool, llm, utils
+from livekit.agents.voice.speech_handle import SpeechHandle
+
+from .fake_io import FakeAudioOutput
+from .fake_realtime import (
+    FakeRealtimeModel,
+    FakeRealtimeSession,
+    _audio_frame,
+    fake_capabilities,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+
+@asynccontextmanager
+async def _speaking_reply() -> AsyncIterator[
+    tuple[
+        AgentSession,
+        FakeRealtimeSession,
+        SpeechHandle,
+        FakeAudioOutput,
+        utils.aio.Chan[llm.FunctionCall],
+    ]
+]:
+    """Drive a realtime reply whose second of audio is still playing when the test resumes.
+
+    The function stream is yielded still open, so the response ends when the test closes it.
+    """
+    model = FakeRealtimeModel(capabilities=fake_capabilities())
+    audio_output = FakeAudioOutput(can_pause=True)
+
+    async with AgentSession(llm=model) as session:
+        session.output.audio = audio_output
+        await session.start(Agent(instructions="test"))
+
+        handle = session.generate_reply()
+        while not model.active_session._reply_futs:
+            await asyncio.sleep(0)
+
+        message_ch = utils.aio.Chan[llm.MessageGeneration]()
+        function_ch = utils.aio.Chan[llm.FunctionCall]()
+        text_ch = utils.aio.Chan[str]()
+        audio_ch = utils.aio.Chan[rtc.AudioFrame]()
+        modalities = asyncio.Future[list[str]]()
+        modalities.set_result(["audio", "text"])
+
+        message_ch.send_nowait(
+            llm.MessageGeneration(
+                message_id="message-id",
+                text_stream=text_ch,
+                audio_stream=audio_ch,
+                modalities=modalities,
+            )
+        )
+        message_ch.close()
+        text_ch.send_nowait("a message the app cuts short")
+        text_ch.close()
+        audio_ch.send_nowait(_audio_frame(1.0))
+        audio_ch.close()
+
+        model.active_session._reply_futs[0].set_result(
+            llm.GenerationCreatedEvent(
+                message_stream=message_ch,
+                function_stream=function_ch,
+                user_initiated=True,
+                response_id="response-id",
+            )
+        )
+
+        while audio_output._started_at is None:
+            await asyncio.sleep(0)
+
+        yield session, model.active_session, handle, audio_output, function_ch
+
+
+async def test_forced_speech_interrupt_cancels_the_response() -> None:
+    async with _speaking_reply() as (_, rt_session, handle, _, function_ch):
+        handle.interrupt(force=True)
+        await asyncio.sleep(0.1)
+
+        assert rt_session.interrupted
+
+        function_ch.close()
+        await asyncio.wait_for(handle.wait_for_playout(), timeout=5)
+
+
+async def test_interrupting_a_played_out_response_spares_the_newer_reply() -> None:
+    # the model finishes the response long before the buffered audio does, so from here on a
+    # cancel would land on whichever response the model started next
+    async with _speaking_reply() as (_, rt_session, handle, _, function_ch):
+        function_ch.close()
+        await asyncio.sleep(0.1)
+
+        handle.interrupt(force=True)
+        await asyncio.wait_for(handle.wait_for_playout(), timeout=5)
+
+        assert handle.interrupted
+        assert not rt_session.interrupted
+
+
+async def test_interrupting_a_queued_finished_response_spares_the_newer_reply() -> None:
+    # a server-initiated turn waits for the speech ahead of it to play out, and its own
+    # response can end, and be replaced, long before it is ever authorized to speak
+    async with _speaking_reply() as (session, rt_session, _, _, function_ch):
+        queued: list[SpeechHandle] = []
+        session.on("speech_created", lambda ev: queued.append(ev.speech_handle))
+
+        b_message_ch = utils.aio.Chan[llm.MessageGeneration]()
+        b_function_ch = utils.aio.Chan[llm.FunctionCall]()
+        b_message_ch.close()
+        b_function_ch.close()
+        rt_session.emit(
+            "generation_created",
+            llm.GenerationCreatedEvent(
+                message_stream=b_message_ch,
+                function_stream=b_function_ch,
+                user_initiated=False,
+                response_id="response-b",
+            ),
+        )
+        await asyncio.sleep(0.1)
+
+        assert len(queued) == 1
+        queued[0].interrupt(force=True)
+        await asyncio.sleep(0.1)
+
+        assert queued[0].interrupted
+        assert not rt_session.interrupted
+
+        function_ch.close()
+
+
+async def test_paused_playout_keeps_the_response() -> None:
+    async with _speaking_reply() as (_, rt_session, handle, audio_output, function_ch):
+        function_ch.close()
+        audio_output.pause()
+        await asyncio.sleep(1.0)
+
+        assert not handle.interrupted
+        assert not rt_session.interrupted
+
+        audio_output.resume()
+        await asyncio.wait_for(handle.wait_for_playout(), timeout=5)
+
+        assert not rt_session.interrupted
+
+
+async def test_interrupt_racing_the_generation_event_cancels_the_response() -> None:
+    # the generation event and the interrupt land in the same tick, so the reply task returns
+    # before it ever forwards the response: nothing else is left to cancel it
+    model = FakeRealtimeModel(capabilities=fake_capabilities())
+
+    async with AgentSession(llm=model) as session:
+        await session.start(Agent(instructions="test"))
+
+        handle = session.generate_reply()
+        while not model.active_session._reply_futs:
+            await asyncio.sleep(0)
+
+        message_ch = utils.aio.Chan[llm.MessageGeneration]()
+        function_ch = utils.aio.Chan[llm.FunctionCall]()
+        message_ch.close()
+        function_ch.close()
+        model.active_session._reply_futs[0].set_result(
+            llm.GenerationCreatedEvent(
+                message_stream=message_ch,
+                function_stream=function_ch,
+                user_initiated=True,
+                response_id="response-id",
+            )
+        )
+        handle.interrupt(force=True)
+        await asyncio.wait_for(handle.wait_for_playout(), timeout=5)
+
+        assert model.active_session.interrupted
+
+
+async def test_interrupting_a_finished_speech_spares_the_newer_reply() -> None:
+    # the older handle stays alive for its tool while the next reply generates, and the cancel
+    # it would send is the one that reply is running on
+    tool_started = asyncio.Event()
+    release_tool = asyncio.Event()
+
+    class ToolAgent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="test")
+
+        @function_tool
+        async def lookup(self) -> str:
+            """Look something up."""
+            tool_started.set()
+            await release_tool.wait()
+            return "ok"
+
+    model = FakeRealtimeModel(capabilities=fake_capabilities())
+
+    async with AgentSession(llm=model) as session:
+        session.output.audio = FakeAudioOutput(can_pause=True)
+        await session.start(ToolAgent())
+        rt_session = model.active_session
+
+        handle_a = session.generate_reply()
+        while not rt_session._reply_futs:
+            await asyncio.sleep(0)
+
+        message_ch = utils.aio.Chan[llm.MessageGeneration]()
+        function_ch = utils.aio.Chan[llm.FunctionCall]()
+        text_ch = utils.aio.Chan[str]()
+        audio_ch = utils.aio.Chan[rtc.AudioFrame]()
+        modalities = asyncio.Future[list[str]]()
+        modalities.set_result(["audio", "text"])
+
+        message_ch.send_nowait(
+            llm.MessageGeneration(
+                message_id="message-a",
+                text_stream=text_ch,
+                audio_stream=audio_ch,
+                modalities=modalities,
+            )
+        )
+        message_ch.close()
+        text_ch.send_nowait("let me check")
+        text_ch.close()
+        audio_ch.send_nowait(_audio_frame(0.2))
+        audio_ch.close()
+        function_ch.send_nowait(llm.FunctionCall(call_id="1", name="lookup", arguments="{}"))
+        function_ch.close()
+
+        rt_session._reply_futs[0].set_result(
+            llm.GenerationCreatedEvent(
+                message_stream=message_ch,
+                function_stream=function_ch,
+                user_initiated=True,
+                response_id="response-a",
+            )
+        )
+
+        await asyncio.wait_for(tool_started.wait(), timeout=5)
+        handle_b = session.generate_reply()
+
+        # A's generation ends with its playout, and only then is B authorized to ask for a response
+        async def _wait_for_second_reply() -> None:
+            while rt_session.generate_reply_calls < 2:
+                await asyncio.sleep(0.01)
+
+        await asyncio.wait_for(_wait_for_second_reply(), timeout=5)
+        assert not handle_a.done()
+        assert session._activity is not None
+        assert handle_a in session._activity._background_speeches
+
+        rt_session.interrupted = False
+        handle_a.interrupt(force=True)
+        await asyncio.sleep(0.1)
+
+        assert handle_a.interrupted
+        assert not rt_session.interrupted
+
+        release_tool.set()
+        b_message_ch = utils.aio.Chan[llm.MessageGeneration]()
+        b_function_ch = utils.aio.Chan[llm.FunctionCall]()
+        b_message_ch.close()
+        b_function_ch.close()
+        rt_session._reply_futs[1].set_result(
+            llm.GenerationCreatedEvent(
+                message_stream=b_message_ch,
+                function_stream=b_function_ch,
+                user_initiated=True,
+                response_id="response-b",
+            )
+        )
+
+        await asyncio.wait_for(handle_b.wait_for_playout(), timeout=5)
+        await asyncio.wait_for(handle_a.wait_for_playout(), timeout=5)
+
+        assert not rt_session.interrupted


### PR DESCRIPTION
**Problem**

`SpeechHandle.interrupt()` marks the handle interrupted and releases `wait_for_playout()`. It does not stop the model.

Only `AgentActivity.interrupt()` pairs the local interruption with `RealtimeSession.interrupt()`, and an `AgentTask` cannot use it. Its future resolves when every interrupted speech is done, and one of them is the task's own `on_enter` speech.

So an app that interrupts a handle directly keeps the response alive. The interrupted reply completes a few seconds later.

**Fix**

The realtime generation task owns the server-side response, so it now sends the cancel where it observes the interrupt. This covers every interrupt path and adds no new API.

The cancel is session-wide, so it must not go out after the provider ended the response. Both streams of the generation are drained through a tee, and the cancel is skipped once they close.

Playout lags generation by seconds, so that guard is load-bearing. Without it, an interrupt on a speech that is still playing buffered audio can stop whichever response took its place.