### PR TITLE
fix(realtime): separate server turn detection from server replies

### DIFF
--- a/livekit-agents/livekit/agents/llm/realtime.py
+++ b/livekit-agents/livekit/agents/llm/realtime.py
@@ -61,7 +61,8 @@ class RealtimeCapabilities:
     message_truncation: bool
     """Whether generated assistant messages can be truncated after interruption"""
     turn_detection: bool
-    """Whether the model emits server-side speech start and stop events for turn taking"""
+    """Whether the model detects turns server-side, segmenting and committing the input audio
+    itself. The client must not commit or clear that buffer."""
     user_transcription: bool
     """Whether the model emits user audio transcription events"""
     auto_tool_reply_generation: bool
@@ -70,6 +71,11 @@ class RealtimeCapabilities:
     """Whether the model can produce audio output directly"""
     manual_function_calls: bool
     """Whether function call items already in the chat context can be resumed"""
+    auto_turn_reply_generation: bool = True
+    """Whether the model replies on its own when its server-side turn detection ends a user turn.
+
+    When False the server keeps segmenting the input audio but the client decides when to reply.
+    """
     can_disable_turn_detection: bool = False
     """Whether server-side turn detection can be disabled for a session so the client drives
     turn-taking. Set by plugins that implement ``session(turn_detection_disabled=True)``."""

--- a/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/realtime_fallback_adapter.py
@@ -39,6 +39,7 @@ class RealtimeAvailabilityChangedEvent:
 _HARD_CAPABILITIES = (
     "audio_output",
     "turn_detection",
+    "auto_turn_reply_generation",
 )
 
 # caps exposed as the conservative AND; the active model's exact value is read per-turn from the session
@@ -103,7 +104,7 @@ class RealtimeModelFallbackAdapter(
 
         Args:
             models: Ordered models; the first is primary, the rest fallbacks. All must agree on
-                the ``audio_output`` and ``turn_detection`` capabilities.
+                the ``audio_output`` and turn-detection capabilities.
             cooldown: Seconds a failed model stays unavailable before it can be preferred again.
             regenerate_on_swap: Re-issue the reply on the new session if one was in progress.
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -272,6 +272,12 @@ class AgentActivity(RecognitionHooks):
 
         # session-scoped truth read by every server-side turn-detection check below
         self._rt_turn_detection_enabled = self._resolve_rt_turn_detection_enabled()
+        # the server owns the turn only when it answers it too, otherwise it just segments audio
+        self._rt_server_reply_enabled = (
+            self._rt_turn_detection_enabled
+            and isinstance(self.llm, llm.RealtimeModel)
+            and self.llm.capabilities.auto_turn_reply_generation
+        )
         if (
             isinstance(self.llm, llm.RealtimeModel)
             and not self._rt_turn_detection_enabled
@@ -282,7 +288,7 @@ class AgentActivity(RecognitionHooks):
                 "turn detection."
             )
 
-        if self._rt_turn_detection_enabled and not self.allow_interruptions:
+        if self._rt_server_reply_enabled and not self.allow_interruptions:
             raise ValueError(
                 "the RealtimeModel uses a server-side turn detection, "
                 "allow_interruptions cannot be False, disable turn_detection in "
@@ -1503,7 +1509,7 @@ class AgentActivity(RecognitionHooks):
                 "add a TTS model to AgentSession to enable say()"
             )
 
-        if self._rt_turn_detection_enabled and allow_interruptions is False:
+        if self._rt_server_reply_enabled and allow_interruptions is False:
             logger.warning(
                 "the RealtimeModel uses a server-side turn detection, allow_interruptions cannot be False when using VoiceAgent.say(), "  # noqa: E501
                 "disable turn_detection in the RealtimeModel and use VAD on the AgentTask/VoiceAgent instead"  # noqa: E501
@@ -1569,7 +1575,7 @@ class AgentActivity(RecognitionHooks):
         schedule_speech: bool = True,
         input_details: InputDetails = DEFAULT_INPUT_DETAILS,
     ) -> SpeechHandle:
-        if self._rt_turn_detection_enabled and allow_interruptions is False:
+        if self._rt_server_reply_enabled and allow_interruptions is False:
             logger.warning(
                 "the RealtimeModel uses a server-side turn detection, allow_interruptions cannot be False when using VoiceAgent.generate_reply(), "  # noqa: E501
                 "disable turn_detection in the RealtimeModel and use VAD on the AgentTask/VoiceAgent instead"  # noqa: E501
@@ -1741,8 +1747,9 @@ class AgentActivity(RecognitionHooks):
         self, *, transcript_timeout: float, stt_flush_duration: float, skip_reply: bool = False
     ) -> asyncio.Future[str]:
         if self._rt_session is not None:
-            # commit audio buffer and conditionally trigger response generation
-            self._rt_session.commit_audio()
+            if not self._rt_turn_detection_enabled:
+                # when the server segments, it commits each turn itself
+                self._rt_session.commit_audio()
             if not skip_reply:
                 self._session.generate_reply()
             # `skip_reply` prevents duplicate reply from _on_user_turn_completed
@@ -2000,7 +2007,7 @@ class AgentActivity(RecognitionHooks):
         except RuntimeError:
             # only out of sync when the server cancelled its own response, with client-side turn
             # taking an uninterruptible speech is expected
-            if self._rt_turn_detection_enabled:
+            if self._rt_server_reply_enabled:
                 logger.exception(
                     "RealtimeAPI input_speech_started, but current speech is not interruptable, this should never happen!"  # noqa: E501
                 )
@@ -2465,7 +2472,7 @@ class AgentActivity(RecognitionHooks):
 
         # a replying turn interrupts the paused speech, so cancel the resume that would race it —
         # but the reply task returns before that in these two cases, so leave the resume armed
-        if not info.skip_reply and not self._rt_turn_detection_enabled:
+        if not info.skip_reply and not self._rt_server_reply_enabled:
             self._cancel_false_interruption_timer()
 
         old_task = self._user_turn_completed_atask
@@ -2512,7 +2519,7 @@ class AgentActivity(RecognitionHooks):
             user_message.metrics = metrics_report
 
         if isinstance(self.llm, llm.RealtimeModel):
-            if self._rt_turn_detection_enabled:
+            if self._rt_server_reply_enabled:
                 return
 
             if self._rt_session is not None:
@@ -2522,7 +2529,9 @@ class AgentActivity(RecognitionHooks):
                         self._agent._chat_ctx.items.append(user_message)
                         self._session._conversation_item_added(user_message)
                     return
-                self._rt_session.commit_audio()
+                if not self._rt_turn_detection_enabled:
+                    # when the server segments, it commits each turn itself
+                    self._rt_session.commit_audio()
 
         if info.skip_reply:
             if info.new_transcript != "":

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -480,7 +480,8 @@ class RealtimeModel(llm.RealtimeModel):
         super().__init__(
             capabilities=llm.RealtimeCapabilities(
                 message_truncation=True,
-                turn_detection=_server_turn_taking_enabled(resolved_turn_detection),
+                turn_detection=resolved_turn_detection is not None,
+                auto_turn_reply_generation=_server_turn_taking_enabled(resolved_turn_detection),
                 can_disable_turn_detection=not is_given(turn_detection),
                 user_transcription=input_audio_transcription is not None,
                 auto_tool_reply_generation=False,
@@ -749,7 +750,8 @@ class RealtimeModel(llm.RealtimeModel):
         if is_given(turn_detection):
             # a derived capability has to follow the option it is derived from
             self._opts.turn_detection = to_turn_detection(turn_detection)
-            self._capabilities.turn_detection = _server_turn_taking_enabled(
+            self._capabilities.turn_detection = self._opts.turn_detection is not None
+            self._capabilities.auto_turn_reply_generation = _server_turn_taking_enabled(
                 self._opts.turn_detection
             )
             # only the model warns: it re-runs the update on every session it owns
@@ -893,9 +895,8 @@ class RealtimeSession(
         # this session's own copy: turn detection can be off here and on for the model
         self._capabilities = replace(
             realtime_model.capabilities,
-            turn_detection=False
-            if turn_detection_disabled
-            else realtime_model.capabilities.turn_detection,
+            turn_detection=self._opts.turn_detection is not None,
+            auto_turn_reply_generation=_server_turn_taking_enabled(self._opts.turn_detection),
         )
         self._tools = llm.ToolContext.empty()
         self._msg_ch = utils.aio.Chan[RealtimeClientEvent | dict[str, Any]]()
@@ -1423,7 +1424,10 @@ class RealtimeSession(
                 audio_input.turn_detection = turn_detection
                 has_audio_config = True
             self._opts.turn_detection = turn_detection
-            self._capabilities.turn_detection = _server_turn_taking_enabled(turn_detection)
+            self._capabilities.turn_detection = turn_detection is not None
+            self._capabilities.auto_turn_reply_generation = _server_turn_taking_enabled(
+                turn_detection
+            )
 
         if is_given(input_audio_transcription):
             if self._opts.input_audio_transcription != input_audio_transcription:

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -282,7 +282,7 @@ async def test_server_side_turn_detection_keeps_the_resume_armed(
 
     session = _session()
     activity, _ = _paused_activity(session)
-    activity._rt_turn_detection_enabled = True
+    activity._rt_server_reply_enabled = True
     activity._create_speech_task = _swallow_task  # type: ignore[method-assign, assignment]
 
     events: list[str] = []

--- a/tests/test_realtime/test_openai_realtime_model.py
+++ b/tests/test_realtime/test_openai_realtime_model.py
@@ -72,23 +72,27 @@ def test_with_azure_preserves_can_disable_turn_detection() -> None:
     assert explicit_off.capabilities.can_disable_turn_detection is False
 
 
-def test_create_response_false_reports_client_side_turn_taking() -> None:
-    # server VAD with create_response=False commits and transcribes the audio server-side but
-    # leaves the reply to the client, so it must not count as server-side turn detection —
-    # otherwise allow_interruptions=False is rejected (issue #6635)
+def test_create_response_false_reports_client_side_replies() -> None:
+    # server VAD with create_response=False still segments and commits the audio server-side, it
+    # only leaves the reply to the client. Reporting it as no turn detection makes the framework
+    # commit a buffer the server already committed (issue #6635)
     manual_reply = RealtimeModel(
         api_key="fake",
         turn_detection=ServerVad(type="server_vad", create_response=False),
     )
-    assert manual_reply.capabilities.turn_detection is False
+    assert manual_reply.capabilities.turn_detection is True
+    assert manual_reply.capabilities.auto_turn_reply_generation is False
 
     auto_reply = RealtimeModel(
         api_key="fake",
         turn_detection=ServerVad(type="server_vad"),
     )
     assert auto_reply.capabilities.turn_detection is True
+    assert auto_reply.capabilities.auto_turn_reply_generation is True
 
-    assert RealtimeModel(api_key="fake").capabilities.turn_detection is True
+    no_server_vad = RealtimeModel(api_key="fake", turn_detection=None)
+    assert no_server_vad.capabilities.turn_detection is False
+    assert no_server_vad.capabilities.auto_turn_reply_generation is False
 
 
 def test_create_response_false_warns_when_the_server_still_interrupts(
@@ -118,7 +122,7 @@ def test_update_options_keeps_derived_capabilities_in_sync() -> None:
     # a stale capability reports the server owning the turn after the caller handed turn
     # taking to the client, and AgentActivity then rejects allow_interruptions=False
     model = RealtimeModel(api_key="fake", turn_detection=ServerVad(type="server_vad"))
-    assert model.capabilities.turn_detection is True
+    assert model.capabilities.auto_turn_reply_generation is True
     assert model.capabilities.user_transcription is True
 
     model.update_options(
@@ -127,14 +131,18 @@ def test_update_options_keeps_derived_capabilities_in_sync() -> None:
         ),
         input_audio_transcription=None,
     )
-    assert model.capabilities.turn_detection is False
+    assert model.capabilities.turn_detection is True
+    assert model.capabilities.auto_turn_reply_generation is False
     assert model.capabilities.user_transcription is False
+
+    model.update_options(turn_detection=None)
+    assert model.capabilities.turn_detection is False
 
     model.update_options(
         turn_detection=ServerVad(type="server_vad"),
         input_audio_transcription=AudioTranscription(model="whisper-1"),
     )
-    assert model.capabilities.turn_detection is True
+    assert model.capabilities.auto_turn_reply_generation is True
     assert model.capabilities.user_transcription is True
 
 
@@ -147,7 +155,7 @@ def test_update_options_leaves_derived_capabilities_alone_when_unset() -> None:
         ),
     )
     model.update_options(voice="marin")
-    assert model.capabilities.turn_detection is False
+    assert model.capabilities.auto_turn_reply_generation is False
 
 
 def _capabilities_session(model: RealtimeModel) -> RealtimeSession:
@@ -177,9 +185,9 @@ def test_session_update_options_keeps_capabilities_on_the_session() -> None:
         input_audio_transcription=None,
     )
 
-    assert session._capabilities.turn_detection is False
+    assert session._capabilities.auto_turn_reply_generation is False
     assert session._capabilities.user_transcription is False
-    assert model.capabilities.turn_detection is True
+    assert model.capabilities.auto_turn_reply_generation is True
     assert model.capabilities.user_transcription is True
 
 

--- a/tests/test_realtime_input_speech_interrupt.py
+++ b/tests/test_realtime_input_speech_interrupt.py
@@ -22,11 +22,13 @@ def _livekit_keys(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
 
 
-def _activity(*, server_turn_detection: bool, allow_interruptions: bool = True) -> AgentActivity:
+def _activity(*, server_reply: bool, allow_interruptions: bool = True) -> AgentActivity:
     session = AgentSession(
         llm=FakeRealtimeModel(
             capabilities=fake_capabilities(
-                turn_detection=server_turn_detection, can_disable_turn_detection=False
+                turn_detection=True,
+                auto_turn_reply_generation=server_reply,
+                can_disable_turn_detection=False,
             )
         ),
         vad=FakeVAD(fake_user_speeches=[]),
@@ -46,15 +48,16 @@ def _speech_started(activity: AgentActivity, *, allow_interruptions: bool) -> Sp
 def test_allow_interruptions_false_rejected_with_server_turn_detection() -> None:
     # the server cancels its own response on user speech, so the local speech can't opt out
     with pytest.raises(ValueError, match="allow_interruptions cannot be False"):
-        _activity(server_turn_detection=True, allow_interruptions=False)
+        _activity(server_reply=True, allow_interruptions=False)
 
 
 def test_allow_interruptions_false_allowed_with_client_turn_taking() -> None:
-    # server VAD with create_response=False reports no server-side turn detection, so a
-    # turn-taking agent can disable interruptions (issue #6635)
-    activity = _activity(server_turn_detection=False, allow_interruptions=False)
+    # server VAD with create_response=False keeps segmenting but never answers, so a turn-taking
+    # agent can disable interruptions (issue #6635)
+    activity = _activity(server_reply=False, allow_interruptions=False)
 
-    assert activity._rt_turn_detection_enabled is False
+    assert activity._rt_turn_detection_enabled is True
+    assert activity._rt_server_reply_enabled is False
 
 
 def test_input_speech_started_keeps_uninterruptible_speech(
@@ -63,7 +66,7 @@ def test_input_speech_started_keeps_uninterruptible_speech(
     # the model still reports user speech (server VAD is on to commit and transcribe audio), but
     # neither side interrupts: no response.cancel, no local interruption, and no error log since
     # this is a valid configuration
-    activity = _activity(server_turn_detection=False, allow_interruptions=False)
+    activity = _activity(server_reply=False, allow_interruptions=False)
 
     with caplog.at_level(logging.ERROR, logger="livekit.agents"):
         handle = _speech_started(activity, allow_interruptions=False)
@@ -74,7 +77,7 @@ def test_input_speech_started_keeps_uninterruptible_speech(
 
 
 def test_input_speech_started_interrupts_interruptible_speech() -> None:
-    activity = _activity(server_turn_detection=True)
+    activity = _activity(server_reply=True)
 
     handle = _speech_started(activity, allow_interruptions=True)
 

--- a/tests/test_realtime_server_segmentation.py
+++ b/tests/test_realtime_server_segmentation.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from livekit.agents import Agent, AgentSession, TurnHandlingOptions
+from livekit.agents.voice.agent_activity import AgentActivity
+from livekit.agents.voice.audio_recognition import _EndOfTurnInfo, _EndOfTurnMetrics
+
+from .fake_realtime import FakeRealtimeModel, fake_capabilities
+from .fake_vad import FakeVAD
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _livekit_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    # the eager TurnDetector() default and the adaptive detector read these
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+
+def _activity(*, server_segments: bool, server_replies: bool, **handling: object) -> AgentActivity:
+    session = AgentSession(
+        llm=FakeRealtimeModel(
+            capabilities=fake_capabilities(
+                turn_detection=server_segments,
+                auto_turn_reply_generation=server_replies,
+                can_disable_turn_detection=False,
+            )
+        ),
+        vad=FakeVAD(fake_user_speeches=[]),
+        turn_handling=TurnHandlingOptions(**handling),  # type: ignore[typeddict-item]
+    )
+    activity = AgentActivity(Agent(instructions="test"), session)
+    activity._rt_session = MagicMock()
+    return activity
+
+
+def _end_of_turn_info() -> _EndOfTurnInfo:
+    return _EndOfTurnInfo(
+        skip_reply=False,
+        new_transcript="hello",
+        transcript_confidence=0.0,
+        metrics=_EndOfTurnMetrics(
+            started_speaking_at=None,
+            stopped_speaking_at=None,
+            transcription_delay=None,
+            end_of_turn_delay=None,
+        ),
+        backchannel_over_agent=False,
+    )
+
+
+async def test_server_segmented_turn_is_not_committed_by_the_client() -> None:
+    # server VAD with create_response=False segments and commits each turn itself, so a client
+    # commit lands on an emptied buffer (input_audio_buffer_commit_empty). The client still owns
+    # the reply.
+    activity = _activity(server_segments=True, server_replies=False)
+    assert activity._rt_turn_detection_enabled is True
+    assert activity._rt_server_reply_enabled is False
+
+    await activity._user_turn_completed_task(None, _end_of_turn_info())
+
+    activity._rt_session.commit_audio.assert_not_called()
+
+
+async def test_client_segmented_turn_is_committed() -> None:
+    # nothing segments server-side: the client owns the input buffer and must commit it
+    activity = _activity(server_segments=False, server_replies=False)
+    assert activity._rt_turn_detection_enabled is False
+
+    await activity._user_turn_completed_task(None, _end_of_turn_info())
+
+    activity._rt_session.commit_audio.assert_called_once()
+
+
+async def test_server_answered_turn_is_left_to_the_server() -> None:
+    # the server both segments and answers, so the client neither commits nor replies
+    activity = _activity(server_segments=True, server_replies=True)
+    assert activity._rt_server_reply_enabled is True
+
+    await activity._user_turn_completed_task(None, _end_of_turn_info())
+
+    activity._rt_session.commit_audio.assert_not_called()
+
+
+def test_commit_user_turn_skips_the_commit_when_the_server_segments() -> None:
+    # the manual turn API has the same buffer owner as the automatic path
+    activity = _activity(server_segments=True, server_replies=False)
+    activity._audio_recognition = MagicMock()
+
+    activity.commit_user_turn(transcript_timeout=1.0, stt_flush_duration=0.0, skip_reply=True)
+
+    activity._rt_session.commit_audio.assert_not_called()
+
+
+def test_commit_user_turn_commits_when_the_client_segments() -> None:
+    activity = _activity(server_segments=False, server_replies=False)
+    activity._audio_recognition = MagicMock()
+
+    activity.commit_user_turn(transcript_timeout=1.0, stt_flush_duration=0.0, skip_reply=True)
+
+    activity._rt_session.commit_audio.assert_called_once()
+
+
+def test_barge_in_is_disabled_when_the_server_segments() -> None:
+    # adaptive barge-in gatekeeps by withholding the commit, which is impossible once the
+    # server commits every segment on its own
+    activity = _activity(
+        server_segments=True, server_replies=False, interruption={"mode": "adaptive"}
+    )
+
+    assert activity._interruption_detector is None
+    assert activity._interruption_detection_enabled is False


### PR DESCRIPTION
**Problem**

`capabilities.turn_detection` tells the framework who owns the input audio buffer. The openai plugin sets it from `create_response`, which says who answers the turn.

With `turn_detection=ServerVad(create_response=False)` the server still segments and commits every turn, but the framework reads the capability as client-side turn taking and commits as well. Each turn logs `input_audio_buffer_commit_empty`, which #6642 suppressed rather than removed.

Seven reads of this capability want the "the server segments" meaning, so barge-in gatekeeping and the default VAD were wrong for this configuration too.

**Fix**

`turn_detection` goes back to its first meaning: the server detects turns, and it segments and commits the input audio itself.

The half it absorbed becomes `auto_turn_reply_generation`, which is `True` by default. Only the openai plugin needs a change, and a plugin that does not know the field behaves as before.

Five of the seven wrong reads become correct with no edit. `AgentActivity` gains `_rt_server_reply_enabled` for the six places that want "the server answers", and only the two `commit_audio()` calls needed an explicit gate.

Note: with an explicit `create_response=False`, endpointing now comes from the server's own speech events, so a client `turn_detection="vad"` is ignored with a warning. Pass `turn_detection=None` to keep full client control. This ordering is what closes the gap where `response.create` could otherwise overtake the server's commit and answer a turn the conversation does not hold yet.