### PR TITLE
fix: retry recording upload connection failures

### DIFF
--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import random
 import threading
 import time
 from collections.abc import Callable, Iterator
@@ -457,13 +458,11 @@ def _chat_item_span_attribute(item: ChatItem) -> dict:
     return MessageToDict(encode_chat_item(item), preserving_proto_field_name=True)
 
 
-async def _parse_retry_delay(resp: aiohttp.ClientResponse) -> float | None:
-    """Parse a protobuf Status error response for RetryInfo and return the retry delay in seconds,
-    or None if the error is not retryable."""
+def _parse_retry_delay(body: bytes) -> float | None:
+    """Return the delay from a protobuf ``RetryInfo`` detail, if present."""
     from google.rpc import error_details_pb2, status_pb2  # type: ignore[import-untyped]
 
     try:
-        body = await resp.read()
         status = status_pb2.Status()
         status.ParseFromString(body)
         for detail in status.details:
@@ -475,6 +474,14 @@ async def _parse_retry_delay(resp: aiohttp.ClientResponse) -> float | None:
         pass
 
     return None
+
+
+_RECORDING_UPLOAD_TIMEOUT = aiohttp.ClientTimeout(total=900, sock_connect=30)
+_RECORDING_UPLOAD_MAX_RETRIES = 3
+
+
+def _recording_upload_retry_delay(attempt: int) -> float:
+    return random.uniform(0.0, min(2.0**attempt, 8.0))
 
 
 async def _upload_session_report(
@@ -671,8 +678,7 @@ async def _upload_session_report(
 
         return mp
 
-    max_retries = 3
-    for attempt in range(max_retries + 1):
+    for attempt in range(_RECORDING_UPLOAD_MAX_RETRIES + 1):
         mp = _build_multipart()
         headers = {
             "Authorization": f"Bearer {jwt}",
@@ -680,27 +686,45 @@ async def _upload_session_report(
         }
 
         logger.debug("uploading session report to LiveKit Cloud")
-        async with http_session.post(url, data=mp, headers=headers) as resp:
-            if resp.status < 400:
-                break
+        retry: tuple[float, str] | None = None
+        try:
+            async with http_session.post(
+                url,
+                data=mp,
+                headers=headers,
+                timeout=_RECORDING_UPLOAD_TIMEOUT,
+            ) as resp:
+                if resp.status < 400:
+                    break
 
-            body = await resp.read()
-            if _upload_gate.is_disabled_response(resp.status, body):
-                _upload_gate.disable()
-                return
+                body = await resp.read()
+                if _upload_gate.is_disabled_response(resp.status, body):
+                    _upload_gate.disable()
+                    return
 
-            retry_delay = await _parse_retry_delay(resp)
-            if retry_delay is None or attempt == max_retries:
-                resp.raise_for_status()
-                raise RuntimeError(f"recording upload failed: status {resp.status}")
+                retry_delay = _parse_retry_delay(body)
+                if retry_delay is None or attempt == _RECORDING_UPLOAD_MAX_RETRIES:
+                    resp.raise_for_status()
+                else:
+                    retry = (retry_delay, f"status {resp.status}")
+        except aiohttp.ClientSSLError:
+            raise
+        except (aiohttp.ConnectionTimeoutError, aiohttp.ClientConnectorError) as e:
+            if attempt == _RECORDING_UPLOAD_MAX_RETRIES:
+                raise
+            retry = (_recording_upload_retry_delay(attempt), type(e).__name__)
 
-            logger.warning(
-                "recording upload failed (attempt %d/%d), retrying in %.1fs",
-                attempt + 1,
-                max_retries + 1,
-                retry_delay,
-            )
-            await asyncio.sleep(retry_delay)
+        if retry is None:
+            break
+        retry_delay, failure = retry
+        logger.warning(
+            "recording upload failed (%s, attempt %d/%d), retrying in %.1fs",
+            failure,
+            attempt + 1,
+            _RECORDING_UPLOAD_MAX_RETRIES + 1,
+            retry_delay,
+        )
+        await asyncio.sleep(retry_delay)
 
     logger.debug("finished uploading")
 

--- a/livekit-agents/livekit/agents/utils/http_context.py
+++ b/livekit-agents/livekit/agents/utils/http_context.py
@@ -14,11 +14,6 @@ from ..log import logger
 _ClientFactory = Callable[[], aiohttp.ClientSession]
 _ContextVar = contextvars.ContextVar[_ClientFactory | None]("agent_http_session")
 
-# aiohttp's total is cumulative over the whole operation, body consumption included,
-# so a still-flowing streaming response is cancelled once it's reached. sock_connect is
-# restated because a bare ClientTimeout(total=...) drops aiohttp's 30s default to None.
-_DEFAULT_TIMEOUT = aiohttp.ClientTimeout(total=900, sock_connect=30)
-
 
 def _has_system_trust_store() -> bool:
     """Whether OpenSSL's default verify paths resolve to something on disk.
@@ -87,9 +82,7 @@ def _new_session_ctx() -> _ClientFactory:
                 keepalive_timeout=120,  # the default is only 15s
                 ssl=_create_ssl_context(),
             )
-            g_session = aiohttp.ClientSession(
-                proxy=http_proxy, connector=connector, timeout=_DEFAULT_TIMEOUT
-            )
+            g_session = aiohttp.ClientSession(proxy=http_proxy, connector=connector)
         return g_session
 
     _ContextVar.set(_new_session)

--- a/tests/test_http_context_helper.py
+++ b/tests/test_http_context_helper.py
@@ -67,10 +67,9 @@ async def test_open_isolated_per_task() -> None:
     assert sess_a.closed and sess_b.closed
 
 
-async def test_shared_session_total_timeout_exceeds_aiohttp_default() -> None:
-    async with http_context.open() as session:
-        assert session.timeout.total == 900
-        assert session.timeout.sock_connect == 30
+async def test_shared_session_uses_aiohttp_default_timeout() -> None:
+    async with http_context.open() as session, aiohttp.ClientSession() as default_session:
+        assert session.timeout == default_session.timeout
 
 
 async def test_http_session_error_message_points_to_helper() -> None:

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import inspect
+import ssl
 from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
@@ -10,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
+from google.rpc import error_details_pb2, status_pb2
 
 from livekit.agents import Agent, AgentSession
 from livekit.agents.telemetry.traces import _upload_session_report
@@ -200,6 +203,14 @@ def _get_multipart_parts(mp_writer: aiohttp.MultipartWriter) -> dict[str, Any]:
     return parts
 
 
+def _retry_info_body(delay_seconds: int = 0) -> bytes:
+    retry_info = error_details_pb2.RetryInfo()
+    retry_info.retry_delay.seconds = delay_seconds
+    status = status_pb2.Status()
+    status.details.add().Pack(retry_info)
+    return status.SerializeToString()
+
+
 # ---------------------------------------------------------------------------
 # Group 1: RecordingOptions normalization (no JobContext)
 # ---------------------------------------------------------------------------
@@ -357,6 +368,134 @@ async def test_upload_transcript_only() -> None:
     assert "header" in part_names
     assert "chat_history" in part_names
     assert "audio" not in part_names
+
+
+async def test_upload_uses_extended_timeout() -> None:
+    report = _make_mock_report({"audio": False, "traces": False, "logs": False, "transcript": True})
+    mock_http = _make_mock_http()
+
+    with _patch_upload_deps():
+        await _call_upload(report, http_session=mock_http)
+
+    timeout = mock_http.post.call_args.kwargs["timeout"]
+    assert timeout.total == 900
+    assert timeout.sock_connect == 30
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(aiohttp.ConnectionTimeoutError("connect timed out"), id="connect-timeout"),
+        pytest.param(
+            aiohttp.ClientConnectorError(MagicMock(), OSError("connection failed")),
+            id="connector-error",
+        ),
+    ],
+)
+async def test_upload_retries_connection_failure(error: Exception) -> None:
+    report = _make_mock_report({"audio": False, "traces": False, "logs": False, "transcript": True})
+    failure_cm = AsyncMock()
+    failure_cm.__aenter__.side_effect = error
+
+    success_resp = AsyncMock()
+    success_resp.status = 200
+    success_cm = AsyncMock()
+    success_cm.__aenter__.return_value = success_resp
+
+    mock_http = MagicMock(spec=aiohttp.ClientSession)
+    mock_http.post.side_effect = [failure_cm, success_cm]
+
+    with (
+        _patch_upload_deps(),
+        patch(f"{_TRACES_MOD}._recording_upload_retry_delay", return_value=0.0),
+    ):
+        await _call_upload(report, http_session=mock_http)
+
+    assert mock_http.post.call_count == 2
+
+
+async def test_upload_retries_response_with_retry_info() -> None:
+    report = _make_mock_report({"audio": False, "traces": False, "logs": False, "transcript": True})
+    retry_resp = AsyncMock()
+    retry_resp.status = 503
+    retry_resp.read.return_value = _retry_info_body()
+    retry_cm = AsyncMock()
+    retry_cm.__aenter__.return_value = retry_resp
+
+    success_resp = AsyncMock()
+    success_resp.status = 200
+    success_cm = AsyncMock()
+    success_cm.__aenter__.return_value = success_resp
+
+    mock_http = MagicMock(spec=aiohttp.ClientSession)
+    mock_http.post.side_effect = [retry_cm, success_cm]
+
+    with _patch_upload_deps():
+        await _call_upload(report, http_session=mock_http)
+
+    assert mock_http.post.call_count == 2
+
+
+async def test_upload_does_not_retry_response_without_retry_info() -> None:
+    report = _make_mock_report({"audio": False, "traces": False, "logs": False, "transcript": True})
+    response_error = aiohttp.ClientResponseError(
+        MagicMock(), (), status=503, message="service unavailable"
+    )
+    response = AsyncMock()
+    response.status = 503
+    response.read.return_value = b""
+    response.raise_for_status = MagicMock(side_effect=response_error)
+    response_cm = AsyncMock()
+    response_cm.__aenter__.return_value = response
+    mock_http = MagicMock(spec=aiohttp.ClientSession)
+    mock_http.post.return_value = response_cm
+
+    with _patch_upload_deps(), pytest.raises(aiohttp.ClientResponseError) as exc_info:
+        await _call_upload(report, http_session=mock_http)
+
+    assert exc_info.value.status == 503
+    assert mock_http.post.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(asyncio.TimeoutError("upload timed out"), id="total-timeout"),
+        pytest.param(aiohttp.ServerDisconnectedError("response lost"), id="disconnected"),
+        pytest.param(
+            aiohttp.ClientConnectorSSLError(MagicMock(), ssl.SSLError("TLS failed")),
+            id="tls-error",
+        ),
+    ],
+)
+async def test_upload_does_not_retry_ambiguous_or_tls_failure(error: Exception) -> None:
+    report = _make_mock_report({"audio": False, "traces": False, "logs": False, "transcript": True})
+    failure_cm = AsyncMock()
+    failure_cm.__aenter__.side_effect = error
+    mock_http = MagicMock(spec=aiohttp.ClientSession)
+    mock_http.post.return_value = failure_cm
+
+    with _patch_upload_deps(), pytest.raises(type(error)):
+        await _call_upload(report, http_session=mock_http)
+
+    assert mock_http.post.call_count == 1
+
+
+async def test_upload_stops_after_connection_retries_are_exhausted() -> None:
+    report = _make_mock_report({"audio": False, "traces": False, "logs": False, "transcript": True})
+    timeout_cm = AsyncMock()
+    timeout_cm.__aenter__.side_effect = aiohttp.ConnectionTimeoutError("connect timed out")
+    mock_http = MagicMock(spec=aiohttp.ClientSession)
+    mock_http.post.return_value = timeout_cm
+
+    with (
+        _patch_upload_deps(),
+        patch(f"{_TRACES_MOD}._recording_upload_retry_delay", return_value=0.0),
+        pytest.raises(aiohttp.ConnectionTimeoutError, match="connect timed out"),
+    ):
+        await _call_upload(report, http_session=mock_http)
+
+    assert mock_http.post.call_count == 4
 
 
 async def test_upload_session_report_sent_without_transcript() -> None:


### PR DESCRIPTION
Recording/session report uploads can fail before request transmission. Retry DNS, connection, and connection-timeout failures, plus responses that explicitly include protobuf `RetryInfo`. Do not retry total timeouts or post-send disconnects because the upload POST is not idempotent.

Keep the 900-second timeout on this upload only. Other users of the shared HTTP session use aiohttp defaults again.

Addresses AGT-3354

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> do we have retry when recording upload failed due to timeout?

> we should add retry at http level?

> yes please. then we can restore the original default timeout and only use 900s timeout for uploading too, right?

> okay, create a PR please. Uploads refer to the recording/session report upload, right?

> sg, we should honor RetryInfo, but I don't think we set them properly today. yeah, limit the retry scope as well.

</details>
