### PR TITLE
test(google): disarm genai client finalizers in realtime tests

### DIFF
--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import pytest
-from google.genai import types
+from google.genai import _api_client, client as genai_client, types
 
 from livekit.agents import llm, utils
 from livekit.plugins.google.realtime.api_proto import ClientEvents
@@ -13,6 +13,20 @@ from livekit.plugins.google.realtime.realtime_api import RealtimeModel, Realtime
 from livekit.plugins.google.utils import create_function_response
 
 pytestmark = pytest.mark.unit
+
+
+# The genai ``AsyncClient.__del__`` and ``BaseApiClient.__del__`` schedule
+# ``aclose()`` on whatever event loop is running when the garbage collector
+# reaches them. Sessions in this module close their clients explicitly in
+# ``RealtimeSession.aclose()``, so those finalizers are pure redundancy — but
+# they leak tasks into whichever test happens to be running at GC time (issue
+# #6881). Disarm them here, in the module that owns the clients.
+def _noop_finalizer(self: object) -> None:
+    pass
+
+
+genai_client.AsyncClient.__del__ = _noop_finalizer  # type: ignore[attr-defined]
+_api_client.BaseApiClient.__del__ = _noop_finalizer  # type: ignore[attr-defined]
 
 # 10ms of silence at the output sample rate (24kHz mono, 16-bit)
 _PCM_FRAME = b"\x00\x01" * 240


### PR DESCRIPTION
Fixes #6881

## Problem

`tests/test_plugin_openai_stt_context.py::test_use_realtime_defaults_to_the_only_transport_a_model_has[gpt-realtime-whisper-True]` intermittently fails with:

```
Failed: Test leaked tasks:
Coroutine : BaseApiClient.aclose    google/genai/_api_client.py:2213
Coroutine : AsyncClient.aclose      google/genai/client.py:152
```

That test is synchronous and never touches google. The tasks come from `tests/test_plugin_google_realtime.py` — the only module in the unit suite that constructs genai clients.

## Root cause

`AsyncClient.__del__` and `BaseApiClient.__del__` both do this unconditionally, with no check for a client that was already closed:

```python
def __del__(self) -> None:
    try:
      asyncio.get_running_loop().create_task(self.aclose())
    except Exception:
      pass
```

`RealtimeSession.aclose()` closes `client.aio`, but that does not disarm the finalizer — the object stays garbage until the collector reaches it, which can be several modules later. `fail_on_leaked_tasks` diffs `asyncio.all_tasks()` around each test, so the task is charged to whatever test happens to be running then.

## Fix

Disarm both finalizers at module import in `tests/test_plugin_google_realtime.py` — the only module that constructs genai clients. Sessions already close their clients explicitly, so the finalizers are pure redundancy.

Verified:
- Without the disarm, dropping a client schedules 2 pending `AsyncClient.aclose` tasks on the running loop
- With the disarm, zero tasks leak
- All 18 realtime tests pass; full unit suite passes (1735 passed)