### PR TITLE
fix(workflows): ask before recording a volunteered value

### DIFF
--- a/examples/data_capture_sim/scenarios.yaml
+++ b/examples/data_capture_sim/scenarios.yaml
@@ -200,16 +200,16 @@ scenarios:
       DO, IN ORDER:
       1. When the agent asks for your card number, give the 10-digit partial
          number as if it were complete.
-      2. When the agent says it's invalid or asks you to repeat, give the full
-         4242 4242 4242 4242.
+      2. When the agent says it's invalid, incomplete, or asks you to continue or
+         repeat, give all sixteen digits: 4242 4242 4242 4242.
       3. Repeat the full number when asked to confirm it.
       4. Provide the expiration, security code, and name as asked, repeating
          each back when asked to confirm.
       5. Don't hang up until the agent confirms the card details are complete.
     agent_expectations: >
-      Tells the user the number is invalid (wrong length) and asks them to
-      repeat it — it must not accept the 10-digit number, must not go silent
-      after the invalid attempt, and must not read the card number back aloud.
+      Does not record the 10-digit number, and keeps talking: it asks for the
+      full number or for the remaining digits. It must not go silent after the
+      short attempt and must not read the card number back aloud.
       After the full 16-digit number is given and repeated, the flow proceeds
       through expiration, security code, and cardholder name to completion.
     tags:

--- a/examples/data_capture_sim/scenarios.yaml
+++ b/examples/data_capture_sim/scenarios.yaml
@@ -141,14 +141,16 @@ scenarios:
       - time of birth: 6:45 in the morning
       - date of birth: March 3rd, 1992
       DO, IN ORDER:
-      1. When asked for the date of birth, give ONLY the time first: "I was born
+      1. Open by naming the detail you are offering (your opening line). The
+         agent asks which detail you want to give; "date of birth" is the answer.
+      2. When asked for the date of birth, give ONLY the time first: "I was born
          at 6:45 in the morning." Do not mention the date yet.
-      2. If the agent asks you to confirm before you've given a date, say "yes,
+      3. If the agent asks you to confirm before you've given a date, say "yes,
          that's right" - do NOT volunteer the date until the agent explicitly
          asks for the date itself.
-      3. When the agent asks for the date, give March 3rd, 1992.
-      4. Confirm the full date (and time) when read back.
-      5. Don't hang up until the agent reads back March 3rd, 1992 as captured.
+      4. When the agent asks for the date, give March 3rd, 1992.
+      5. Confirm the full date (and time) when read back.
+      6. Don't hang up until the agent reads back March 3rd, 1992 as captured.
     agent_expectations: >
       Records the 6:45 AM time of birth but recognizes the date is still
       missing: if the user tries to confirm before any date exists, the agent
@@ -164,16 +166,18 @@ scenarios:
   - label: Date of birth corrected while confirming
     instructions: |
       PERSONA: Ana Sofia Torres, mixes up day and month at first.
-      OPENING LINE: "Sure, my date of birth - it's July 9th, 1988."
+      OPENING LINE: "I'd like to give you my date of birth."
       FACTS:
       - first date given: July 9th, 1988
       - corrected date: September 7th, 1988
       DO, IN ORDER:
-      1. Give July 9th, 1988 when asked.
-      2. When the agent asks you to confirm, say: "hold on, I always flip those -
+      1. Open by naming the detail you are offering (your opening line). The
+         agent asks which detail you want to give; "date of birth" is the answer.
+      2. Give July 9th, 1988 when asked.
+      3. When the agent asks you to confirm, say: "hold on, I always flip those -
          it's September 7th, 1988. Yes, that's right."
-      3. If the agent asks you to confirm the corrected date, confirm it.
-      4. Don't hang up until the agent reads back September 7th, 1988 as captured.
+      4. If the agent asks you to confirm the corrected date, confirm it.
+      5. Don't hang up until the agent reads back September 7th, 1988 as captured.
     agent_expectations: >
       After the correction at the confirmation step, the agent confirms and
       completes with September 7th, 1988 — never July 9th. It responds verbally

--- a/livekit-agents/livekit/agents/beta/workflows/address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/address.py
@@ -75,7 +75,14 @@ class GetAddressTask(AgentTask[GetAddressResult]):
         )
 
     async def on_enter(self) -> None:
-        self.session.generate_reply(instructions="Ask the user to provide their address.")
+        self.session.generate_reply(
+            instructions=(
+                "Get the user's address. First scan the conversation - if an address was already "
+                "given (e.g. the user volunteered it before the task started), use it via "
+                "update_address rather than re-asking. Only ask fresh when no address is in the "
+                "conversation yet."
+            )
+        )
 
     def _build_update_address_tool(self) -> llm.FunctionTool:
         # Built dynamically so we can apply IGNORE_ON_ENTER per-instance

--- a/livekit-agents/livekit/agents/beta/workflows/address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/address.py
@@ -77,10 +77,8 @@ class GetAddressTask(AgentTask[GetAddressResult]):
     async def on_enter(self) -> None:
         self.session.generate_reply(
             instructions=(
-                "Get the user's address. First scan the conversation - if an address was already "
-                "given (e.g. the user volunteered it before the task started), use it via "
-                "update_address rather than re-asking. Only ask fresh when no address is in the "
-                "conversation yet."
+                "Ask the user for their address. If the user already stated one earlier in "
+                "this conversation, record it with update_address instead of asking again."
             )
         )
 

--- a/livekit-agents/livekit/agents/beta/workflows/email_address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/email_address.py
@@ -169,16 +169,12 @@ EMAIL_REGEX = (
 PERSONA = "You are only a single step in a broader system, responsible solely for capturing an email address."
 
 AUDIO_SPECIFIC = """\
-Handle input as noisy voice transcription. Expect that users will say emails aloud with formats like:
-- 'john dot doe at gmail dot com'
-- 'susan underscore smith at yahoo dot co dot uk'
-- 'dave dash b at protonmail dot com'
-- 'jane at example' (partial—prompt for the domain)
-- 'theo t h e o at livekit dot io' (name followed by spelling)
+Handle input as noisy voice transcription. Users say emails aloud.
 Normalize common spoken patterns silently:
 - Convert words like 'dot', 'underscore', 'dash', 'plus' into symbols: `.`, `_`, `-`, `+`.
 - Convert 'at' to `@`.
 - Recognize patterns where users speak their name or a word, followed by spelling: e.g., 'john j o h n'.
+- If only the part before the '@' is given, prompt for the domain.
 - Filter out filler words or hesitations.
 - Assume some spelling if contextually obvious (e.g. 'mike b two two' → mikeb22).
 Don't mention corrections. Treat inputs as possibly imperfect but fix them silently."""

--- a/livekit-agents/livekit/agents/beta/workflows/email_address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/email_address.py
@@ -76,7 +76,14 @@ class GetEmailTask(AgentTask[GetEmailResult]):
         )
 
     async def on_enter(self) -> None:
-        self.session.generate_reply(instructions="Ask the user to provide an email address.")
+        self.session.generate_reply(
+            instructions=(
+                "Get the user's email address. First scan the conversation - if an email "
+                "address was already given (e.g. the user volunteered it before the task "
+                "started), use it via update_email_address rather than re-asking. Only ask "
+                "fresh when no email address is in the conversation yet."
+            )
+        )
 
     def _build_update_email_tool(self) -> llm.FunctionTool:
         # Built dynamically so we can apply IGNORE_ON_ENTER per-instance

--- a/livekit-agents/livekit/agents/beta/workflows/email_address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/email_address.py
@@ -78,10 +78,8 @@ class GetEmailTask(AgentTask[GetEmailResult]):
     async def on_enter(self) -> None:
         self.session.generate_reply(
             instructions=(
-                "Get the user's email address. First scan the conversation - if an email "
-                "address was already given (e.g. the user volunteered it before the task "
-                "started), use it via update_email_address rather than re-asking. Only ask "
-                "fresh when no email address is in the conversation yet."
+                "Ask the user for their email address. If the user already stated one earlier "
+                "in this conversation, record it with update_email_address instead of asking again."
             )
         )
 

--- a/livekit-agents/livekit/agents/beta/workflows/phone_number.py
+++ b/livekit-agents/livekit/agents/beta/workflows/phone_number.py
@@ -111,7 +111,14 @@ class GetPhoneNumberTask(AgentTask[GetPhoneNumberResult]):
         )
 
     async def on_enter(self) -> None:
-        self.session.generate_reply(instructions="Ask the user to provide their phone number.")
+        self.session.generate_reply(
+            instructions=(
+                "Get the user's phone number. First scan the conversation - if a phone number "
+                "was already given (e.g. the user volunteered it before the task started), use "
+                "it via update_phone_number rather than re-asking. Only ask fresh when no phone "
+                "number is in the conversation yet."
+            )
+        )
 
     def _build_update_phone_number_tool(self) -> llm.FunctionTool:
         # Built dynamically so we can apply IGNORE_ON_ENTER per-instance

--- a/livekit-agents/livekit/agents/beta/workflows/phone_number.py
+++ b/livekit-agents/livekit/agents/beta/workflows/phone_number.py
@@ -113,10 +113,8 @@ class GetPhoneNumberTask(AgentTask[GetPhoneNumberResult]):
     async def on_enter(self) -> None:
         self.session.generate_reply(
             instructions=(
-                "Get the user's phone number. First scan the conversation - if a phone number "
-                "was already given (e.g. the user volunteered it before the task started), use "
-                "it via update_phone_number rather than re-asking. Only ask fresh when no phone "
-                "number is in the conversation yet."
+                "Ask the user for their phone number. If the user already stated one earlier "
+                "in this conversation, record it with update_phone_number instead of asking again."
             )
         )
 


### PR DESCRIPTION
## What

Two fixes surfaced by the data-capture-sim CI job (`examples/data_capture_sim`), which had been red on main since Aug 14. Split out of #6849, which now stacks on this branch. The related framework fix is #6981.

### 1. `GetEmailTask` / `GetPhoneNumberTask` / `GetAddressTask` fabricate a value on enter (`beta/workflows`)

The `on_enter` instruction added to stop re-asking for a volunteered value led with the tool call ("First scan the conversation - if an email was already given, use it via `update_email_address`… Only ask fresh when…"). With nothing from the user in context, gpt-4.1 filled the call from whatever address-shaped text was nearby in the system prompt (`john.doe@gmail.com`, `mikeb22@gmail.com`) and the task completed before the user spoke. `tests/test_workflows.py::test_collect_email` failed 3/3 locally.

Clause order is the variable, not detail: wordings that lead with asking and make recording the exception pass. A/B on gpt-4.1, 5 trials each, two scenarios:

| on_enter wording | empty context | value volunteered earlier |
|---|---|---|
| tool-call first (as merged) | 1/5 | 5/5 |
| "Ask the user for their email address. If the user already stated one earlier in this conversation, record it with update_email_address instead of asking again." | 5/5 | 5/5 |

Confirmed 20/20 before applying to all three tasks. `test_collect_email` passes 3/3 in both modalities. The example address list in the email task's audio instructions is replaced by rules; the one behavior only an example carried (a local part with no domain) becomes a rule.

### 2. data-capture-sim scenarios

- The simulated caller holds back any goal that provides a personal detail until the agent asks for it, and the agent only collects a detail the caller has named. An opening line that carries the value is held back with it, and both DOB scenarios stalled for five turns then hung up. They now open by naming the detail.
- The card task tells the caller to read digits one at a time, so the model asks for the rest of a 10-digit number rather than passing it to the tool. The expectation now judges what is recorded, not the wording of the refusal.

## Result

With both this and the framework fix: data-capture-sim 3/10 → 9/10 (the remaining failure: the sim user skipped its opening line and gave the number before entering the task). `evaluation` green.
