### PR TITLE
fix(llm): place a backdated chat item by its creation time

### DIFF
--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -764,14 +764,14 @@ class ChatContext:
         return 0
 
     def _upsert_item(self, item: ChatItem, *, allow_type_mismatch: bool = False) -> None:
-        """Update an item with the same ID if it exists, otherwise append it."""
+        """Update an item with the same ID if it exists, otherwise insert it by creation time."""
         idx = self.index_by_id(item.id)
         if idx is not None:
             if not allow_type_mismatch and item.type != self._items[idx].type:
                 raise ValueError(f"Item type mismatch: {item.type} != {self._items[idx].type}")
             self._items[idx] = item
         else:
-            self._items.append(item)
+            self.insert(item)
 
     async def _summarize(
         self,

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -5,7 +5,14 @@ from typing import Any
 import pytest
 
 from livekit.agents import inference
-from livekit.agents.llm import AgentHandoff, ChatContext, FunctionCall, FunctionCallOutput, utils
+from livekit.agents.llm import (
+    AgentHandoff,
+    ChatContext,
+    ChatMessage,
+    FunctionCall,
+    FunctionCallOutput,
+    utils,
+)
 from livekit.agents.types import (
     DEFAULT_API_CONNECT_OPTIONS,
     NOT_GIVEN,
@@ -738,3 +745,40 @@ def test_resolve_template_identical_variants_collapse():
     assert instr.text is None
     assert instr.render() == "You are a helpful assistant.\n\nshared note"
     assert instr.render(modality="audio") == "You are a helpful assistant.\n\nshared note"
+
+
+def test_upsert_places_a_backdated_item_where_it_happened():
+    """A realtime user turn is stamped when it began, which can predate what is already there."""
+    ctx = ChatContext.empty()
+    first = ctx.add_message(role="user", content="first", id="a", created_at=100.0)
+    reply = ctx.add_message(role="assistant", content="reply", id="b", created_at=200.0)
+
+    backdated = ChatMessage(role="user", content=["spoken over the reply"], id="c")
+    backdated.created_at = 150.0
+    ctx._upsert_item(backdated)
+
+    assert [item.id for item in ctx.items] == [first.id, backdated.id, reply.id]
+
+
+def test_upsert_appends_an_item_stamped_now():
+    ctx = ChatContext.empty()
+    ctx.add_message(role="user", content="first", id="a", created_at=100.0)
+
+    fresh = ChatMessage(role="assistant", content=["later"], id="b")
+    ctx._upsert_item(fresh)
+
+    assert [item.id for item in ctx.items] == ["a", "b"]
+
+
+def test_upsert_still_replaces_an_item_in_place():
+    """A corrected transcript re-delivers the same id, and must not become a second item."""
+    ctx = ChatContext.empty()
+    ctx.add_message(role="user", content="first", id="a", created_at=100.0)
+    ctx.add_message(role="assistant", content="reply", id="b", created_at=200.0)
+
+    corrected = ChatMessage(role="user", content=["first, corrected"], id="a")
+    corrected.created_at = 100.0
+    ctx._upsert_item(corrected)
+
+    assert [item.id for item in ctx.items] == ["a", "b"]
+    assert ctx.items[0].text_content == "first, corrected"

--- a/tests/test_realtime_message_metrics.py
+++ b/tests/test_realtime_message_metrics.py
@@ -128,3 +128,31 @@ async def test_realtime_user_message_falls_back_to_delivery_time() -> None:
     assert len(messages) == 1
     assert before <= messages[0].created_at <= time.time()
     assert "started_speaking_at" not in messages[0].metrics
+
+
+async def test_realtime_user_turn_is_ordered_before_the_reply_it_prompted() -> None:
+    """A duplex model answers over the caller, so the transcript arrives after its own reply."""
+    model = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=False))
+
+    async with AgentSession(llm=model) as session:
+        agent = Agent(instructions="test")
+        await session.start(agent)
+
+        reply = agent.chat_ctx.add_message(
+            role="assistant", content="answering", id="reply", created_at=1_000_500.0
+        )
+        agent._chat_ctx.insert(reply)
+
+        model.active_session.emit(
+            "input_audio_transcription_completed",
+            llm.InputTranscriptionCompleted(
+                item_id="user_turn",
+                transcript="what is my name?",
+                is_final=True,
+                turn_started_at=1_000_000.0,
+            ),
+        )
+        await asyncio.sleep(0)
+
+        ids = [item.id for item in agent.chat_ctx.items if item.type == "message"]
+        assert ids.index("user_turn") < ids.index("reply")


### PR DESCRIPTION
**Problem**

`ChatContext._upsert_item` appends a new item rather than placing it by `created_at`.

That matched an ordered insert for as long as every caller stamped its items on creation, so nothing showed the difference. #6616 changed that: it backdates a realtime user message to the moment the turn began.

When a model can answer while the caller is still speaking, the final transcript arrives after the reply it prompted. The message then carries the earlier timestamp but sits after the reply in `chat_ctx.items`, and `created_at` runs backwards down the list.

**Fix**

The new-item branch calls `insert`, which places the item by creation time.

