### PR TITLE
fix: warn about realtime audio redaction

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -282,6 +282,18 @@ class AgentActivity(RecognitionHooks):
                 "turn detection."
             )
 
+        if (
+            isinstance(self.llm, llm.RealtimeModel)
+            and self._session.options.recording_options["audio"]
+            and self._session._redaction_enabled
+            and not self._session._warned_realtime_audio_redaction
+        ):
+            logger.warning(
+                "RealtimeModel user turns lack complete speech timestamps, so audio redaction "
+                "may be inaccurate; disable audio recording to prevent redaction leak."
+            )
+            self._session._warned_realtime_audio_redaction = True
+
         if self._rt_turn_detection_enabled and not self.allow_interruptions:
             raise ValueError(
                 "the RealtimeModel uses a server-side turn detection, "

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -709,6 +709,8 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         self._recorded_events: list[AgentEvent] = []
         self._started_at: float | None = None
         self._usage_collector = ModelUsageCollector()
+        self._redaction_enabled = False
+        self._warned_realtime_audio_redaction = False
 
         # ivr and AMD
         self._ivr_activity: IVRActivity | None = None
@@ -922,6 +924,11 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
                             self._opts.recording_options = _resolve_recording_options(False)
 
                 job_ctx.init_recording(self._opts.recording_options)
+
+            self._redaction_enabled = bool(
+                self._opts.recording_options["redaction"]
+                or (job_ctx and job_ctx.job.enable_redaction)
+            )
 
             # hosting needs the primary designation as before, and the caller's consent
             hosting = is_primary and (session_host if is_given(session_host) else True)

--- a/tests/test_realtime_message_metrics.py
+++ b/tests/test_realtime_message_metrics.py
@@ -1,5 +1,8 @@
 import asyncio
+import logging
 import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -8,8 +11,54 @@ from livekit.agents import Agent, AgentSession, llm, utils
 from livekit.agents.voice.events import ConversationItemAddedEvent
 
 from .fake_realtime import FakeRealtimeModel, fake_capabilities
+from .fake_stt import FakeSTT
 
 pytestmark = pytest.mark.unit
+
+
+_REALTIME_AUDIO_REDACTION_WARNING = (
+    "RealtimeModel user turns lack complete speech timestamps, so audio redaction may be "
+    "inaccurate; disable audio recording to prevent redaction leak."
+)
+
+
+def _fake_job_context(*, enable_redaction: bool) -> MagicMock:
+    job_ctx = MagicMock()
+    job_ctx.job.enable_recording = True
+    job_ctx.job.enable_redaction = enable_redaction
+    job_ctx.job.id = "test-job-id"
+    job_ctx.job.room.sid = "test-room-sid"
+    job_ctx.job.agent_name = "test-agent"
+    job_ctx.room.name = "test-room"
+    job_ctx._primary_agent_session = None
+    job_ctx.session_directory = Path("/tmp/test-session")
+    return job_ctx
+
+
+async def _run_realtime_redaction_session(
+    *,
+    project_redaction: bool,
+    session_redaction: bool,
+    audio_recording: bool = True,
+    stt: FakeSTT | None = None,
+    server_turn_detection: bool = True,
+) -> None:
+    model = FakeRealtimeModel(
+        capabilities=fake_capabilities(turn_detection=server_turn_detection, audio_output=False)
+    )
+    job_ctx = _fake_job_context(enable_redaction=project_redaction)
+
+    with patch("livekit.agents.voice.agent_session.get_job_context", return_value=job_ctx):
+        async with AgentSession(
+            llm=model,
+            stt=stt,
+            vad=None,
+            turn_handling={"turn_detection": None},
+        ) as session:
+            await session.start(
+                Agent(instructions="test"),
+                record={"audio": audio_recording, "redaction": session_redaction},
+            )
 
 
 async def test_realtime_response_id_is_available_on_assistant_message() -> None:
@@ -156,3 +205,84 @@ async def test_realtime_user_turn_is_ordered_before_the_reply_it_prompted() -> N
 
         ids = [item.id for item in agent.chat_ctx.items if item.type == "message"]
         assert ids.index("user_turn") < ids.index("reply")
+
+
+@pytest.mark.parametrize(
+    ("project_redaction", "session_redaction"),
+    [(True, False), (False, True)],
+    ids=["project", "session"],
+)
+async def test_realtime_audio_redaction_warns_when_redaction_is_enabled(
+    caplog: pytest.LogCaptureFixture,
+    project_redaction: bool,
+    session_redaction: bool,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        await _run_realtime_redaction_session(
+            project_redaction=project_redaction,
+            session_redaction=session_redaction,
+        )
+
+    assert _REALTIME_AUDIO_REDACTION_WARNING in caplog.messages
+
+
+@pytest.mark.parametrize(
+    ("with_stt", "server_turn_detection"),
+    [(True, True), (False, False)],
+    ids=["with-stt", "without-server-turn-detection"],
+)
+async def test_realtime_audio_redaction_warning_covers_all_realtime_turn_modes(
+    caplog: pytest.LogCaptureFixture,
+    with_stt: bool,
+    server_turn_detection: bool,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        await _run_realtime_redaction_session(
+            project_redaction=True,
+            session_redaction=False,
+            stt=FakeSTT() if with_stt else None,
+            server_turn_detection=server_turn_detection,
+        )
+
+    assert _REALTIME_AUDIO_REDACTION_WARNING in caplog.messages
+
+
+@pytest.mark.parametrize(
+    ("project_redaction", "session_redaction", "audio_recording"),
+    [(False, False, True), (True, False, False)],
+    ids=["redaction-disabled", "audio-recording-disabled"],
+)
+async def test_realtime_audio_redaction_warning_requires_redacted_audio_recording(
+    caplog: pytest.LogCaptureFixture,
+    project_redaction: bool,
+    session_redaction: bool,
+    audio_recording: bool,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        await _run_realtime_redaction_session(
+            project_redaction=project_redaction,
+            session_redaction=session_redaction,
+            audio_recording=audio_recording,
+        )
+
+    assert _REALTIME_AUDIO_REDACTION_WARNING not in caplog.messages
+
+
+async def test_realtime_audio_redaction_warning_is_emitted_once_per_session(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    model = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=False))
+
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        async with AgentSession(
+            llm=model, vad=None, turn_handling={"turn_detection": None}
+        ) as session:
+            await session.start(
+                Agent(instructions="first"),
+                record={"redaction": True},
+            )
+            session.update_agent(Agent(instructions="second"))
+            assert session._update_activity_atask is not None
+            await session._update_activity_atask
+
+    assert caplog.messages.count(_REALTIME_AUDIO_REDACTION_WARNING) == 1


### PR DESCRIPTION
Realtime audio user turns lack complete speech timestamps, which can make audio redaction inaccurate. Warn once per session when redaction and audio recording are enabled. The warning also covers realtime sessions with STT or client-side turn detection.

Python already reports Unix seconds, so this port excludes Node's timestamp conversion.

Addresses AGT-3375

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> port node 2348 to Python, only the warning part, we don't need the unix timestamp convert
>
> RealtimeModel user turns lack complete speech timestamps, so audio redaction may be inaccurate; disable audio recording to prevent redaction leak.

</details>
