### PR TITLE
fix(openai realtime): do not commit a turn the server closed itself

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/realtime_model.py
@@ -54,6 +54,7 @@ from openai.types.realtime import (
     InputAudioBufferAppendEvent,
     InputAudioBufferClearEvent,
     InputAudioBufferCommitEvent,
+    InputAudioBufferCommittedEvent,
     InputAudioBufferSpeechStartedEvent,
     InputAudioBufferSpeechStoppedEvent,
     NoiseReductionType,
@@ -1188,6 +1189,10 @@ class RealtimeSession(
                         self._handle_input_audio_buffer_speech_stopped(
                             InputAudioBufferSpeechStoppedEvent.construct(**event)
                         )
+                    elif event["type"] == "input_audio_buffer.committed":
+                        self._handle_input_audio_buffer_committed(
+                            InputAudioBufferCommittedEvent.construct(**event)
+                        )
                     elif event["type"] == "response.created":
                         self._handle_response_created(ResponseCreatedEvent.construct(**event))
                     elif event["type"] == "response.output_item.added":
@@ -1861,6 +1866,12 @@ class RealtimeSession(
             "input_speech_stopped",
             llm.InputSpeechStoppedEvent(user_transcription_enabled=user_transcription_enabled),
         )
+
+    def _handle_input_audio_buffer_committed(self, _: InputAudioBufferCommittedEvent) -> None:
+        # only a segment the server closed itself leaves us nothing to commit; our own commit
+        # is echoed here too, and it already cleared the audio it owned
+        if self._opts.turn_detection is not None:
+            self._pushed_duration_s = 0
 
     def _handle_response_created(self, event: ResponseCreatedEvent) -> None:
         assert event.response.id is not None, "response.id is None"

--- a/tests/test_realtime/test_openai_realtime_model.py
+++ b/tests/test_realtime/test_openai_realtime_model.py
@@ -11,6 +11,7 @@ from openai.types.beta.realtime.session import TurnDetection as BetaTurnDetectio
 from openai.types.realtime import (
     ConversationItemCreateEvent,
     ConversationItemDeletedEvent,
+    InputAudioBufferCommittedEvent,
     RealtimeErrorEvent,
 )
 from openai.types.realtime.audio_transcription import AudioTranscription
@@ -24,6 +25,7 @@ from livekit.plugins.openai.realtime.realtime_model import (
     RealtimeModel,
     RealtimeSession,
     _is_fatal_error,
+    _RealtimeOptions,
 )
 
 pytestmark = pytest.mark.unit
@@ -503,3 +505,49 @@ def test_error_with_unknown_event_id_leaves_generate_reply_futures_untouched() -
     assert session._response_created_futures == {"response_create_1": fut}
     # still reported down the ordinary path
     assert captured["recoverable"] is True
+
+
+def _audio_buffer_session(turn_detection: ServerVad | None) -> RealtimeSession:
+    session = RealtimeSession.__new__(RealtimeSession)
+    session._opts = cast("_RealtimeOptions", SimpleNamespace(turn_detection=turn_detection))
+    session._pushed_duration_s = 3.0
+    session._sent_events = []
+    session.send_event = session._sent_events.append  # type: ignore[method-assign]
+    return session
+
+
+def _server_commit(session: RealtimeSession) -> None:
+    RealtimeSession._handle_input_audio_buffer_committed(
+        session, InputAudioBufferCommittedEvent.construct(item_id="item_1")
+    )
+
+
+def test_a_turn_the_server_committed_is_not_committed_again() -> None:
+    # server-side turn detection closes each segment itself, and committing again asks the
+    # server to close a buffer it already emptied (code=input_audio_buffer_commit_empty)
+    session = _audio_buffer_session(ServerVad(type="server_vad"))
+    _server_commit(session)
+    session.commit_audio()
+
+    assert session._sent_events == []
+
+
+def test_audio_pushed_after_a_server_commit_is_still_committed() -> None:
+    # the client owns the turn boundary when the server does not reply on its own, so audio
+    # the server has not segmented yet has to reach the conversation before the reply
+    session = _audio_buffer_session(ServerVad(type="server_vad"))
+    _server_commit(session)
+    session._pushed_duration_s = 3.0
+    session.commit_audio()
+
+    assert [event.type for event in session._sent_events] == ["input_audio_buffer.commit"]
+
+
+def test_the_echo_of_our_own_commit_keeps_the_pushed_audio() -> None:
+    # a client commit is acknowledged with the same event, and the audio that arrived while it
+    # was in flight is still ours to commit
+    session = _audio_buffer_session(None)
+    _server_commit(session)
+    session.commit_audio()
+
+    assert [event.type for event in session._sent_events] == ["input_audio_buffer.commit"]


### PR DESCRIPTION
**Problem:** With server-side turn detection the server closes each audio segment itself, and the framework still calls `commit_audio()` on every client turn. The server answers that second commit with `input_audio_buffer_commit_empty`, and #6642 only suppressed the error, so every turn still pays for a commit the server rejects.

**Fix:** The session now handles `input_audio_buffer.committed` and clears the count of pushed audio, so `commit_audio()` has nothing left to send. The meaning of `commit_audio()` does not change, and the error suppression stays for a client commit and a server commit that cross on the wire.

Follows up #6642.

<details>
<summary>Context for reviewing and coding agents</summary>

> **How to see it**
>
> Three unit tests in `tests/test_realtime/test_openai_realtime_model.py` push a `input_audio_buffer.committed` event into the session and then call `commit_audio()`. The first test fails on main, where the handler does not exist. The other two hold the two cases that must keep committing: audio pushed after a server commit, and the echo of the client's own commit when the server does no segmentation.
>
> ```bash
> uv run pytest tests/test_realtime/test_openai_realtime_model.py --unit
> ```
>
> **Blast radius**
>
> `commit_audio()` has two callers, `agent_activity.py:1777` and `agent_activity.py:2554`, and both run only when `_rt_turn_detection_enabled` is False, which is the client-side turn taking path. A session that leaves turn taking on the server never reaches them and sees no change. The fix stays inside the openai realtime plugin; other realtime plugins keep their own commit path.
>
> **Why the handler is gated on `turn_detection`**
>
> When `turn_detection` is None the server never commits on its own, so every `input_audio_buffer.committed` is the echo of a client commit. Audio that arrived while that commit was in flight is still the client's to commit, and the count must survive the echo. With server VAD on, the server segments that audio itself, so clearing the count loses nothing.
>
> **Alternatives rejected**
>
> The caller in `agent_activity` cannot make this decision. It knows that server-side turn taking is off, but `create_response=False` leaves the server detecting and committing turns, and only the plugin sees that setting.
>
> The error suppression alone is not enough. It hides every `input_audio_buffer_commit_empty` while `turn_detection` is set, including one that comes from a genuine client mistake, and the needless commit still goes out on each turn.

</details>
