### PR TITLE
fix(agents): date an inline task's tool call with its result

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -1051,6 +1051,10 @@ class AgentTask(Agent, Generic[TaskResult_T]):
                     # set the chat_ctx directly, `session._update_activity` will sync it to the rt_session if needed
                     old_agent._chat_ctx.items[:] = merged_chat_ctx.items
 
+                    # the call sorts after the sub-conversation it produced, next to its output
+                    if (fnc_call := task_info.function_call) is not None:
+                        fnc_call.created_at = time.time()
+
                     await session._update_activity(
                         old_agent, new_activity="resume", wait_on_enter=False
                     )


### PR DESCRIPTION
## What

After a tool awaits an `AgentTask` and the task completes, the parent's next LLM turn sometimes calls the same tool again instead of using the result. A second task starts, the caller hangs up, and the tool fails with `AgentTask ... is cancelled`. Seen in the data-capture-sim CI job (`examples/data_capture_sim`) on main since at least Aug 20, in the phone and date-of-birth scenarios.

## Cause

The parent's `FunctionCall` item is created before the task's sub-conversation exists. When that conversation is merged into the parent's `chat_ctx` (sorted by `created_at`), the call sorts ahead of it, and `group_tool_calls` places its output beside the call. The parent model reads:

```
call collect_phone_number -> "Phone number captured: … Read it back."
assistant: Please tell me your phone number
… whole capture dialogue …
user: Yes, that's correct.
call confirm_phone_number -> (empty)
```

and treats the capture as still in progress.

## Fix

Date the call at task completion. The call then sorts after the sub-conversation it produced, next to its output:

```
… capture dialogue …
user: Yes, that's correct.
call confirm_phone_number -> (empty)
call collect_phone_number -> "Phone number captured: … Read it back."
assistant: Your phone number +1 415 555 0199 has been recorded. …
```

Parallel tool calls sharing a `group_id` are grouped at the first call's position, so this is a no-op for them.

## Measured

Real `DataCaptureAgent` on gpt-4.1-mini, 5-turn phone scenario, text modality: **3/10 re-calls before, 0/20 after**. Unit suite: 2133 passed.

agents-js has the same `merge` + `insert`-by-`createdAt` shape in `agents/src/voice/agent.ts` and needs the same change.
