### PR TITLE
fix(voice): report played audio across an audio sink swap

### DIFF
--- a/livekit-agents/livekit/agents/voice/io.py
+++ b/livekit-agents/livekit/agents/voice/io.py
@@ -385,11 +385,22 @@ class _AudioSinkProxy(AudioOutput):
             # progress only observes, so the clear is still the sink's last word
             old.off("playback_progressed", self._forward_next_playback_progressed)
 
-            if self._capturing:
-                # it cannot be asked once detached, so all it was given counts as played
-                if not self._sink_reported:
-                    self._report_run(self._pushed_duration - self._offset_base)
+            # it cannot be asked once detached: what it was given counts as played, capped by
+            # how long it played, unless the recorder has the whole segment to place
+            if (
+                self._pending_playback_count > 0
+                and not self._sink_reported
+                and (self._capturing or self._offset_base)
+                and self._sink_started_at is not None
+            ):
+                self._report_run(
+                    min(
+                        self._pushed_duration - self._offset_base,
+                        time.time() - self._sink_started_at,
+                    )
+                )
 
+            if self._capturing:
                 # the new sink counts from its own zero, this far into the segment
                 self._offset_base = self._pushed_duration
                 self._sink_reported = False
@@ -412,16 +423,15 @@ class _AudioSinkProxy(AudioOutput):
             self.on_playback_finished(playback_position=self._pushed_duration, interrupted=True)
 
     def _report_run(self, duration: float) -> None:
-        """Report a run the current sink played but never reported itself."""
-        if duration <= 0:
+        """Report a run the current sink played but never reported itself.
+
+        A sink that never said playback started has nothing to place: nothing reached it.
+        """
+        if duration <= 0 or self._sink_started_at is None:
             return
 
         self.on_playback_progressed(
-            started_at=self._sink_started_at
-            if self._sink_started_at is not None
-            else time.time() - duration,
-            offset=self._offset_base,
-            duration=duration,
+            started_at=self._sink_started_at, offset=self._offset_base, duration=duration
         )
 
     def _forward_next_playback_started(self, ev: PlaybackStartedEvent) -> None:
@@ -456,8 +466,9 @@ class _AudioSinkProxy(AudioOutput):
             self._sink_started_at = None
 
         await super().capture_frame(frame)
-        await self.next_in_chain.capture_frame(frame)
+        # counted before the handover, so a swap during it keeps the frame on the old sink
         self._pushed_duration += frame.duration
+        await self.next_in_chain.capture_frame(frame)
 
     def flush(self) -> None:
         super().flush()

--- a/livekit-agents/livekit/agents/voice/io.py
+++ b/livekit-agents/livekit/agents/voice/io.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal
 
 from livekit import rtc
@@ -341,10 +342,14 @@ class _AudioSinkProxy(AudioOutput):
         # whether the wrapper above us has attached the proxy; set_next_in_chain
         # uses this to decide if a new/old downstream should be notified
         self._attached = False
-        self.set_next_in_chain(next_in_chain)
-
         self._capturing = False
         self._pushed_duration: float = 0.0
+        # the current sink counts from its own zero; these place its runs in the segment
+        self._offset_base: float = 0.0
+        self._sink_reported = False
+        self._sink_started_at: float | None = None
+
+        self.set_next_in_chain(next_in_chain)
 
     @property
     def next_in_chain(self) -> AudioOutput:
@@ -368,12 +373,24 @@ class _AudioSinkProxy(AudioOutput):
 
         old = self._next_in_chain
         if old is not None:
+            # a clear can finish a segment that is not over, and that call is the proxy's
             old.off("playback_finished", self._forward_next_playback_finished)
             old.off("playback_started", self._forward_next_playback_started)
-            old.off("playback_progressed", self._forward_next_playback_progressed)
             if self._pending_playback_count > 0:
                 # stop audio still playing on the old sink
                 old.clear_buffer()
+            # progress only observes, so the clear is still the sink's last word
+            old.off("playback_progressed", self._forward_next_playback_progressed)
+
+            if self._capturing:
+                # it cannot be asked once detached, so all it was given counts as played
+                if not self._sink_reported:
+                    self._report_run(self._pushed_duration - self._offset_base)
+
+                # the new sink counts from its own zero, this far into the segment
+                self._offset_base = self._pushed_duration
+                self._sink_reported = False
+                self._sink_started_at = None
 
             if self._attached:
                 old.on_detached()
@@ -391,6 +408,34 @@ class _AudioSinkProxy(AudioOutput):
         if old is not None and self._pending_playback_count > 0 and not self._capturing:
             self.on_playback_finished(playback_position=self._pushed_duration, interrupted=True)
 
+    def _report_run(self, duration: float) -> None:
+        """Report a run the current sink played but never reported itself."""
+        if duration <= 0:
+            return
+
+        self.on_playback_progressed(
+            started_at=self._sink_started_at
+            if self._sink_started_at is not None
+            else time.time() - duration,
+            offset=self._offset_base,
+            duration=duration,
+        )
+
+    def _forward_next_playback_started(self, ev: PlaybackStartedEvent) -> None:
+        self._sink_started_at = ev.created_at
+        super()._forward_next_playback_started(ev)
+
+    def _forward_next_playback_progressed(self, ev: PlaybackProgressedEvent) -> None:
+        self._sink_reported = True
+        super()._forward_next_playback_progressed(replace(ev, offset=self._offset_base + ev.offset))
+
+    def _forward_next_playback_finished(self, ev: PlaybackFinishedEvent) -> None:
+        if self._offset_base and not self._sink_reported:
+            # all it said is how much played; the offset is the segment's to supply
+            self._report_run(ev.playback_position)
+
+        super()._forward_next_playback_finished(ev)
+
     @property
     def sample_rate(self) -> int | None:
         return self.next_in_chain.sample_rate
@@ -403,6 +448,9 @@ class _AudioSinkProxy(AudioOutput):
         if not self._capturing:
             self._capturing = True
             self._pushed_duration = 0.0
+            self._offset_base = 0.0
+            self._sink_reported = False
+            self._sink_started_at = None
 
         await super().capture_frame(frame)
         await self.next_in_chain.capture_frame(frame)

--- a/livekit-agents/livekit/agents/voice/io.py
+++ b/livekit-agents/livekit/agents/voice/io.py
@@ -377,7 +377,10 @@ class _AudioSinkProxy(AudioOutput):
             old.off("playback_finished", self._forward_next_playback_finished)
             old.off("playback_started", self._forward_next_playback_started)
             if self._pending_playback_count > 0:
-                # stop audio still playing on the old sink
+                # a sink ends a segment when it is flushed, and nothing flushes this one
+                # once it is detached, so a clear alone leaves it open and holding audio
+                if self._capturing:
+                    old.flush()
                 old.clear_buffer()
             # progress only observes, so the clear is still the sink's last word
             old.off("playback_progressed", self._forward_next_playback_progressed)

--- a/livekit-agents/livekit/agents/voice/io.py
+++ b/livekit-agents/livekit/agents/voice/io.py
@@ -346,7 +346,8 @@ class _AudioSinkProxy(AudioOutput):
         self._pushed_duration: float = 0.0
         # the current sink counts from its own zero; these place its runs in the segment
         self._offset_base: float = 0.0
-        self._sink_reported = False
+        # how far the current sink said it played, None while it has reported nothing
+        self._sink_played: float | None = None
         self._sink_started_at: float | None = None
 
         self.set_next_in_chain(next_in_chain)
@@ -372,6 +373,7 @@ class _AudioSinkProxy(AudioOutput):
             return
 
         old = self._next_in_chain
+        played = 0.0
         if old is not None:
             # a clear can finish a segment that is not over, and that call is the proxy's
             old.off("playback_finished", self._forward_next_playback_finished)
@@ -385,25 +387,27 @@ class _AudioSinkProxy(AudioOutput):
             # progress only observes, so the clear is still the sink's last word
             old.off("playback_progressed", self._forward_next_playback_progressed)
 
-            # it cannot be asked once detached: what it was given counts as played, capped by
-            # how long it played, unless the recorder has the whole segment to place
-            if (
-                self._pending_playback_count > 0
-                and not self._sink_reported
-                and (self._capturing or self._offset_base)
-                and self._sink_started_at is not None
-            ):
-                self._report_run(
+            # where the old sink got to: what it reported, else what it was given capped by how
+            # long it has been playing; a sink that never said playback started played nothing
+            if self._sink_played is not None:
+                played = self._sink_played
+            elif self._sink_started_at is not None:
+                played = max(
+                    0.0,
                     min(
                         self._pushed_duration - self._offset_base,
                         time.time() - self._sink_started_at,
-                    )
+                    ),
                 )
+                # it cannot be asked once detached, so the assumed run is placed for it, unless
+                # the recorder has the whole segment to place
+                if self._pending_playback_count > 0 and (self._capturing or self._offset_base):
+                    self._report_run(played)
 
             if self._capturing:
                 # the new sink counts from its own zero, this far into the segment
                 self._offset_base = self._pushed_duration
-                self._sink_reported = False
+                self._sink_played = None
                 self._sink_started_at = None
 
             if self._attached:
@@ -420,7 +424,9 @@ class _AudioSinkProxy(AudioOutput):
         # a segment already flushed to the old sink will never be reported by the
         # new one; finish it as interrupted so wait_for_playout() doesn't hang
         if old is not None and self._pending_playback_count > 0 and not self._capturing:
-            self.on_playback_finished(playback_position=self._pushed_duration, interrupted=True)
+            self.on_playback_finished(
+                playback_position=self._offset_base + played, interrupted=True
+            )
 
     def _report_run(self, duration: float) -> None:
         """Report a run the current sink played but never reported itself.
@@ -439,11 +445,11 @@ class _AudioSinkProxy(AudioOutput):
         super()._forward_next_playback_started(ev)
 
     def _forward_next_playback_progressed(self, ev: PlaybackProgressedEvent) -> None:
-        self._sink_reported = True
+        self._sink_played = ev.offset + ev.duration
         super()._forward_next_playback_progressed(replace(ev, offset=self._offset_base + ev.offset))
 
     def _forward_next_playback_finished(self, ev: PlaybackFinishedEvent) -> None:
-        if self._offset_base and not self._sink_reported:
+        if self._offset_base and self._sink_played is None:
             # all it said is how much played; the offset is the segment's to supply
             self._report_run(ev.playback_position)
 
@@ -462,7 +468,7 @@ class _AudioSinkProxy(AudioOutput):
             self._capturing = True
             self._pushed_duration = 0.0
             self._offset_base = 0.0
-            self._sink_reported = False
+            self._sink_played = None
             self._sink_started_at = None
 
         await super().capture_frame(frame)

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -162,7 +162,12 @@ class _ParticipantAudioOutput(io.AudioOutput):
     def _report_run(
         self, *, offset: float, ended_at: float, resumes_at: float | None = None
     ) -> None:
-        """Report the open run, and begin the next past any audio that never played."""
+        """Report the open run, and begin the next past any audio that never played.
+
+        The run covers ``[_run_offset, offset)`` and stopped at ``ended_at``. The next one
+        starts at ``offset``, or at ``resumes_at`` when the audio between the two was
+        discarded rather than played.
+        """
         if self._dry_at is not None:
             # a run cannot outlast the audio the source held, however late the caller noticed
             ended_at = min(ended_at, self._dry_at)

--- a/livekit-agents/livekit/agents/voice/room_io/_output.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_output.py
@@ -142,6 +142,12 @@ class _ParticipantAudioOutput(io.AudioOutput):
 
         if not self._pushed_duration:
             return
+
+        # a detaching sink never reaches the playout wait, so the playhead is reported here
+        self._report_run(
+            offset=self._source_pushed_duration - self._audio_source.queued_duration,
+            ended_at=time.time(),
+        )
         self._interrupted_event.set()
 
     def pause(self) -> None:

--- a/tests/test_audio_sink_proxy.py
+++ b/tests/test_audio_sink_proxy.py
@@ -223,6 +223,116 @@ async def test_swap_stops_playback_progress_from_the_old_leaf() -> None:
     assert received == []
 
 
+class _ReportingSink(FakeAudioOutput):
+    """A sink with a local playhead, which reports it as it is cleared."""
+
+    def __init__(self, played: float = 0.4, started_at: float = 100.0) -> None:
+        super().__init__()
+        self._played = played
+        self._started_at = started_at
+
+    def clear_buffer(self) -> None:
+        self.on_playback_progressed(started_at=self._started_at, offset=0.0, duration=self._played)
+        super().clear_buffer()
+
+
+async def test_a_swap_still_hears_where_the_old_sink_got_to() -> None:
+    """The clear happens while the proxy is still listening for progress."""
+    leaf_a, leaf_b = _ReportingSink(), FakeAudioOutput()
+    wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
+    proxy = wrapper.next_in_chain
+    assert isinstance(proxy, _AudioSinkProxy)
+
+    received: list[PlaybackProgressedEvent] = []
+    wrapper.on("playback_progressed", received.append)
+
+    await wrapper.capture_frame(_silence(duration_s=1.0))
+    wrapper.flush()
+    proxy.set_next_in_chain(leaf_b)
+
+    assert [(ev.offset, ev.duration) for ev in received] == [(0.0, 0.4)]
+
+
+async def test_a_mid_segment_swap_keeps_progress_offsets_on_the_segment() -> None:
+    """A sink attached mid-segment counts from its own zero, the segment is already further in."""
+    leaf_a, leaf_b = _ReportingSink(played=2.0, started_at=100.0), FakeAudioOutput()
+    wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
+    proxy = wrapper.next_in_chain
+    assert isinstance(proxy, _AudioSinkProxy)
+
+    received: list[PlaybackProgressedEvent] = []
+    wrapper.on("playback_progressed", received.append)
+
+    # the avatar sink arrives mid-segment; what leaf_a still held never plays
+    await wrapper.capture_frame(_silence(duration_s=5.0))
+    proxy.set_next_in_chain(leaf_b)
+    await wrapper.capture_frame(_silence(duration_s=5.0))
+    leaf_b.on_playback_progressed(started_at=105.0, offset=0.0, duration=5.0)
+
+    assert [(ev.offset, ev.duration) for ev in received] == [(0.0, 2.0), (5.0, 5.0)]
+
+
+async def test_a_detached_sink_that_reported_nothing_keeps_its_stretch() -> None:
+    """It cannot be asked now, so all it was given counts as played."""
+    leaf_a, leaf_b = FakeAudioOutput(), FakeAudioOutput()
+    wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
+    proxy = wrapper.next_in_chain
+    assert isinstance(proxy, _AudioSinkProxy)
+
+    received: list[PlaybackProgressedEvent] = []
+    wrapper.on("playback_progressed", received.append)
+
+    await wrapper.capture_frame(_silence(duration_s=5.0))
+    proxy.set_next_in_chain(leaf_b)
+
+    assert [(ev.offset, ev.duration) for ev in received] == [(0.0, 5.0)]
+
+
+async def test_a_sink_that_only_reports_a_position_is_placed_at_its_offset() -> None:
+    """All a remote sink can say is how much played, so the segment supplies the where."""
+    leaf_a, leaf_b = _ReportingSink(played=0.03), FakeAudioOutput()
+    wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
+    proxy = wrapper.next_in_chain
+    assert isinstance(proxy, _AudioSinkProxy)
+
+    received: list[PlaybackProgressedEvent] = []
+    wrapper.on("playback_progressed", received.append)
+
+    await wrapper.capture_frame(_silence(duration_s=0.05))
+    proxy.set_next_in_chain(leaf_b)
+    await wrapper.capture_frame(_silence(duration_s=0.02))
+    wrapper.flush()
+    await asyncio.wait_for(wrapper.wait_for_playout(), timeout=2.0)
+
+    # leaf_b reports no runs, only that 0.02s played, and the segment puts that at 0.05
+    assert [(round(ev.offset, 3), round(ev.duration, 3)) for ev in received] == [
+        (0.0, 0.03),
+        (0.05, 0.02),
+    ]
+
+
+async def test_the_next_segment_counts_from_its_own_start_again() -> None:
+    leaf_a, leaf_b = _ReportingSink(played=0.05), FakeAudioOutput()
+    wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
+    proxy = wrapper.next_in_chain
+    assert isinstance(proxy, _AudioSinkProxy)
+
+    received: list[PlaybackProgressedEvent] = []
+    wrapper.on("playback_progressed", received.append)
+
+    await wrapper.capture_frame(_silence(duration_s=0.05))
+    proxy.set_next_in_chain(leaf_b)
+    await wrapper.capture_frame(_silence(duration_s=0.02))
+    wrapper.flush()
+    await asyncio.wait_for(wrapper.wait_for_playout(), timeout=2.0)
+
+    await wrapper.capture_frame(_silence(duration_s=0.02))
+    leaf_b.on_playback_progressed(started_at=200.0, offset=0.0, duration=0.02)
+
+    # leaf_a's stretch, leaf_b's stretch in the same segment, then a segment from zero again
+    assert [round(ev.offset, 3) for ev in received] == [0.0, 0.05, 0.0]
+
+
 @pytest.mark.asyncio
 async def test_swap_disconnects_old_leaf() -> None:
     leaf_a = FakeAudioOutput()

--- a/tests/test_audio_sink_proxy.py
+++ b/tests/test_audio_sink_proxy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from unittest.mock import patch
 
 import pytest
 
@@ -272,9 +273,58 @@ async def test_a_mid_segment_swap_keeps_progress_offsets_on_the_segment() -> Non
     assert [(ev.offset, ev.duration) for ev in received] == [(0.0, 2.0), (5.0, 5.0)]
 
 
+class _StartedSink(_TrackingSink):
+    """Says playback started at a fixed time, and reports nothing else."""
+
+    def __init__(self, started_at: float) -> None:
+        super().__init__()
+        self._started_at = started_at
+        self._started = False
+
+    async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        await super().capture_frame(frame)
+        if not self._started:
+            self._started = True
+            self.on_playback_started(created_at=self._started_at)
+
+
 async def test_a_detached_sink_that_reported_nothing_keeps_its_stretch() -> None:
     """It cannot be asked now, so all it was given counts as played."""
-    leaf_a, leaf_b = FakeAudioOutput(), FakeAudioOutput()
+    leaf_a, leaf_b = _StartedSink(1000.0), FakeAudioOutput()
+    wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
+    proxy = wrapper.next_in_chain
+    assert isinstance(proxy, _AudioSinkProxy)
+
+    received: list[PlaybackProgressedEvent] = []
+    wrapper.on("playback_progressed", received.append)
+
+    await wrapper.capture_frame(_silence(duration_s=5.0))
+    with patch("livekit.agents.voice.io.time.time", return_value=1005.0):
+        proxy.set_next_in_chain(leaf_b)
+
+    assert [(ev.offset, ev.duration) for ev in received] == [(0.0, 5.0)]
+
+
+async def test_an_assumed_run_cannot_outrun_the_clock() -> None:
+    """Audio plays no faster than realtime, however much the sink was given."""
+    leaf_a, leaf_b = _StartedSink(1000.0), FakeAudioOutput()
+    wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
+    proxy = wrapper.next_in_chain
+    assert isinstance(proxy, _AudioSinkProxy)
+
+    received: list[PlaybackProgressedEvent] = []
+    wrapper.on("playback_progressed", received.append)
+
+    await wrapper.capture_frame(_silence(duration_s=5.0))
+    with patch("livekit.agents.voice.io.time.time", return_value=1000.1):
+        proxy.set_next_in_chain(leaf_b)  # given 5s, but only 0.1s has passed
+
+    assert [(ev.offset, round(ev.duration, 3)) for ev in received] == [(0.0, 0.1)]
+
+
+async def test_a_sink_that_never_started_playing_has_nothing_assumed() -> None:
+    """Its silence means nothing reached its device, not that it cannot report."""
+    leaf_a, leaf_b = _TrackingSink(), FakeAudioOutput()
     wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
     proxy = wrapper.next_in_chain
     assert isinstance(proxy, _AudioSinkProxy)
@@ -285,7 +335,54 @@ async def test_a_detached_sink_that_reported_nothing_keeps_its_stretch() -> None
     await wrapper.capture_frame(_silence(duration_s=5.0))
     proxy.set_next_in_chain(leaf_b)
 
-    assert [(ev.offset, ev.duration) for ev in received] == [(0.0, 5.0)]
+    assert received == []
+
+
+async def test_a_segment_ending_on_a_detached_sink_keeps_its_stretch() -> None:
+    """The swap ends the segment there, and the sink reported no run of its own."""
+    leaf_a, leaf_b = FakeAudioOutput(), _StartedSink(105.0)
+    wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
+    proxy = wrapper.next_in_chain
+    assert isinstance(proxy, _AudioSinkProxy)
+
+    received: list[PlaybackProgressedEvent] = []
+    wrapper.on("playback_progressed", received.append)
+
+    await wrapper.capture_frame(_silence(duration_s=2.0))
+    leaf_a.on_playback_progressed(started_at=100.0, offset=0.0, duration=2.0)
+    proxy.set_next_in_chain(leaf_b)  # mid-segment
+    await wrapper.capture_frame(_silence(duration_s=5.0))
+    wrapper.flush()
+    with patch("livekit.agents.voice.io.time.time", return_value=110.0):
+        proxy.set_next_in_chain(FakeAudioOutput())  # the segment ends on leaf_b
+
+    assert [(ev.offset, ev.duration) for ev in received] == [(0.0, 2.0), (2.0, 5.0)]
+
+
+async def test_a_swap_during_a_handover_counts_the_frame_on_the_old_sink() -> None:
+    """The old sink already has the frame, so the new sink's zero sits past it."""
+    box: list[tuple[_AudioSinkProxy, AudioOutput]] = []
+
+    class _SwappingSink(_TrackingSink):
+        async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+            await super().capture_frame(frame)
+            if box:
+                swap_proxy, new = box.pop()
+                swap_proxy.set_next_in_chain(new)
+
+    leaf_a, leaf_b = _SwappingSink(), FakeAudioOutput()
+    wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
+    proxy = wrapper.next_in_chain
+    assert isinstance(proxy, _AudioSinkProxy)
+    box.append((proxy, leaf_b))
+
+    received: list[PlaybackProgressedEvent] = []
+    wrapper.on("playback_progressed", received.append)
+
+    await wrapper.capture_frame(_silence(duration_s=0.5))
+    leaf_b.on_playback_progressed(started_at=200.0, offset=0.0, duration=0.5)
+
+    assert [(ev.offset, ev.duration) for ev in received] == [(0.5, 0.5)]
 
 
 async def test_a_sink_that_only_reports_a_position_is_placed_at_its_offset() -> None:

--- a/tests/test_audio_sink_proxy.py
+++ b/tests/test_audio_sink_proxy.py
@@ -361,10 +361,42 @@ class _ClearCountingSink(FakeAudioOutput):
     def __init__(self) -> None:
         super().__init__()
         self.clear_calls = 0
+        self.flush_calls = 0
+
+    def flush(self) -> None:
+        self.flush_calls += 1
+        super().flush()
 
     def clear_buffer(self) -> None:
         self.clear_calls += 1
         super().clear_buffer()
+
+
+async def test_a_mid_capture_swap_interrupts_the_old_sink() -> None:
+    """It sees a flush and a clear, the shape every other interruption gives it."""
+    leaf_a, leaf_b = _ClearCountingSink(), FakeAudioOutput()
+    wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
+    proxy = wrapper.next_in_chain
+    assert isinstance(proxy, _AudioSinkProxy)
+
+    await wrapper.capture_frame(_silence(duration_s=0.05))
+    proxy.set_next_in_chain(leaf_b)
+
+    assert (leaf_a.flush_calls, leaf_a.clear_calls) == (1, 1)
+
+
+async def test_a_swap_after_a_flush_does_not_flush_again() -> None:
+    """A second flush cancels the playout wait that is already draining the sink."""
+    leaf_a, leaf_b = _ClearCountingSink(), FakeAudioOutput()
+    wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
+    proxy = wrapper.next_in_chain
+    assert isinstance(proxy, _AudioSinkProxy)
+
+    await wrapper.capture_frame(_silence(duration_s=1.0))
+    wrapper.flush()
+    proxy.set_next_in_chain(leaf_b)
+
+    assert (leaf_a.flush_calls, leaf_a.clear_calls) == (1, 1)
 
 
 @pytest.mark.asyncio

--- a/tests/test_audio_sink_proxy.py
+++ b/tests/test_audio_sink_proxy.py
@@ -507,17 +507,39 @@ async def test_swap_finishes_pending_segment_as_interrupted() -> None:
     # a flushed segment still playing out on leaf_a (frames are pushed faster than realtime)
     await wrapper.capture_frame(_silence(duration_s=1.0))
     wrapper.flush()
+    assert leaf_a._started_at is not None
 
     received: list[PlaybackFinishedEvent] = []
     wrapper.on("playback_finished", received.append)
 
-    proxy.set_next_in_chain(leaf_b)
+    with patch("livekit.agents.voice.io.time.time", return_value=leaf_a._started_at + 0.4):
+        proxy.set_next_in_chain(leaf_b)  # given 1s, but only 0.4s has played
 
-    # the pending segment must be finished as interrupted so wait_for_playout() doesn't hang
+    # the pending segment must be finished as interrupted so wait_for_playout() doesn't hang,
+    # and where the old sink got to, not with all it was given
     ev = await asyncio.wait_for(wrapper.wait_for_playout(), timeout=0.5)
     assert ev.interrupted is True
-    assert ev.playback_position == pytest.approx(1.0)
+    assert ev.playback_position == pytest.approx(0.4)
     assert len(received) == 1
+
+
+async def test_a_swap_finishes_a_flushed_segment_where_the_sink_said_it_got_to() -> None:
+    """The clock overstates a sink that paused or ran dry; its own playhead wins."""
+    leaf_a, leaf_b = _ReportingSink(played=0.4), FakeAudioOutput()
+    wrapper = _PassthroughWrapper(next_in_chain=leaf_a)
+    proxy = wrapper.next_in_chain
+    assert isinstance(proxy, _AudioSinkProxy)
+
+    await wrapper.capture_frame(_silence(duration_s=1.0))
+    leaf_a.on_playback_started(created_at=100.0)
+    wrapper.flush()
+
+    with patch("livekit.agents.voice.io.time.time", return_value=100.9):
+        proxy.set_next_in_chain(leaf_b)  # 0.9s on the clock, but the clear reports 0.4s played
+
+    ev = await asyncio.wait_for(wrapper.wait_for_playout(), timeout=0.5)
+    assert ev.interrupted is True
+    assert ev.playback_position == pytest.approx(0.4)
 
 
 @pytest.mark.asyncio

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -246,6 +246,28 @@ async def test_an_interruption_ends_the_run_at_the_playhead() -> None:
     assert h.progress[0].duration == pytest.approx(pushed - 0.15)
 
 
+async def test_the_playout_wait_reports_what_plays_after_a_clear() -> None:
+    """The clear reports the playhead, and the queue plays on until the wait drops it."""
+    async with _Harness() as h:
+        await h.push(0.5)
+        pushed = h.sink._source_pushed_duration
+        h.source.queued_duration = 0.2
+
+        h.sink.flush()
+        h.sink.clear_buffer()
+        h.now += 0.05
+        h.source.queued_duration = 0.15  # the device played on while the wait was scheduled
+
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+    played = round(pushed - 0.2, 3)
+    assert [(round(ev.offset, 3), round(ev.duration, 3)) for ev in h.progress] == [
+        (0.0, played),
+        (played, 0.05),
+    ]
+
+
 async def test_offsets_restart_with_each_segment() -> None:
     async with _Harness() as h:
         for _ in range(2):

--- a/tests/test_playback_progress.py
+++ b/tests/test_playback_progress.py
@@ -141,6 +141,22 @@ async def test_a_flush_after_the_source_drained_ends_the_run_when_it_ran_dry() -
     assert ev.started_at == pytest.approx(dry_at - played)
 
 
+async def test_a_cleared_buffer_reports_the_playhead_without_waiting() -> None:
+    """A swap detaches the sink before its playout wait runs, so the clear is its last word."""
+    async with _Harness() as h:
+        await h.push(0.5)
+        pushed = h.sink._source_pushed_duration
+        h.now += 0.3
+        h.source.queued_duration = 0.2  # queued, so not yet played
+
+        h.sink.clear_buffer()
+
+    assert len(h.progress) == 1
+    ev = h.progress[0]
+    assert ev.offset == 0.0
+    assert ev.duration == pytest.approx(pushed - 0.2)
+
+
 async def test_a_cleared_queue_leaves_a_hole_rather_than_a_short_tail() -> None:
     """pause() drops what the source holds, so the audio that never played is in the middle."""
     async with _Harness() as h:

--- a/tests/test_recorder_io.py
+++ b/tests/test_recorder_io.py
@@ -130,6 +130,150 @@ async def test_the_fallback_truncates_an_interrupted_segment() -> None:
     assert round(placed[0][1].duration, 3) == 0.4
 
 
+class _RemoteSink(io.AudioOutput):
+    """A leaf shaped like a remote avatar worker: no runs, a position only at the end."""
+
+    def __init__(self, started_at: float = 100.0) -> None:
+        super().__init__(label="test", capabilities=io.AudioOutputCapabilities(pause=True))
+        self._started_at = started_at
+        self._received = 0.0
+
+    async def capture_frame(self, frame: rtc.AudioFrame) -> None:
+        await super().capture_frame(frame)
+        if not self._received:
+            self.on_playback_started(created_at=self._started_at)
+        self._received += frame.duration
+
+    def flush(self) -> None:
+        super().flush()
+
+    def clear_buffer(self) -> None:
+        pass
+
+    def finish_segment(self) -> None:
+        self.on_playback_finished(playback_position=self._received, interrupted=False)
+
+
+class _ReportingSink(_RemoteSink):
+    """A leaf with a local playhead, which reports it as it is cleared."""
+
+    def __init__(self, played: float = 0.0, started_at: float = 100.0) -> None:
+        super().__init__(started_at=started_at)
+        self._played = played
+
+    def clear_buffer(self) -> None:
+        self.on_playback_progressed(started_at=self._started_at, offset=0.0, duration=self._played)
+
+
+async def test_a_detached_sink_places_only_the_audio_it_played() -> None:
+    """A swap mid-playout must not record what the old sink still held."""
+    placed: list[tuple[float, rtc.AudioFrame]] = []
+    output = RecorderAudioOutput(
+        recording_io=MagicMock(recording=True),
+        audio_output=_ReportingSink(played=0.4),
+        on_played=lambda started_at, frame: placed.append((started_at, frame)),
+    )
+    proxy = output.next_in_chain
+    assert isinstance(proxy, io._AudioSinkProxy)
+
+    await output.capture_frame(_tone(1.0))
+    output.flush()
+    output.on_playback_started(created_at=100.0)
+
+    proxy.set_next_in_chain(_ReportingSink())  # 0.6s of the segment never played
+
+    assert len(placed) == 1
+    started_at, frame = placed[0]
+    assert started_at == 100.0
+    assert round(frame.duration, 3) == 0.4
+
+
+def _second(frame: rtc.AudioFrame) -> int:
+    """Which second of the marked segment a placed frame holds."""
+    data = np.frombuffer(frame.data, dtype=np.int16)
+    return int(np.unique(data)[0]) // 100 - 1
+
+
+def _marked(second: int) -> rtc.AudioFrame:
+    """One second of audio whose samples name their place in the segment."""
+    data = np.full(RATE, (second + 1) * 100, dtype=np.int16)
+    return rtc.AudioFrame(data.tobytes(), RATE, 1, RATE)
+
+
+async def _swap_mid_segment(
+    old: _RemoteSink, new: _RemoteSink
+) -> list[tuple[float, rtc.AudioFrame]]:
+    """A 10s segment whose sink is replaced after 5s, and where the recorder puts it."""
+    placed: list[tuple[float, rtc.AudioFrame]] = []
+    output = RecorderAudioOutput(
+        recording_io=MagicMock(recording=True),
+        audio_output=old,
+        on_played=lambda started_at, frame: placed.append((started_at, frame)),
+    )
+    proxy = output.next_in_chain
+    assert isinstance(proxy, io._AudioSinkProxy)
+
+    for s in range(5):
+        await output.capture_frame(_marked(s))
+    proxy.set_next_in_chain(new)
+    for s in range(5, 10):
+        await output.capture_frame(_marked(s))
+    output.flush()
+    new.finish_segment()
+    return placed
+
+
+async def test_a_sink_taking_over_a_segment_places_its_own_half() -> None:
+    """It counts from its own zero, so only the segment knows where its audio belongs."""
+    placed = await _swap_mid_segment(
+        _ReportingSink(played=2.0, started_at=100.0), _RemoteSink(started_at=105.0)
+    )
+
+    assert [(t, _second(f), round(f.duration, 3)) for t, f in placed] == [
+        (100.0, 0, 2.0),  # what the old sink reported playing
+        (105.0, 5, 5.0),  # the rest, which the new sink reports only as a position
+    ]
+
+
+async def test_a_detached_sink_that_reports_nothing_keeps_its_half() -> None:
+    """Everything it was given counts as played, the same as when a segment ends on it."""
+    placed = await _swap_mid_segment(_RemoteSink(started_at=100.0), _RemoteSink(started_at=105.0))
+
+    assert [(t, _second(f), round(f.duration, 3)) for t, f in placed] == [
+        (100.0, 0, 5.0),
+        (105.0, 5, 5.0),
+    ]
+
+
+async def test_each_sink_of_a_segment_places_the_stretch_it_was_given() -> None:
+    placed: list[tuple[float, rtc.AudioFrame]] = []
+    output = RecorderAudioOutput(
+        recording_io=MagicMock(recording=True),
+        audio_output=_RemoteSink(started_at=100.0),
+        on_played=lambda started_at, frame: placed.append((started_at, frame)),
+    )
+    proxy = output.next_in_chain
+    assert isinstance(proxy, io._AudioSinkProxy)
+    second, third = _RemoteSink(started_at=104.0), _RemoteSink(started_at=107.0)
+
+    for s in range(4):
+        await output.capture_frame(_marked(s))
+    proxy.set_next_in_chain(second)
+    for s in range(4, 7):
+        await output.capture_frame(_marked(s))
+    proxy.set_next_in_chain(third)
+    for s in range(7, 10):
+        await output.capture_frame(_marked(s))
+    output.flush()
+    third.finish_segment()
+
+    assert [(t, _second(f), round(f.duration, 3)) for t, f in placed] == [
+        (100.0, 0, 4.0),
+        (104.0, 4, 3.0),
+        (107.0, 7, 3.0),
+    ]
+
+
 async def test_a_segment_in_flight_holds_the_timeline() -> None:
     """The writer cannot settle a window whose agent audio has not been reported yet."""
     output, _ = _placing_output()


### PR DESCRIPTION
**Problem:** `replace_audio_tail` can swap the audio sink while a segment still plays. Each sink counts playback from its own first frame, not from the start of the segment, so the recorder placed the audio of a new sink at the segment start and dropped what the detached sink played.

**Fix:** Room I/O reports its playhead when it clears its buffer, and the proxy maps every report onto the segment timeline. A sink that reports no runs of its own, such as a remote avatar worker, is reported on its behalf.

Follow-up of https://github.com/livekit/agents/pull/6921#discussion_r3835990289

<details>
<summary>Context for reviewing and coding agents</summary>

> **How to see it**
>
> `tests/test_audio_sink_proxy.py` is a new file and every case in it describes behaviour main does not have. The recorder-side effect is covered by the new cases in `tests/test_recorder_io.py`.
>
> **Blast radius**
>
> `set_next_in_chain` has two callers: the proxy's own constructor, and `replace_audio_tail` at `io.py:731`. `replace_audio_tail` has one in-tree caller, `inference/avatar.py:318`, so the swap this fixes is the inference avatar handover. Every other sink chain reaches the untouched path.
>
> **The three fields and when they reset**
>
> `_offset_base` is where the current sink's zero sits inside the segment, `_sink_reported` records whether that sink ever emitted progress of its own, and `_sink_started_at` is when it began. All three reset on the first frame of a new segment in `capture_frame`; only `_offset_base` advances on a swap.
>
> **Why a detached sink's run is capped by elapsed time**
>
> `min(self._pushed_duration - self._offset_base, time.time() - self._sink_started_at)`. A sink can be handed more audio than it had time to play, and once it is detached it cannot be asked, so the smaller of the two is the most that can be claimed.
>
> **Why the old sink is flushed on the clear**
>
> A sink ends a segment when it is flushed, and nothing flushes it once detached. A clear alone would leave it open and holding audio.

</details>
