### PR TITLE
fix(dtmf): drop removed repeat_instructions arg from GetDtmfTask example and docstring

### DIFF
--- a/examples/telephony/basic_dtmf_agent.py
+++ b/examples/telephony/basic_dtmf_agent.py
@@ -75,7 +75,6 @@ class DtmfAgent(Agent):
                         "press 1 to hear details about their current plan, press 2 to enable international data roaming, "
                         "or press 3 to explore upgrade options. Prompt them for a single digit and give them a moment to respond."
                     ),
-                    repeat_instructions=2,
                 )
             except ToolError as e:
                 await self.session.generate_reply(instructions=e.message, allow_interruptions=False)
@@ -115,7 +114,6 @@ class DtmfAgent(Agent):
                         "Provide an example such as 415 555 0199, remind them you're keeping their information secure, "
                         "then capture the digits. Read the number back in grouped segments for confirmation and invite them to confirm or re-enter."
                     ),
-                    repeat_instructions=2,
                 )
             except ToolError as e:
                 await self.session.generate_reply(instructions=e.message, allow_interruptions=False)

--- a/livekit-agents/livekit/agents/beta/workflows/dtmf_inputs.py
+++ b/livekit-agents/livekit/agents/beta/workflows/dtmf_inputs.py
@@ -49,7 +49,6 @@ class GetDtmfTask(AgentTask[GetDtmfResult]):
         Args:
             num_digits: The number of digits to collect.
             ask_for_confirmation: Whether to ask for confirmation when agent has collected full digits.
-            repeat_instructions: The number of times to repeat the initial instructions.
             dtmf_input_timeout: The per-digit timeout.
             dtmf_stop_event: The DTMF event to stop collecting inputs.
             chat_ctx: The chat context to use.


### PR DESCRIPTION
### Problem

`GetDtmfTask.__init__` (`livekit-agents/livekit/agents/beta/workflows/dtmf_inputs.py`) accepts these keyword-only parameters:

```
num_digits, ask_for_confirmation, dtmf_input_timeout, dtmf_stop_event, chat_ctx, extra_instructions
```

There is **no** `repeat_instructions` parameter and no `**kwargs`. However, the shipped example `examples/telephony/basic_dtmf_agent.py` passes `repeat_instructions=2` at **both** `GetDtmfTask(...)` call sites (in `ask_for_service` and `ask_for_phone_number`). Running the example therefore fails immediately with:

```
TypeError: GetDtmfTask.__init__() got an unexpected keyword argument 'repeat_instructions'
```

The `__init__` docstring also still lists `repeat_instructions: The number of times to repeat the initial instructions.` as an argument, even though that parameter no longer exists (the current supported one is `extra_instructions`, which both call sites already pass).

### Fix

- Remove the dead `repeat_instructions=2` keyword argument from both `GetDtmfTask(...)` call sites in `examples/telephony/basic_dtmf_agent.py`.
- Remove the stale `repeat_instructions` line from the `GetDtmfTask.__init__` docstring.

No behavior change beyond making the example runnable again; `extra_instructions` (already present at both call sites) is untouched.

### How to verify

- `grep -rn repeat_instructions` returns nothing after the change.
- The docstring `Args:` now matches the actual signature exactly.
- Instantiating `GetDtmfTask` with only the supported keyword arguments no longer raises `TypeError`.