### PR TITLE
fix: retry connection pool prewarm after failure

### DIFF
--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -173,7 +173,13 @@ class ConnectionPool(Generic[T]):
         This method starts a background task that creates a new connection if none exist.
         The task automatically cleans itself up when the connection pool is closed.
         """
-        if self._prewarm_task is not None or self._connections:
+        if self._prewarm_task is not None:
+            task = self._prewarm_task()
+            if task is not None and not task.done():
+                return
+            self._prewarm_task = None
+
+        if self._connections:
             return
 
         async def _prewarm_impl() -> None:

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -142,3 +142,32 @@ async def test_prewarm_failure_does_not_leak_url_credentials_in_logs(caplog):
     ]
     assert warning_records
     assert warning_records[0].exception_type == "ConnectionError"
+
+
+@pytest.mark.asyncio
+async def test_prewarm_retries_after_failure():
+    attempts = 0
+
+    async def flaky_connect(timeout: float):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ConnectionError("temporary prewarm failure")
+        return DummyConnection(attempts)
+
+    pool = ConnectionPool(connect_cb=flaky_connect)
+    pool.prewarm()
+    task = pool._prewarm_task()
+    assert task is not None
+    await task
+
+    assert attempts == 1
+    assert not pool._connections
+
+    pool.prewarm()
+    task = pool._prewarm_task()
+    assert task is not None
+    await task
+
+    assert attempts == 2
+    assert len(pool._available) == 1


### PR DESCRIPTION
## Summary

`ConnectionPool.prewarm()` records an in-flight task to suppress duplicate work. When that task completes or fails, the task reference was retained, so later prewarm calls permanently skipped the pool even though no prewarm operation was still running.

This change clears the completed task reference before deciding whether to return, allowing a later call to retry after failure or perform a fresh prewarm after completion. The patch is limited to the connection-pool lifecycle and adds a regression for retry-after-failure behavior.

## Testing

- `uv run pytest tests/test_connection_pool.py --unit` - 7 passed.
- `uv run ruff check livekit-agents/livekit/agents/utils/connection_pool.py tests/test_connection_pool.py` - passed.
- `uv run ruff format --check livekit-agents/livekit/agents/utils/connection_pool.py tests/test_connection_pool.py` - passed.
- The core package strict mypy check passed before the final current-main rebase; the repository-wide `make check` format and lint stages pass on the current head. The repository-wide type stage remains blocked by the existing missing `boto3` import in the experimental AWS realtime plugin, outside this patch.
- `git diff --check origin/main...HEAD` - passed.

No external provider, LiveKit server, network credential, or integration account is required for this unit-level lifecycle regression.

The submitted commit is SSH-signed with the configured GitHub signing identity.

## Compatibility

This is backward compatible. Successful prewarm behavior is unchanged; failed or completed prewarm tasks can now be retried instead of suppressing all future attempts.
