### PR TITLE
fix(cli): stabilize millisecond timestamp width

### DIFF
--- a/livekit-agents/livekit/agents/cli/_legacy.py
+++ b/livekit-agents/livekit/agents/cli/_legacy.py
@@ -846,6 +846,8 @@ class FrequencyVisualizer:
 
 
 class RichLoggingHandler(logging.Handler):
+    _DEFAULT_TIME_WIDTH = len("00:00:00.000")
+
     def __init__(self, agents_console: AgentsConsole):
         super().__init__()
         self.c = agents_console
@@ -881,15 +883,6 @@ class RichLoggingHandler(logging.Handler):
 
         MAX_NAME_WIDTH = 18
 
-        output = Table.grid(padding=(0, 1))
-        output.add_column(style="log.time")
-        output.add_column(style="log.level", width=8, no_wrap=True)
-        output.add_column(style="log.name", width=MAX_NAME_WIDTH, no_wrap=True, overflow="ellipsis")
-        output.add_column(ratio=1, style="log.message")
-        output.add_column(style="log.extra", no_wrap=True)
-
-        row: list[RenderableType] = []
-
         time_format = None if self.formatter is None else self.formatter.datefmt
         log_time = datetime.datetime.fromtimestamp(record.created)
         log_time = log_time or self.c.console.get_datetime()
@@ -899,6 +892,19 @@ class RichLoggingHandler(logging.Handler):
             if time_format
             else Text(log_time.strftime("%H:%M:%S.%f")[:-3])
         )
+
+        output = Table.grid(padding=(0, 1))
+        output.add_column(
+            style="log.time",
+            width=self._DEFAULT_TIME_WIDTH if time_format is None else None,
+            no_wrap=time_format is None,
+        )
+        output.add_column(style="log.level", width=8, no_wrap=True)
+        output.add_column(style="log.name", width=MAX_NAME_WIDTH, no_wrap=True, overflow="ellipsis")
+        output.add_column(ratio=1, style="log.message")
+        output.add_column(style="log.extra", no_wrap=True)
+
+        row: list[RenderableType] = []
 
         if log_time_display == self._last_time:
             time_str = log_time_display.plain

--- a/tests/test_cli_logging.py
+++ b/tests/test_cli_logging.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+from rich.table import Table
+from rich.text import Text
+
+from livekit.agents.cli._legacy import RichLoggingHandler
+
+pytestmark = pytest.mark.unit
+
+
+class _StubConsole:
+    width = 120
+
+    def print(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+class _StubAgentsConsole:
+    def __init__(self) -> None:
+        self.console = _StubConsole()
+        self.rendered: Table | None = None
+
+    def _render_tag(self, output: Table, *, tag_width: int) -> Table:
+        self.rendered = output
+        return output
+
+
+def test_default_millisecond_timestamp_has_fixed_width() -> None:
+    console = _StubAgentsConsole()
+    handler = RichLoggingHandler(console)  # type: ignore[arg-type]
+    record = logging.LogRecord("axum", logging.INFO, "", 0, "request complete", (), None)
+    record.created = 0.001
+
+    handler.emit(record)
+
+    assert console.rendered is not None
+    time_column = console.rendered.columns[0]
+    assert time_column.width == len("00:00:00.000")
+    assert time_column.no_wrap is True
+
+    timestamp = time_column._cells[0]
+    assert isinstance(timestamp, Text)
+    assert timestamp.cell_len == time_column.width


### PR DESCRIPTION
## Summary

- reserve a fixed 12-cell column for default millisecond timestamps
- preserve custom date-format sizing behavior
- add a regression test for timestamp width and no-wrap rendering

## Validation

- `uv run pytest tests/test_cli_log_level.py tests/test_cli_logging.py --unit` (26 passed)
- `uv run --group typing mypy --platform linux -p livekit.agents`
- `make check` formatting and lint passed; repository-wide mypy is blocked by the existing missing `boto3` stub in the AWS plugin