### PR TITLE
fix(openai realtime): recover when the server anchors to a deleted item

### DIFF
--- a/livekit-agents/livekit/agents/llm/remote_chat_context.py
+++ b/livekit-agents/livekit/agents/llm/remote_chat_context.py
@@ -32,6 +32,11 @@ class RemoteChatContext:
     def get(self, item_id: str) -> _RemoteChatItem | None:
         return self._id_to_item.get(item_id)
 
+    @property
+    def tail_id(self) -> str | None:
+        """Id of the last item, or None when the context is empty."""
+        return self._tail.item.id if self._tail else None
+
     def insert(self, previous_item_id: str | None, message: ChatItem) -> None:
         """
         Insert `message` after the node with ID `previous_item_id`.

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -1952,6 +1952,15 @@ class RealtimeSession(
     def _handle_conversion_item_added(self, event: ConversationItemAdded) -> None:
         assert event.item.id is not None, "item.id is None"
 
+        if event.previous_item_id and not self._remote_chat_ctx.get(event.previous_item_id):
+            # the server can anchor to an item it just deleted; the item belongs at the tail
+            logger.warning(
+                f"{self._realtime_model._provider_label} anchored an item to one it is no longer "
+                "tracking, appending it instead",
+                extra={"item_id": event.item.id, "previous_item_id": event.previous_item_id},
+            )
+            event.previous_item_id = self._remote_chat_ctx.tail_id
+
         try:
             lk_item = openai_item_to_livekit_item(event.item)
             self._remote_chat_ctx.insert(event.previous_item_id, lk_item)
@@ -2309,7 +2318,11 @@ class RealtimeSession(
             # leave update_chat_ctx to stall inside the speech that awaits it
             if fut := self._chat_ctx_event_futures.pop(event_id, None):
                 if not fut.done():
-                    fut.set_exception(llm.RealtimeError(event.error.message))
+                    # a duplicate id means the item is already there, as the create wanted
+                    if event.error.code == "item_create_duplicate_item_id":
+                        fut.set_result(None)
+                    else:
+                        fut.set_exception(llm.RealtimeError(event.error.message))
                 # a terminal one still has to end the session, whatever it came in reply to
                 if not _is_fatal_error(event.error):
                     return

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py
@@ -418,9 +418,7 @@ class RealtimeSession(openai.realtime.RealtimeSession):
             event.previous_item_id = None
 
         if event.previous_item_id is None:
-            event.previous_item_id = (
-                self._remote_chat_ctx._tail.item.id if self._remote_chat_ctx._tail else None
-            )
+            event.previous_item_id = self._remote_chat_ctx.tail_id
 
         super()._handle_conversion_item_added(event)
 

--- a/tests/test_openai_realtime_chat_ctx.py
+++ b/tests/test_openai_realtime_chat_ctx.py
@@ -142,3 +142,37 @@ def test_short_call_id_is_unchanged() -> None:
         llm.FunctionCall(id="item_1", call_id="call_abc", name="get_weather", arguments="{}")
     )
     assert call.call_id == "call_abc"
+
+
+async def test_an_item_anchored_to_a_deleted_one_is_appended() -> None:
+    # the server sometimes anchors a new item to one it has just confirmed deleting; dropping
+    # the item leaves the mirror short of it, and the next update then re-creates an item the
+    # server already has, which it rejects as a duplicate
+    from openai.types.realtime import ConversationItemAdded
+
+    session = _create_session()
+    session._realtime_model = types.SimpleNamespace(_provider_label="openai.realtime")
+    session.emit = lambda name, ev: None
+    session._remote_chat_ctx.insert(None, llm.ChatMessage(role="user", content=["hi"], id="item_1"))
+
+    session._handle_conversion_item_added(
+        ConversationItemAdded.construct(
+            type="conversation.item.added",
+            event_id="evt",
+            previous_item_id="deleted_item",
+            item={
+                "id": "item_2",
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "hello"}],
+                "status": "completed",
+            },
+        )
+    )
+    remote_ctx = session._remote_chat_ctx.to_chat_ctx()
+
+    assert [item.id for item in remote_ctx.items] == ["item_1", "item_2"]
+
+    await session.update_chat_ctx(remote_ctx)
+
+    assert session._sent_events == []

--- a/tests/test_realtime/test_openai_realtime_model.py
+++ b/tests/test_realtime/test_openai_realtime_model.py
@@ -425,6 +425,19 @@ async def test_an_error_outliving_its_update_is_still_reported() -> None:
     assert [e.recoverable for e in errors] == [True], "swallowed by a retired waiter"
 
 
+async def test_a_duplicate_item_id_settles_its_waiter_as_a_no_op() -> None:
+    # the item is already on the conversation, which is all the create asked for; failing the
+    # waiter would report a rejection for an update that got what it wanted
+    session = _chat_ctx_update_session()
+    waiter = session._item_create_future["item_1"]
+
+    RealtimeSession._handle_error(
+        session, _rejection("chat_ctx_create_abc", code="item_create_duplicate_item_id")
+    )
+
+    assert waiter.done() and waiter.exception() is None
+
+
 async def test_a_rejection_leaves_its_sibling_event_alone() -> None:
     # an updated item is deleted and created under one id, and the create can still land
     session = _chat_ctx_update_session()


### PR DESCRIPTION
**Problem**

The server can send `conversation.item.added` with a `previous_item_id` that it confirmed deleting 396 ms earlier. The client is right and the anchor is stale: the same case returns `None` on a passing run.

`RemoteChatContext.insert` rejects the unknown anchor, and the handler dropped the item. The local mirror then loses an item that the server holds.

One activity handoff later, the `update_chat_ctx` diff sees that item as missing and re-creates it. The server rejects it as a duplicate, and no `conversation.item.added` arrives to settle the waiter, so the caller waits five seconds and raises `update_chat_ctx timed out`.

**Fix**

The handler appends the item at the tail and logs one warning. An item announced right after a deletion is the newest one, so the tail is where the server itself would put it.

An `item_create_duplicate_item_id` rejection now settles its waiter as done. The item is present, which is what the create asked for.

`RemoteChatContext.insert` keeps rejecting an unknown anchor. It is shared with the other realtime plugins, and it is the only place that can still report a real bookkeeping error. Its new `tail_id` property replaces a reach into `_tail` in the xai plugin.