### PR TITLE
feat: add Synthorai LLM factory method

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -944,6 +944,56 @@ class LLM(llm.LLM):
             tool_choice=NOT_GIVEN,
         )
 
+    @staticmethod
+    def with_synthorai(
+        *,
+        model: str = "claude-opus-5",
+        api_key: str | None = None,
+        base_url: str = "https://synthorai.io/v1",
+        client: openai.AsyncClient | None = None,
+        user: NotGivenOr[str] = NOT_GIVEN,
+        temperature: NotGivenOr[float] = NOT_GIVEN,
+        parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
+        tool_choice: ToolChoice = "auto",
+        reasoning_effort: NotGivenOr[ReasoningEffort] = NOT_GIVEN,
+        safety_identifier: NotGivenOr[str] = NOT_GIVEN,
+        prompt_cache_key: NotGivenOr[str] = NOT_GIVEN,
+        top_p: NotGivenOr[float] = NOT_GIVEN,
+    ) -> LLM:
+        """
+        Create a new instance of Synthorai LLM.
+
+        ``api_key`` must be set to your Synthorai API key, either using the argument or by setting
+        the ``SYNTHORAI_API_KEY`` environmental variable.
+
+        Synthorai provides access to 122 models from multiple providers including Anthropic,
+        OpenAI, Google, Z.ai, Moonshot, DeepSeek, and Qwen through a unified, OpenAI-compatible API.
+
+        Get your API key at: https://synthorai.io
+        Learn more: https://synthorai.io/docs
+        """
+
+        api_key = api_key or os.environ.get("SYNTHORAI_API_KEY")
+        if api_key is None:
+            raise ValueError(
+                "Synthorai API key is required, either as argument or set SYNTHORAI_API_KEY environmental variable"  # noqa: E501
+            )
+
+        return LLM(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            client=client,
+            user=user,
+            temperature=temperature,
+            parallel_tool_calls=parallel_tool_calls,
+            tool_choice=tool_choice,
+            reasoning_effort=reasoning_effort,
+            safety_identifier=safety_identifier,
+            prompt_cache_key=prompt_cache_key,
+            top_p=top_p,
+        )
+
     def chat(
         self,
         *,


### PR DESCRIPTION
Adds a `with_synthorai()` factory method to the OpenAI plugin's `LLM` class, following the same pattern as the existing gateway integrations (`with_cometapi`, `with_ovhcloud`, etc.).

Synthorai (https://synthorai.io) is an OpenAI/Anthropic-compatible LLM gateway routing to 113 models across 11 upstream providers (Claude, GPT, Gemini, GLM, Kimi, DeepSeek, Qwen, etc.) at direct upstream pricing, no markup. Docs: https://synthorai.io/docs

## Changes

- `livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py` — `with_synthorai()` static method, base_url `https://synthorai.io/v1`, reads `SYNTHORAI_API_KEY` from env

Plain OpenAI-compatible surface, no custom request/response shaping needed — same shape as the CometAPI/OVHcloud integrations.