### PR TITLE
fix(google): don't cut streaming TTS off at the connect timeout

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
@@ -451,15 +451,27 @@ class SynthesizeStream(tts.SynthesizeStream):
             except Exception:
                 logger.exception("an error occurred while streaming input to google TTS")
 
-        input_gen = input_generator()
+        # grpc.aio consumes the request generator from its own task and finalizes it once the RPC
+        # completes or is cancelled; closing it from here would race with that task ("aclose():
+        # asynchronous generator is already running") when the RPC ends while the LLM is still
+        # producing text.
         try:
-            stream = await self._tts._ensure_client().streaming_synthesize(
-                input_gen, timeout=self._conn_options.timeout
-            )
+            # no RPC deadline: the call stays open for as long as the LLM keeps producing text,
+            # the connect timeout only bounds the wait for the first audio chunk
+            stream = await self._tts._ensure_client().streaming_synthesize(input_generator())
             output_emitter.start_segment(segment_id=utils.shortuuid())
 
-            async for resp in stream:
+            resp_iter = aiter(stream)
+            try:
+                resp = await asyncio.wait_for(
+                    anext(resp_iter, None), timeout=self._conn_options.timeout
+                )
+            except asyncio.TimeoutError:
+                raise APITimeoutError() from None
+
+            while resp is not None:
                 output_emitter.push(resp.audio_content)
+                resp = await anext(resp_iter, None)
 
             output_emitter.end_segment()
 
@@ -467,8 +479,6 @@ class SynthesizeStream(tts.SynthesizeStream):
             raise APITimeoutError() from None
         except GoogleAPICallError as e:
             raise APIStatusError(e.message, status_code=e.code or -1, body=f"{e.details}") from e
-        finally:
-            await input_gen.aclose()
 
 
 def _gender_from_str(gender: str) -> SsmlVoiceGender:

--- a/tests/test_plugin_google_tts.py
+++ b/tests/test_plugin_google_tts.py
@@ -1,0 +1,157 @@
+"""Unit tests for the Google TTS plugin's streaming synthesis."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator
+
+import pytest
+from google.api_core.exceptions import DeadlineExceeded
+from google.cloud import texttospeech
+
+from livekit.agents import APIConnectOptions, APITimeoutError
+from livekit.plugins.google import tts as google_tts
+
+pytestmark = pytest.mark.plugin("google")
+
+# 100ms of 24kHz 16-bit mono PCM per synthesized sentence
+_AUDIO_CHUNK = b"\x01\x00" * 2400
+
+SENTENCES = [
+    "This is the first sentence of a long reply.",
+    "The language model keeps producing more text.",
+    "And the very last sentence closes the reply.",
+]
+
+
+class _FakeStreamingCall:
+    """Stand-in for the bidi StreamingSynthesize call.
+
+    Mirrors grpc.aio: the request iterator is consumed by a background task, ``timeout`` is a
+    deadline for the whole call, and cancelling a read cancels the RPC (and its request poller).
+    Replies with one audio chunk per text input, unless ``respond`` is False (stalled server).
+    """
+
+    def __init__(
+        self,
+        requests: AsyncIterator[texttospeech.StreamingSynthesizeRequest],
+        *,
+        timeout: float | None,
+        respond: bool,
+    ) -> None:
+        self.timeout = timeout
+        self.received: list[texttospeech.StreamingSynthesizeRequest] = []
+        self._respond = respond
+        self._deadline = None if timeout is None else time.monotonic() + timeout
+        self._responses = asyncio.Queue[texttospeech.StreamingSynthesizeResponse | None]()
+        self._poller = asyncio.create_task(self._consume_requests(requests))
+
+    async def _consume_requests(
+        self, requests: AsyncIterator[texttospeech.StreamingSynthesizeRequest]
+    ) -> None:
+        async for req in requests:
+            self.received.append(req)
+            if self._respond and req.input.text:
+                self._responses.put_nowait(
+                    texttospeech.StreamingSynthesizeResponse(audio_content=_AUDIO_CHUNK)
+                )
+        # client half-closed the stream, the server finishes it
+        self._responses.put_nowait(None)
+
+    def cancel(self) -> None:
+        self._poller.cancel()
+
+    def __aiter__(self) -> _FakeStreamingCall:
+        return self
+
+    async def __anext__(self) -> texttospeech.StreamingSynthesizeResponse:
+        remaining = None if self._deadline is None else self._deadline - time.monotonic()
+        try:
+            resp = await asyncio.wait_for(self._responses.get(), remaining)
+        except asyncio.TimeoutError:
+            raise DeadlineExceeded("Deadline Exceeded") from None
+        except asyncio.CancelledError:
+            self.cancel()
+            raise
+
+        if resp is None:
+            raise StopAsyncIteration
+        return resp
+
+
+class _FakeTTSClient:
+    def __init__(self, *, respond: bool = True) -> None:
+        self.calls: list[_FakeStreamingCall] = []
+        self._respond = respond
+
+    async def streaming_synthesize(
+        self,
+        requests: AsyncIterator[texttospeech.StreamingSynthesizeRequest],
+        *,
+        timeout: float | None = None,
+        **_kwargs: object,
+    ) -> _FakeStreamingCall:
+        call = _FakeStreamingCall(requests, timeout=timeout, respond=self._respond)
+        self.calls.append(call)
+        return call
+
+
+def _make_tts(client: _FakeTTSClient) -> google_tts.TTS:
+    tts = google_tts.TTS()
+    tts._client = client  # type: ignore[assignment]
+    return tts
+
+
+async def _collect_audio(stream: google_tts.SynthesizeStream) -> int:
+    num_bytes = 0
+    async for ev in stream:
+        num_bytes += ev.frame.data.nbytes
+    return num_bytes
+
+
+async def test_streaming_not_cut_off_by_connect_timeout() -> None:
+    # the LLM keeps producing text for longer than the connect timeout: the RPC must stay
+    # open and every sentence must be synthesized
+    client = _FakeTTSClient()
+    tts = _make_tts(client)
+    stream = tts.stream(conn_options=APIConnectOptions(max_retry=0, timeout=0.2))
+
+    async def _push() -> None:
+        for sentence in SENTENCES:
+            stream.push_text(sentence + " ")
+            await asyncio.sleep(0.15)
+        stream.end_input()
+
+    push_task = asyncio.create_task(_push())
+    try:
+        num_bytes = await asyncio.wait_for(_collect_audio(stream), timeout=5.0)
+    finally:
+        await asyncio.gather(push_task, return_exceptions=True)
+        await stream.aclose()
+
+    assert len(client.calls) == 1
+    texts = [req.input.text for req in client.calls[0].received if req.input.text]
+    assert " ".join(texts).split() == " ".join(SENTENCES).split()
+    assert num_bytes == len(SENTENCES) * len(_AUDIO_CHUNK)
+
+
+async def test_streaming_first_response_timeout() -> None:
+    # a server that never answers must still surface an APITimeoutError within the connect
+    # timeout, even while the LLM is still producing text
+    client = _FakeTTSClient(respond=False)
+    tts = _make_tts(client)
+    stream = tts.stream(conn_options=APIConnectOptions(max_retry=0, timeout=0.2))
+    stream.push_text(SENTENCES[0] + " " + SENTENCES[1] + " ")
+
+    started_at = time.monotonic()
+    try:
+        with pytest.raises(APITimeoutError):
+            await asyncio.wait_for(_collect_audio(stream), timeout=5.0)
+    finally:
+        await stream.aclose()
+
+    assert time.monotonic() - started_at < 2.0
+    assert len(client.calls) == 1
+    # the first sentence was sent and the input was still open when the timeout fired
+    assert any(req.input.text for req in client.calls[0].received)


### PR DESCRIPTION

**Problem**

`SynthesizeStream._run_stream` passes `conn_options.timeout` (10 s by default, documented as the *connect* timeout) as `timeout=` of `streaming_synthesize()`. For a gapic streaming method that is the gRPC deadline of the whole bidi call (`google.api_core` → `grpc.aio.StreamStreamMultiCallable(timeout=...)`, "duration of time in seconds to allow for the RPC"), and the request generator keeps the call open for as long as the LLM produces text for the segment. Any reply that takes longer than 10 s to generate and synthesize is ended with `DeadlineExceeded` → `APITimeoutError` mid-utterance, and because audio was already emitted the base class doesn't retry ("TTS failed after partial audio was already sent to the user, skip retrying") — the rest of the turn is dropped. `use_streaming=True` is the default, so this hits every long reply.

The deadline has a second effect: grpc only cancels its request-poller task in `cancel()`, never when the deadline fires. So when the LLM is still producing text at that moment, the poller is mid-`__anext__` on `input_gen` and the `finally: await input_gen.aclose()` fails with `RuntimeError: aclose(): asynchronous generator is already running` (the traceback in #2951), leaking the poller.

**Fix**

- Open the RPC without a deadline (like `stt.py`'s `streaming_recognize`), and use `conn_options.timeout` only to bound the wait for the first audio chunk (`asyncio.wait_for` on the first `anext`), still surfacing it as `APITimeoutError`. Subsequent chunks are unbounded, since the gaps between them follow the LLM's pace.
- Let grpc own the request generator's lifetime: it finalizes it when the call completes or is cancelled (which is what a first-chunk timeout does), so the explicit `aclose()` that raced with grpc's poller is gone.

`ChunkedStream` is untouched: there the kwarg is a per-request deadline for a single unary `synthesize_speech`, which is what it should be.

**Tests**

`tests/test_plugin_google_tts.py` drives `tts.stream()` against a fake client that mirrors grpc.aio (request iterator consumed by a background task, `timeout` enforced as a whole-call deadline, cancelling a read cancels the RPC and its poller):
- `test_streaming_not_cut_off_by_connect_timeout`: three sentences pushed over ~0.45 s with `timeout=0.2` — every sentence reaches the fake and every audio byte is delivered. On `main` it fails with the `aclose()` RuntimeError above and a leaked poller task.
- `test_streaming_first_response_timeout`: a server that never answers while the input is still open raises `APITimeoutError` within the timeout, with no leaked tasks.

ruff / mypy (strict) clean.

Fixes #3347
Fixes the timeout part of #5117 (its chirp_3 voice-name error is a separate config/model-support question).
Also fixes the `aclose(): asynchronous generator is already running` failure reported in #2951.