### PR TITLE
workflows: spell the value back once the caller refuses a confirmation

### DIFF
--- a/livekit-agents/livekit/agents/beta/workflows/address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/address.py
@@ -11,7 +11,7 @@ from ...types import NOT_GIVEN, NotGivenOr
 from ...utils import is_given
 from ...voice.agent import AgentTask
 from ...voice.events import RunContext
-from .utils import WorkflowInstructions
+from .utils import ReadBack, WorkflowInstructions
 
 if TYPE_CHECKING:
     from ...voice.turn import TurnDetectionMode
@@ -59,6 +59,7 @@ class GetAddressTask(AgentTask[GetAddressResult]):
 
         assert isinstance(instructions, (str, Instructions))  # for type checking
         self._current_address = ""
+        self._read_back = ReadBack()
         self._require_confirmation = require_confirmation
         self._require_explicit_ask = require_explicit_ask
 
@@ -135,9 +136,16 @@ class GetAddressTask(AgentTask[GetAddressResult]):
         current_tools.append(confirm_tool)
         await self.update_tools(current_tools)
 
+        read_back = self._read_back.instruction(
+            natural="Repeat the address back to the user.",
+            spelled=(
+                f"Repeat the address field by field, spelling the street name letter by "
+                f"letter: {address_fields}"
+            ),
+        )
         return (
             f"The address has been updated to {address}\n"
-            f"Repeat the address field by field: {address_fields} if needed\n"
+            f"{read_back}\n"
             f"Prompt the user for confirmation, do not call `confirm_address` directly"
         )
 

--- a/livekit-agents/livekit/agents/beta/workflows/address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/address.py
@@ -11,7 +11,7 @@ from ...types import NOT_GIVEN, NotGivenOr
 from ...utils import is_given
 from ...voice.agent import AgentTask
 from ...voice.events import RunContext
-from .utils import ReadBack, WorkflowInstructions
+from .utils import WorkflowInstructions
 
 if TYPE_CHECKING:
     from ...voice.turn import TurnDetectionMode
@@ -59,7 +59,7 @@ class GetAddressTask(AgentTask[GetAddressResult]):
 
         assert isinstance(instructions, (str, Instructions))  # for type checking
         self._current_address = ""
-        self._read_back = ReadBack()
+        self._spell_read_back = False
         self._require_confirmation = require_confirmation
         self._require_explicit_ask = require_explicit_ask
 
@@ -136,13 +136,13 @@ class GetAddressTask(AgentTask[GetAddressResult]):
         current_tools.append(confirm_tool)
         await self.update_tools(current_tools)
 
-        read_back = self._read_back.instruction(
-            natural="Repeat the address back to the user.",
-            spelled=(
-                f"Repeat the address field by field, spelling the street name letter by "
-                f"letter: {address_fields}"
-            ),
+        read_back = (
+            f"Repeat the address field by field, spelling the street name letter by "
+            f"letter: {address_fields}"
+            if self._spell_read_back
+            else "Repeat the address back to the user."
         )
+        self._spell_read_back = True
         return (
             f"The address has been updated to {address}\n"
             f"{read_back}\n"

--- a/livekit-agents/livekit/agents/beta/workflows/address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/address.py
@@ -138,7 +138,7 @@ class GetAddressTask(AgentTask[GetAddressResult]):
 
         read_back = (
             f"Repeat the address field by field, spelling the street name letter by "
-            f"letter: {[' '.join(street_address), *address_fields[1:]]}"
+            f"letter: {[' '.join(street_address.replace(' ', '')), *address_fields[1:]]}"
             if self._spell_read_back
             else "Repeat the address back to the user."
         )

--- a/livekit-agents/livekit/agents/beta/workflows/address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/address.py
@@ -138,7 +138,7 @@ class GetAddressTask(AgentTask[GetAddressResult]):
 
         read_back = (
             f"Repeat the address field by field, spelling the street name letter by "
-            f"letter: {address_fields}"
+            f"letter: {[' '.join(street_address), *address_fields[1:]]}"
             if self._spell_read_back
             else "Repeat the address back to the user."
         )

--- a/livekit-agents/livekit/agents/beta/workflows/dob.py
+++ b/livekit-agents/livekit/agents/beta/workflows/dob.py
@@ -11,6 +11,7 @@ from ...types import NOT_GIVEN, NotGivenOr
 from ...utils import is_given
 from ...voice.agent import AgentTask
 from ...voice.events import RunContext
+from .utils import ReadBack
 
 if TYPE_CHECKING:
     from ...voice.audio_recognition import TurnDetectionMode
@@ -91,6 +92,7 @@ class GetDOBTask(AgentTask[GetDOBResult]):
         self._require_explicit_ask = require_explicit_ask
         self._current_dob: date | None = None
         self._current_time: time | None = None
+        self._read_back = ReadBack()
 
         super().__init__(
             instructions=Instructions(
@@ -195,9 +197,15 @@ class GetDOBTask(AgentTask[GetDOBResult]):
             formatted_time = self._current_time.strftime("%I:%M %p")
             response += f" at {formatted_time}"
 
+        read_back = self._read_back.instruction(
+            natural="Repeat the date back to the user in a natural spoken format.",
+            spelled=(
+                f"Repeat the date back one part at a time, the month, the day, then the year: "
+                f"{dob.strftime('%B')}, {dob.day}, {dob.year}"
+            ),
+        )
         response += (
-            "\nRepeat the date back to the user in a natural spoken format.\n"
-            "Prompt the user for confirmation, do not call `confirm_dob` directly"
+            f"\n{read_back}\nPrompt the user for confirmation, do not call `confirm_dob` directly"
         )
 
         return response

--- a/livekit-agents/livekit/agents/beta/workflows/dob.py
+++ b/livekit-agents/livekit/agents/beta/workflows/dob.py
@@ -11,7 +11,6 @@ from ...types import NOT_GIVEN, NotGivenOr
 from ...utils import is_given
 from ...voice.agent import AgentTask
 from ...voice.events import RunContext
-from .utils import ReadBack
 
 if TYPE_CHECKING:
     from ...voice.audio_recognition import TurnDetectionMode
@@ -92,7 +91,7 @@ class GetDOBTask(AgentTask[GetDOBResult]):
         self._require_explicit_ask = require_explicit_ask
         self._current_dob: date | None = None
         self._current_time: time | None = None
-        self._read_back = ReadBack()
+        self._spell_read_back = False
 
         super().__init__(
             instructions=Instructions(
@@ -197,13 +196,13 @@ class GetDOBTask(AgentTask[GetDOBResult]):
             formatted_time = self._current_time.strftime("%I:%M %p")
             response += f" at {formatted_time}"
 
-        read_back = self._read_back.instruction(
-            natural="Repeat the date back to the user in a natural spoken format.",
-            spelled=(
-                f"Repeat the date back one part at a time, the month, the day, then the year: "
-                f"{dob.strftime('%B')}, {dob.day}, {dob.year}"
-            ),
+        read_back = (
+            f"Repeat the date back one part at a time, the month, the day, then the year: "
+            f"{dob.strftime('%B')}, {dob.day}, {dob.year}"
+            if self._spell_read_back
+            else "Repeat the date back to the user in a natural spoken format."
         )
+        self._spell_read_back = True
         response += (
             f"\n{read_back}\nPrompt the user for confirmation, do not call `confirm_dob` directly"
         )

--- a/livekit-agents/livekit/agents/beta/workflows/email_address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/email_address.py
@@ -12,7 +12,7 @@ from ...types import NOT_GIVEN, NotGivenOr
 from ...utils import is_given
 from ...voice.agent import AgentTask
 from ...voice.events import RunContext
-from .utils import ReadBack, WorkflowInstructions
+from .utils import WorkflowInstructions
 
 if TYPE_CHECKING:
     from ...voice.turn import TurnDetectionMode
@@ -60,7 +60,7 @@ class GetEmailTask(AgentTask[GetEmailResult]):
 
         assert isinstance(instructions, (str, Instructions))  # for type checking
         self._current_email = ""
-        self._read_back = ReadBack()
+        self._spell_read_back = False
         self._require_confirmation = require_confirmation
         self._require_explicit_ask = require_explicit_ask
 
@@ -119,10 +119,12 @@ class GetEmailTask(AgentTask[GetEmailResult]):
         current_tools.append(confirm_tool)
         await self.update_tools(current_tools)
 
-        read_back = self._read_back.instruction(
-            natural="Repeat the email back to the user.",
-            spelled=f"Repeat the email character by character: {separated_email}",
+        read_back = (
+            f"Repeat the email character by character: {separated_email}"
+            if self._spell_read_back
+            else "Repeat the email back to the user."
         )
+        self._spell_read_back = True
         return (
             f"The email has been updated to {email}\n"
             f"{read_back}\n"

--- a/livekit-agents/livekit/agents/beta/workflows/email_address.py
+++ b/livekit-agents/livekit/agents/beta/workflows/email_address.py
@@ -12,7 +12,7 @@ from ...types import NOT_GIVEN, NotGivenOr
 from ...utils import is_given
 from ...voice.agent import AgentTask
 from ...voice.events import RunContext
-from .utils import WorkflowInstructions
+from .utils import ReadBack, WorkflowInstructions
 
 if TYPE_CHECKING:
     from ...voice.turn import TurnDetectionMode
@@ -60,6 +60,7 @@ class GetEmailTask(AgentTask[GetEmailResult]):
 
         assert isinstance(instructions, (str, Instructions))  # for type checking
         self._current_email = ""
+        self._read_back = ReadBack()
         self._require_confirmation = require_confirmation
         self._require_explicit_ask = require_explicit_ask
 
@@ -118,9 +119,13 @@ class GetEmailTask(AgentTask[GetEmailResult]):
         current_tools.append(confirm_tool)
         await self.update_tools(current_tools)
 
+        read_back = self._read_back.instruction(
+            natural="Repeat the email back to the user.",
+            spelled=f"Repeat the email character by character: {separated_email}",
+        )
         return (
             f"The email has been updated to {email}\n"
-            f"Repeat the email character by character: {separated_email} if needed\n"
+            f"{read_back}\n"
             f"Prompt the user for confirmation, do not call `confirm_email_address` directly"
         )
 

--- a/livekit-agents/livekit/agents/beta/workflows/name.py
+++ b/livekit-agents/livekit/agents/beta/workflows/name.py
@@ -10,6 +10,7 @@ from ...types import NOT_GIVEN, NotGivenOr
 from ...utils import is_given
 from ...voice.agent import AgentTask
 from ...voice.events import RunContext
+from .utils import ReadBack
 
 if TYPE_CHECKING:
     from ...voice.audio_recognition import TurnDetectionMode
@@ -130,6 +131,7 @@ class GetNameTask(AgentTask[GetNameResult]):
         self._first_name: str = ""
         self._middle_name: str = ""
         self._last_name: str = ""
+        self._read_back = ReadBack()
 
         super().__init__(
             instructions=Instructions(
@@ -268,17 +270,18 @@ class GetNameTask(AgentTask[GetNameResult]):
         current_tools.append(confirm_tool)
         await self.update_tools(current_tools)
 
-        if self._verify_spelling:
-            return (
-                f"The name has been updated to {full_name}\n"
-                f"Spell out the name letter by letter for verification: {full_name}\n"
-                f"Prompt the user for confirmation, do not call `confirm_name` directly"
+        spelled = f"Spell out the name letter by letter for verification: {full_name}"
+        read_back = (
+            spelled
+            if self._verify_spelling
+            else self._read_back.instruction(
+                natural="Repeat the name back to the user.", spelled=spelled
             )
-
+        )
         return (
             f"The name has been updated to {full_name}\n"
-            f"Repeat the name back to the user and prompt for confirmation, "
-            f"do not call `confirm_name` directly"
+            f"{read_back}\n"
+            f"Prompt the user for confirmation, do not call `confirm_name` directly"
         )
 
     def _build_confirm_tool(

--- a/livekit-agents/livekit/agents/beta/workflows/name.py
+++ b/livekit-agents/livekit/agents/beta/workflows/name.py
@@ -10,7 +10,6 @@ from ...types import NOT_GIVEN, NotGivenOr
 from ...utils import is_given
 from ...voice.agent import AgentTask
 from ...voice.events import RunContext
-from .utils import ReadBack
 
 if TYPE_CHECKING:
     from ...voice.audio_recognition import TurnDetectionMode
@@ -96,7 +95,7 @@ class GetNameTask(AgentTask[GetNameResult]):
         self._collect_first_name = first_name
         self._collect_last_name = last_name
         self._collect_middle_name = middle_name
-        self._verify_spelling = verify_spelling
+        self._spell_read_back = verify_spelling
         self._require_confirmation = require_confirmation
         self._require_explicit_ask = require_explicit_ask
 
@@ -131,7 +130,6 @@ class GetNameTask(AgentTask[GetNameResult]):
         self._first_name: str = ""
         self._middle_name: str = ""
         self._last_name: str = ""
-        self._read_back = ReadBack()
 
         super().__init__(
             instructions=Instructions(
@@ -270,14 +268,12 @@ class GetNameTask(AgentTask[GetNameResult]):
         current_tools.append(confirm_tool)
         await self.update_tools(current_tools)
 
-        spelled = f"Spell out the name letter by letter for verification: {full_name}"
         read_back = (
-            spelled
-            if self._verify_spelling
-            else self._read_back.instruction(
-                natural="Repeat the name back to the user.", spelled=spelled
-            )
+            f"Spell out the name letter by letter for verification: {full_name}"
+            if self._spell_read_back
+            else "Repeat the name back to the user."
         )
+        self._spell_read_back = True
         return (
             f"The name has been updated to {full_name}\n"
             f"{read_back}\n"

--- a/livekit-agents/livekit/agents/beta/workflows/name.py
+++ b/livekit-agents/livekit/agents/beta/workflows/name.py
@@ -269,7 +269,7 @@ class GetNameTask(AgentTask[GetNameResult]):
         await self.update_tools(current_tools)
 
         read_back = (
-            f"Spell out the name letter by letter for verification: {' '.join(full_name)}"
+            f"Spell out the name letter by letter for verification: {' '.join(full_name.replace(' ', ''))}"
             if self._spell_read_back
             else "Repeat the name back to the user."
         )

--- a/livekit-agents/livekit/agents/beta/workflows/name.py
+++ b/livekit-agents/livekit/agents/beta/workflows/name.py
@@ -269,7 +269,7 @@ class GetNameTask(AgentTask[GetNameResult]):
         await self.update_tools(current_tools)
 
         read_back = (
-            f"Spell out the name letter by letter for verification: {full_name}"
+            f"Spell out the name letter by letter for verification: {' '.join(full_name)}"
             if self._spell_read_back
             else "Repeat the name back to the user."
         )

--- a/livekit-agents/livekit/agents/beta/workflows/phone_number.py
+++ b/livekit-agents/livekit/agents/beta/workflows/phone_number.py
@@ -11,6 +11,7 @@ from ...types import NOT_GIVEN, NotGivenOr
 from ...utils import is_given
 from ...voice.agent import AgentTask
 from ...voice.events import RunContext
+from .utils import ReadBack
 
 if TYPE_CHECKING:
     from ...voice.audio_recognition import TurnDetectionMode
@@ -80,6 +81,7 @@ class GetPhoneNumberTask(AgentTask[GetPhoneNumberResult]):
         extra = extra_instructions if extra_instructions else ""
 
         self._current_phone_number = ""
+        self._read_back = ReadBack()
         self._require_confirmation = require_confirmation
         self._require_explicit_ask = require_explicit_ask
 
@@ -152,9 +154,13 @@ class GetPhoneNumberTask(AgentTask[GetPhoneNumberResult]):
         current_tools.append(confirm_tool)
         await self.update_tools(current_tools)
 
+        read_back = self._read_back.instruction(
+            natural="Read the number back to the user in groups.",
+            spelled=f"Read the number back digit by digit: {' '.join(cleaned)}",
+        )
         return (
             f"The phone number has been updated to {cleaned}\n"
-            f"Read the number back to the user in groups.\n"
+            f"{read_back}\n"
             f"Prompt the user for confirmation, do not call `confirm_phone_number` directly"
         )
 

--- a/livekit-agents/livekit/agents/beta/workflows/phone_number.py
+++ b/livekit-agents/livekit/agents/beta/workflows/phone_number.py
@@ -11,7 +11,6 @@ from ...types import NOT_GIVEN, NotGivenOr
 from ...utils import is_given
 from ...voice.agent import AgentTask
 from ...voice.events import RunContext
-from .utils import ReadBack
 
 if TYPE_CHECKING:
     from ...voice.audio_recognition import TurnDetectionMode
@@ -81,7 +80,7 @@ class GetPhoneNumberTask(AgentTask[GetPhoneNumberResult]):
         extra = extra_instructions if extra_instructions else ""
 
         self._current_phone_number = ""
-        self._read_back = ReadBack()
+        self._spell_read_back = False
         self._require_confirmation = require_confirmation
         self._require_explicit_ask = require_explicit_ask
 
@@ -154,10 +153,12 @@ class GetPhoneNumberTask(AgentTask[GetPhoneNumberResult]):
         current_tools.append(confirm_tool)
         await self.update_tools(current_tools)
 
-        read_back = self._read_back.instruction(
-            natural="Read the number back to the user in groups.",
-            spelled=f"Read the number back digit by digit: {' '.join(cleaned)}",
+        read_back = (
+            f"Read the number back digit by digit: {' '.join(cleaned)}"
+            if self._spell_read_back
+            else "Read the number back to the user in groups."
         )
+        self._spell_read_back = True
         return (
             f"The phone number has been updated to {cleaned}\n"
             f"{read_back}\n"

--- a/livekit-agents/livekit/agents/beta/workflows/utils.py
+++ b/livekit-agents/livekit/agents/beta/workflows/utils.py
@@ -82,19 +82,3 @@ class WorkflowInstructions(Instructions):
             extra=self.extra,
             **format_kwargs,
         )
-
-
-class ReadBack:
-    """Escalates a value's confirmation read-back once the first one is not accepted.
-
-    A task records the value again only when the caller did not confirm it, so the
-    second and later read-backs spell the value out instead of saying it naturally:
-    a value that sounds like another cannot be told apart by hearing it again.
-    """
-
-    def __init__(self) -> None:
-        self._attempts = 0
-
-    def instruction(self, *, natural: str, spelled: str) -> str:
-        self._attempts += 1
-        return natural if self._attempts == 1 else spelled

--- a/livekit-agents/livekit/agents/beta/workflows/utils.py
+++ b/livekit-agents/livekit/agents/beta/workflows/utils.py
@@ -82,3 +82,19 @@ class WorkflowInstructions(Instructions):
             extra=self.extra,
             **format_kwargs,
         )
+
+
+class ReadBack:
+    """Escalates a value's confirmation read-back once the first one is not accepted.
+
+    A task records the value again only when the caller did not confirm it, so the
+    second and later read-backs spell the value out instead of saying it naturally:
+    a value that sounds like another cannot be told apart by hearing it again.
+    """
+
+    def __init__(self) -> None:
+        self._attempts = 0
+
+    def instruction(self, *, natural: str, spelled: str) -> str:
+        self._attempts += 1
+        return natural if self._attempts == 1 else spelled

--- a/tests/test_workflow_readback.py
+++ b/tests/test_workflow_readback.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents.beta.workflows.utils import ReadBack
+
+pytestmark = pytest.mark.unit
+
+
+def test_first_read_back_is_natural() -> None:
+    read_back = ReadBack()
+
+    assert read_back.instruction(natural="natural", spelled="spelled") == "natural"
+
+
+def test_every_read_back_after_the_first_is_spelled() -> None:
+    read_back = ReadBack()
+    read_back.instruction(natural="natural", spelled="spelled")
+
+    assert read_back.instruction(natural="natural", spelled="spelled") == "spelled"
+    assert read_back.instruction(natural="natural", spelled="spelled") == "spelled"

--- a/tests/test_workflow_readback.py
+++ b/tests/test_workflow_readback.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import Any
+
 import pytest
 
+from livekit.agents import beta
 from livekit.agents.beta.workflows.utils import ReadBack
 
 pytestmark = pytest.mark.unit
@@ -19,3 +23,82 @@ def test_every_read_back_after_the_first_is_spelled() -> None:
 
     assert read_back.instruction(natural="natural", spelled="spelled") == "spelled"
     assert read_back.instruction(natural="natural", spelled="spelled") == "spelled"
+
+
+def _audio_ctx() -> Any:
+    return SimpleNamespace(
+        speech_handle=SimpleNamespace(input_details=SimpleNamespace(modality="audio"))
+    )
+
+
+@pytest.mark.asyncio
+async def test_email_is_spelled_once_a_confirmation_is_refused() -> None:
+    task = beta.workflows.GetEmailTask()
+    ctx = _audio_ctx()
+
+    first = await task._update_email_impl("shayne.cole@gmail.com", ctx)
+    second = await task._update_email_impl("shayne.cole@gmail.com", ctx)
+
+    assert first is not None and second is not None
+    assert first != second
+    assert " ".join("shayne.cole@gmail.com") in second
+
+
+@pytest.mark.asyncio
+async def test_name_is_spelled_once_a_confirmation_is_refused() -> None:
+    task = beta.workflows.GetNameTask(first_name=True, last_name=True)
+    ctx = _audio_ctx()
+
+    first = await task._update_name_impl(ctx, first_name="Shayne", last_name="Cole")
+    second = await task._update_name_impl(ctx, first_name="Shayne", last_name="Cole")
+
+    assert first is not None and second is not None
+    assert first != second
+
+
+@pytest.mark.asyncio
+async def test_name_with_verify_spelling_is_spelled_from_the_start() -> None:
+    task = beta.workflows.GetNameTask(first_name=True, verify_spelling=True)
+    ctx = _audio_ctx()
+
+    first = await task._update_name_impl(ctx, first_name="Shayne")
+    second = await task._update_name_impl(ctx, first_name="Shayne")
+
+    assert first == second
+
+
+@pytest.mark.asyncio
+async def test_phone_is_read_digit_by_digit_once_a_confirmation_is_refused() -> None:
+    task = beta.workflows.GetPhoneNumberTask()
+    ctx = _audio_ctx()
+
+    first = await task._update_phone_number_impl("415-555-0626", ctx)
+    second = await task._update_phone_number_impl("415-555-0626", ctx)
+
+    assert first is not None and second is not None
+    assert first != second
+    assert " ".join("4155550626") in second
+
+
+@pytest.mark.asyncio
+async def test_address_is_spelled_once_a_confirmation_is_refused() -> None:
+    task = beta.workflows.GetAddressTask()
+    ctx = _audio_ctx()
+
+    first = await task._update_address_impl("1 Main St", "", "Springfield", "US", ctx)
+    second = await task._update_address_impl("1 Main St", "", "Springfield", "US", ctx)
+
+    assert first is not None and second is not None
+    assert first != second
+
+
+@pytest.mark.asyncio
+async def test_dob_is_read_part_by_part_once_a_confirmation_is_refused() -> None:
+    task = beta.workflows.GetDOBTask()
+    ctx = _audio_ctx()
+
+    first = await task._update_dob_impl(1990, 5, 17, ctx)
+    second = await task._update_dob_impl(1990, 5, 17, ctx)
+
+    assert first is not None and second is not None
+    assert first != second

--- a/tests/test_workflow_readback.py
+++ b/tests/test_workflow_readback.py
@@ -6,23 +6,8 @@ from typing import Any
 import pytest
 
 from livekit.agents import beta
-from livekit.agents.beta.workflows.utils import ReadBack
 
 pytestmark = pytest.mark.unit
-
-
-def test_first_read_back_is_natural() -> None:
-    read_back = ReadBack()
-
-    assert read_back.instruction(natural="natural", spelled="spelled") == "natural"
-
-
-def test_every_read_back_after_the_first_is_spelled() -> None:
-    read_back = ReadBack()
-    read_back.instruction(natural="natural", spelled="spelled")
-
-    assert read_back.instruction(natural="natural", spelled="spelled") == "spelled"
-    assert read_back.instruction(natural="natural", spelled="spelled") == "spelled"
 
 
 def _audio_ctx() -> Any:

--- a/tests/test_workflow_readback.py
+++ b/tests/test_workflow_readback.py
@@ -44,9 +44,10 @@ async def test_name_is_spelled_on_subsequent_updates(first_name: str, last_name:
 
     assert first is not None and second is not None
     assert first != second
-    full_name = f"{first_name} {last_name}"
-    assert " ".join(full_name) not in first
-    assert " ".join(full_name) in second
+    spelled = " ".join(f"{first_name}{last_name}")
+    assert spelled not in first
+    assert spelled in second
+    assert "  " not in second
     assert third == second
     assert task._first_name == first_name
     assert task._last_name == last_name
@@ -99,12 +100,14 @@ async def test_address_is_spelled_on_subsequent_updates(
 
     assert first is not None and second is not None
     assert first != second
-    assert " ".join(street) not in first
-    assert " ".join(street) in second
+    spelled = " ".join(street.replace(" ", ""))
+    assert spelled not in first
+    assert spelled in second
+    assert "  " not in second
     assert third == second
     fields = [street, unit, locality, country] if unit else [street, locality, country]
     assert task._current_address == " ".join(fields)
-    assert str([" ".join(street), *fields[1:]]) in second
+    assert str([spelled, *fields[1:]]) in second
 
 
 @pytest.mark.asyncio

--- a/tests/test_workflow_readback.py
+++ b/tests/test_workflow_readback.py
@@ -30,15 +30,26 @@ async def test_email_is_spelled_once_a_confirmation_is_refused() -> None:
 
 
 @pytest.mark.asyncio
-async def test_name_is_spelled_once_a_confirmation_is_refused() -> None:
+@pytest.mark.parametrize(
+    ("first_name", "last_name"),
+    [("Shayne", "Cole"), ("Anne-Marie", "O'Neill"), ("Ana", "García")],
+)
+async def test_name_is_spelled_on_subsequent_updates(first_name: str, last_name: str) -> None:
     task = beta.workflows.GetNameTask(first_name=True, last_name=True)
     ctx = _audio_ctx()
 
-    first = await task._update_name_impl(ctx, first_name="Shayne", last_name="Cole")
-    second = await task._update_name_impl(ctx, first_name="Shayne", last_name="Cole")
+    first = await task._update_name_impl(ctx, first_name=first_name, last_name=last_name)
+    second = await task._update_name_impl(ctx, first_name=first_name, last_name=last_name)
+    third = await task._update_name_impl(ctx, first_name=first_name, last_name=last_name)
 
     assert first is not None and second is not None
     assert first != second
+    full_name = f"{first_name} {last_name}"
+    assert " ".join(full_name) not in first
+    assert " ".join(full_name) in second
+    assert third == second
+    assert task._first_name == first_name
+    assert task._last_name == last_name
 
 
 @pytest.mark.asyncio
@@ -50,6 +61,8 @@ async def test_name_with_verify_spelling_is_spelled_from_the_start() -> None:
     second = await task._update_name_impl(ctx, first_name="Shayne")
 
     assert first == second
+    assert first is not None
+    assert "S h a y n e" in first
 
 
 @pytest.mark.asyncio
@@ -66,15 +79,32 @@ async def test_phone_is_read_digit_by_digit_once_a_confirmation_is_refused() -> 
 
 
 @pytest.mark.asyncio
-async def test_address_is_spelled_once_a_confirmation_is_refused() -> None:
+@pytest.mark.parametrize(
+    ("street", "unit", "locality", "country"),
+    [
+        ("1 Main St", "", "Springfield", "US"),
+        ("88 Harbor Lane", "Apartment 3", "Portland Oregon 97209", "United States"),
+        ("5 Rue de l’Ancienne Comédie", "App C4", "75006 Paris", "France"),
+    ],
+)
+async def test_address_is_spelled_on_subsequent_updates(
+    street: str, unit: str, locality: str, country: str
+) -> None:
     task = beta.workflows.GetAddressTask()
     ctx = _audio_ctx()
 
-    first = await task._update_address_impl("1 Main St", "", "Springfield", "US", ctx)
-    second = await task._update_address_impl("1 Main St", "", "Springfield", "US", ctx)
+    first = await task._update_address_impl(street, unit, locality, country, ctx)
+    second = await task._update_address_impl(street, unit, locality, country, ctx)
+    third = await task._update_address_impl(street, unit, locality, country, ctx)
 
     assert first is not None and second is not None
     assert first != second
+    assert " ".join(street) not in first
+    assert " ".join(street) in second
+    assert third == second
+    fields = [street, unit, locality, country] if unit else [street, locality, country]
+    assert task._current_address == " ".join(fields)
+    assert str([" ".join(street), *fields[1:]]) in second
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Callers can get stuck correcting a value that sounds identical to another spelling. In hotel-receptionist simulation `SR_yxUq2cWd3C3D` (job `SRJ_8GbAvzvRUXAF`), the agent recorded `shayne.cole@gmail.com` correctly three times but kept reading it as a word; the caller could not distinguish it from “shane” and the call ended without a booking.

Each capture task now switches its confirmation instruction after the first successful update that requests confirmation:

| Task | First read-back | Subsequent read-backs |
|---|---|---|
| Email | Natural | Character by character, with pre-spaced input |
| Name | Natural, or spelled when `verify_spelling=True` | Letter by letter, with pre-spaced input |
| Phone | In groups | Digit by digit, with pre-spaced input |
| Address | Whole address | Field by field, with the street-address field pre-spaced |
| Date of birth | Natural spoken date | Month, day, year one part at a time |

The state is an inline boolean in each task. Name and address spelling preserves punctuation and accented characters; address unit, locality, and country remain separate fields. Stored values retain their original formatting. Credit-card tasks do not read their values back and are outside this change.

Escalation depends on the model calling the update tool again. A spoken refusal alone does not guarantee that call: the [benchmark](https://github.com/livekit/agents/pull/6990#issuecomment-5541561431) found that callers re-spelling a value triggered updates more reliably than simply restating it. This change addresses repeated updates; it does not establish refusal detection.

Validation:

- `tests/test_workflow_readback.py`: 10 hermetic cases cover the transition, repeated spelled attempts, spelling from the first attempt, punctuation/accents, and preservation of stored names and address fields.
- `make check` passes (formatting, lint, and type checking); `make fix` leaves all files unchanged.
- [Fresh CI unit tests](https://github.com/livekit/agents/actions/runs/34246723226/job/102130493092): **2,634 passed, 5 skipped**. Formatting, Python 3.10/3.13 type checking, behavioral evals, provider tests, and review checks also pass. The simulation job is the sole failing check: after authentication was repaired, 9 of 10 scenarios passed, with the remaining simulated-caller refusal described below.
- The full local run, after allowing test-server sockets and raising the process file limit, reports 2,187 passed, 5 skipped, and 9 room-test failures with `ConnectError` / invalid HTTP version. Those tests pass in CI; the local full-suite run is not green.
- The previously posted audio-modality replay through `GetEmailTask` on `openai/gpt-4.1` changed the second and third read-backs from words to separated characters.
- The [posted spelling benchmark](https://github.com/livekit/agents/pull/6990#issuecomment-5541561431) supports supplying pre-spaced names: GPT-4.1 name spelling after correction improved from 80% to 95% in its 20-case sample. This revision implements that recommendation; it does not add NATO spelling.

Simulation check investigation:

- The [previous PR run](https://github.com/livekit/agents/actions/runs/33021872073) failed in card collection after the simulated caller declined to repeat the full number, and in DOB collection after successful capture followed by a redundant restart.
- The DOB correction loop also occurred on [main before this PR](https://github.com/livekit/agents/actions/runs/32800856104), in “Date of birth corrected while confirming.”
- The same card scenario failed on [main](https://github.com/livekit/agents/actions/runs/33493435866) when the simulated caller said “Sorry, I can’t provide credit card details,” contrary to its scenario instructions. The card implementation is unchanged by this PR.
- CI authentication was repaired on September 8 by updating the URL, API key, and API secret together. [Simulation attempt 2 on `8232cb414`](https://github.com/livekit/agents/actions/runs/34246723169/attempts/2) registered the worker successfully and ran all 10 scenarios: **9 passed, 1 failed**. The name, address, and DOB correction scenarios passed. The remaining failure is “Card number too short on the first try”: the simulated caller declined to provide the test card number for privacy reasons, contrary to its scenario instructions. This matches the existing caller-refusal failure on main noted above.

