### PR TITLE
feat(deepgram): add numerals, profanity_filter, and redact options to STTv2 (Flux)

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -57,6 +57,7 @@ class STTOptions:
     eot_threshold: NotGivenOr[float] = NOT_GIVEN
     eot_timeout_ms: NotGivenOr[int] = NOT_GIVEN
     mip_opt_out: bool = False
+    numerals: bool = False
     tags: NotGivenOr[list[str]] = NOT_GIVEN
     language_hint: NotGivenOr[list[str]] = NOT_GIVEN
 
@@ -77,6 +78,7 @@ class STTv2(stt.STT):
         http_session: aiohttp.ClientSession | None = None,
         base_url: str = "wss://api.deepgram.com/v2/listen",
         mip_opt_out: bool = False,
+        numerals: bool = False,
         # deprecated
         keyterms: NotGivenOr[list[str]] = NOT_GIVEN,
     ) -> None:
@@ -95,6 +97,7 @@ class STTv2(stt.STT):
             http_session: Optional aiohttp ClientSession to use for requests.
             base_url: The base URL for Deepgram API. Defaults to "https://api.deepgram.com/v1/listen".
             mip_opt_out: Whether to take part in the model improvement program
+            numerals: Whether to convert spoken numbers into numerical formats. Applied at connection time; Flux does not support toggling it mid-stream. Defaults to False.
 
         Raises:
             ValueError: If no API key is provided or found in environment variables.
@@ -145,6 +148,7 @@ class STTv2(stt.STT):
             if is_given(keyterm)
             else [],
             mip_opt_out=mip_opt_out,
+            numerals=numerals,
             tags=_validate_tags(tags) if is_given(tags) else [],
             language_hint=language_hint if is_given(language_hint) else [],
             eager_eot_threshold=eager_eot_threshold,
@@ -210,6 +214,7 @@ class STTv2(stt.STT):
         eot_timeout_ms: NotGivenOr[int] = NOT_GIVEN,
         keyterm: NotGivenOr[str | list[str]] = NOT_GIVEN,
         mip_opt_out: NotGivenOr[bool] = NOT_GIVEN,
+        numerals: NotGivenOr[bool] = NOT_GIVEN,
         tags: NotGivenOr[list[str]] = NOT_GIVEN,
         language_hint: NotGivenOr[list[str]] = NOT_GIVEN,
         endpoint_url: NotGivenOr[str] = NOT_GIVEN,
@@ -247,6 +252,8 @@ class STTv2(stt.STT):
             self._opts.keyterm = keyterm
         if is_given(mip_opt_out):
             self._opts.mip_opt_out = mip_opt_out
+        if is_given(numerals):
+            self._opts.numerals = numerals
         if is_given(tags):
             self._opts.tags = _validate_tags(tags)
         if is_given(language_hint):
@@ -269,6 +276,7 @@ class STTv2(stt.STT):
                 eot_timeout_ms=eot_timeout_ms,
                 keyterm=keyterm,
                 mip_opt_out=mip_opt_out,
+                numerals=numerals,
                 endpoint_url=endpoint_url,
                 tags=tags,
                 language_hint=language_hint,
@@ -327,6 +335,7 @@ class SpeechStreamv2(stt.SpeechStream):
         eot_timeout_ms: NotGivenOr[int] = NOT_GIVEN,
         keyterm: NotGivenOr[str | list[str]] = NOT_GIVEN,
         mip_opt_out: NotGivenOr[bool] = NOT_GIVEN,
+        numerals: NotGivenOr[bool] = NOT_GIVEN,
         tags: NotGivenOr[list[str]] = NOT_GIVEN,
         language_hint: NotGivenOr[list[str]] = NOT_GIVEN,
         endpoint_url: NotGivenOr[str] = NOT_GIVEN,
@@ -351,6 +360,8 @@ class SpeechStreamv2(stt.SpeechStream):
             self._opts.keyterm = keyterm
         if is_given(mip_opt_out):
             self._opts.mip_opt_out = mip_opt_out
+        if is_given(numerals):
+            self._opts.numerals = numerals
         if is_given(tags):
             self._opts.tags = _validate_tags(tags)
         if is_given(language_hint):
@@ -361,8 +372,10 @@ class SpeechStreamv2(stt.SpeechStream):
             self._opts.eager_eot_threshold = eager_eot_threshold
 
         # these only take effect on a fresh connection
+        # numerals included: Flux does not support toggling it through Configure
+        # https://developers.deepgram.com/docs/numerals
         needs_reconnect = any(
-            is_given(opt) for opt in (model, sample_rate, mip_opt_out, tags, endpoint_url)
+            is_given(opt) for opt in (model, sample_rate, mip_opt_out, numerals, tags, endpoint_url)
         )
         if needs_reconnect:
             # reconnect carries the latest options
@@ -538,7 +551,7 @@ class SpeechStreamv2(stt.SpeechStream):
                 if ws is not None:
                     await ws.close()
 
-    async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
+    def _live_config(self) -> dict[str, Any]:
         live_config: dict[str, Any] = {
             "model": self._opts.model,
             "sample_rate": self._opts.sample_rate,
@@ -563,6 +576,14 @@ class SpeechStreamv2(stt.SpeechStream):
 
         if self._opts.language_hint:
             live_config["language_hint"] = self._opts.language_hint
+
+        if self._opts.numerals:
+            live_config["numerals"] = self._opts.numerals
+
+        return live_config
+
+    async def _connect_ws(self) -> aiohttp.ClientWebSocketResponse:
+        live_config = self._live_config()
 
         try:
             ws = await asyncio.wait_for(

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -20,7 +20,7 @@ import os
 import weakref
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 import aiohttp
 
@@ -45,6 +45,8 @@ from ._utils import PeriodicCollector, _to_deepgram_url
 from .log import logger
 from .models import V2Models
 
+FluxRedaction = Literal["numbers", "aggressive_numbers"]
+
 
 @dataclass
 class STTOptions:
@@ -58,6 +60,8 @@ class STTOptions:
     eot_timeout_ms: NotGivenOr[int] = NOT_GIVEN
     mip_opt_out: bool = False
     numerals: bool = False
+    profanity_filter: bool = False
+    redact: NotGivenOr[FluxRedaction] = NOT_GIVEN
     tags: NotGivenOr[list[str]] = NOT_GIVEN
     language_hint: NotGivenOr[list[str]] = NOT_GIVEN
 
@@ -79,6 +83,8 @@ class STTv2(stt.STT):
         base_url: str = "wss://api.deepgram.com/v2/listen",
         mip_opt_out: bool = False,
         numerals: bool = False,
+        profanity_filter: bool = False,
+        redact: NotGivenOr[FluxRedaction] = NOT_GIVEN,
         # deprecated
         keyterms: NotGivenOr[list[str]] = NOT_GIVEN,
     ) -> None:
@@ -98,6 +104,8 @@ class STTv2(stt.STT):
             base_url: The base URL for Deepgram API. Defaults to "https://api.deepgram.com/v1/listen".
             mip_opt_out: Whether to take part in the model improvement program
             numerals: Whether to convert spoken numbers into numerical formats. Applied at connection time; Flux does not support toggling it mid-stream. Defaults to False.
+            profanity_filter: Whether to filter profanity from the transcription. Applied at connection time. Defaults to False.
+            redact: Redact numbers from the transcription, "numbers" or "aggressive_numbers". Flux does not support entity redaction (pci, pii, ...). Applied at connection time. Defaults to NOT_GIVEN.
 
         Raises:
             ValueError: If no API key is provided or found in environment variables.
@@ -149,6 +157,8 @@ class STTv2(stt.STT):
             else [],
             mip_opt_out=mip_opt_out,
             numerals=numerals,
+            profanity_filter=profanity_filter,
+            redact=redact,
             tags=_validate_tags(tags) if is_given(tags) else [],
             language_hint=language_hint if is_given(language_hint) else [],
             eager_eot_threshold=eager_eot_threshold,
@@ -215,6 +225,8 @@ class STTv2(stt.STT):
         keyterm: NotGivenOr[str | list[str]] = NOT_GIVEN,
         mip_opt_out: NotGivenOr[bool] = NOT_GIVEN,
         numerals: NotGivenOr[bool] = NOT_GIVEN,
+        profanity_filter: NotGivenOr[bool] = NOT_GIVEN,
+        redact: NotGivenOr[FluxRedaction] = NOT_GIVEN,
         tags: NotGivenOr[list[str]] = NOT_GIVEN,
         language_hint: NotGivenOr[list[str]] = NOT_GIVEN,
         endpoint_url: NotGivenOr[str] = NOT_GIVEN,
@@ -254,6 +266,10 @@ class STTv2(stt.STT):
             self._opts.mip_opt_out = mip_opt_out
         if is_given(numerals):
             self._opts.numerals = numerals
+        if is_given(profanity_filter):
+            self._opts.profanity_filter = profanity_filter
+        if is_given(redact):
+            self._opts.redact = redact
         if is_given(tags):
             self._opts.tags = _validate_tags(tags)
         if is_given(language_hint):
@@ -277,6 +293,8 @@ class STTv2(stt.STT):
                 keyterm=keyterm,
                 mip_opt_out=mip_opt_out,
                 numerals=numerals,
+                profanity_filter=profanity_filter,
+                redact=redact,
                 endpoint_url=endpoint_url,
                 tags=tags,
                 language_hint=language_hint,
@@ -336,6 +354,8 @@ class SpeechStreamv2(stt.SpeechStream):
         keyterm: NotGivenOr[str | list[str]] = NOT_GIVEN,
         mip_opt_out: NotGivenOr[bool] = NOT_GIVEN,
         numerals: NotGivenOr[bool] = NOT_GIVEN,
+        profanity_filter: NotGivenOr[bool] = NOT_GIVEN,
+        redact: NotGivenOr[FluxRedaction] = NOT_GIVEN,
         tags: NotGivenOr[list[str]] = NOT_GIVEN,
         language_hint: NotGivenOr[list[str]] = NOT_GIVEN,
         endpoint_url: NotGivenOr[str] = NOT_GIVEN,
@@ -362,6 +382,10 @@ class SpeechStreamv2(stt.SpeechStream):
             self._opts.mip_opt_out = mip_opt_out
         if is_given(numerals):
             self._opts.numerals = numerals
+        if is_given(profanity_filter):
+            self._opts.profanity_filter = profanity_filter
+        if is_given(redact):
+            self._opts.redact = redact
         if is_given(tags):
             self._opts.tags = _validate_tags(tags)
         if is_given(language_hint):
@@ -371,11 +395,21 @@ class SpeechStreamv2(stt.SpeechStream):
         if is_given(eager_eot_threshold):
             self._opts.eager_eot_threshold = eager_eot_threshold
 
-        # these only take effect on a fresh connection
-        # numerals included: Flux does not support toggling it through Configure
+        # these only take effect on a fresh connection: Flux does not support
+        # toggling numerals, profanity_filter, or redact through Configure
         # https://developers.deepgram.com/docs/numerals
         needs_reconnect = any(
-            is_given(opt) for opt in (model, sample_rate, mip_opt_out, numerals, tags, endpoint_url)
+            is_given(opt)
+            for opt in (
+                model,
+                sample_rate,
+                mip_opt_out,
+                numerals,
+                profanity_filter,
+                redact,
+                tags,
+                endpoint_url,
+            )
         )
         if needs_reconnect:
             # reconnect carries the latest options
@@ -579,6 +613,12 @@ class SpeechStreamv2(stt.SpeechStream):
 
         if self._opts.numerals:
             live_config["numerals"] = self._opts.numerals
+
+        if self._opts.profanity_filter:
+            live_config["profanity_filter"] = self._opts.profanity_filter
+
+        if is_given(self._opts.redact):
+            live_config["redact"] = self._opts.redact
 
         return live_config
 

--- a/tests/test_plugin_deepgram_stt.py
+++ b/tests/test_plugin_deepgram_stt.py
@@ -33,6 +33,8 @@ def _make_flux_stream(*, ws=None, **opts_kwargs):
         eot_timeout_ms=opts_kwargs.get("eot_timeout_ms", NOT_GIVEN),
         language_hint=opts_kwargs.get("language_hint", []),
         numerals=opts_kwargs.get("numerals", False),
+        profanity_filter=opts_kwargs.get("profanity_filter", False),
+        redact=opts_kwargs.get("redact", NOT_GIVEN),
     )
     opts.keyterm = opts_kwargs.get("keyterm", [])
     stream = SimpleNamespace(
@@ -106,25 +108,36 @@ async def test_flux_reconnect_fields_skip_inband_configure():
     assert ws.sent == []
 
 
-async def test_flux_numerals_triggers_reconnect_not_configure():
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("numerals", True), ("profanity_filter", True), ("redact", "numbers")],
+)
+async def test_flux_connection_time_fields_trigger_reconnect_not_configure(field, value):
     from livekit.plugins.deepgram.stt_v2 import SpeechStreamv2
 
     ws = _FakeWS()
     stream = _make_flux_stream(ws=ws)
-    SpeechStreamv2.update_options(stream, numerals=True)
+    SpeechStreamv2.update_options(stream, **{field: value})
 
-    # Flux can't toggle numerals via Configure, only at connection time
-    assert stream._opts.numerals is True
+    # Flux can't toggle these via Configure, only at connection time
+    assert getattr(stream._opts, field) == value
     assert stream._reconnect_event.is_set()
     assert stream._reconfigure_atask is None
     assert ws.sent == []
 
 
-async def test_flux_numerals_in_connection_config():
+async def test_flux_connection_config_includes_formatting_fields():
     from livekit.plugins.deepgram.stt_v2 import SpeechStreamv2
 
-    assert SpeechStreamv2._live_config(_make_flux_stream(numerals=True))["numerals"] is True
-    assert "numerals" not in SpeechStreamv2._live_config(_make_flux_stream())
+    config = SpeechStreamv2._live_config(
+        _make_flux_stream(numerals=True, profanity_filter=True, redact="aggressive_numbers")
+    )
+    assert config["numerals"] is True
+    assert config["profanity_filter"] is True
+    assert config["redact"] == "aggressive_numbers"
+
+    default_config = SpeechStreamv2._live_config(_make_flux_stream())
+    assert not {"numerals", "profanity_filter", "redact"} & default_config.keys()
 
 
 async def test_flux_configure_sends_only_changed_fields():

--- a/tests/test_plugin_deepgram_stt.py
+++ b/tests/test_plugin_deepgram_stt.py
@@ -32,6 +32,7 @@ def _make_flux_stream(*, ws=None, **opts_kwargs):
         eager_eot_threshold=opts_kwargs.get("eager_eot_threshold", NOT_GIVEN),
         eot_timeout_ms=opts_kwargs.get("eot_timeout_ms", NOT_GIVEN),
         language_hint=opts_kwargs.get("language_hint", []),
+        numerals=opts_kwargs.get("numerals", False),
     )
     opts.keyterm = opts_kwargs.get("keyterm", [])
     stream = SimpleNamespace(
@@ -103,6 +104,27 @@ async def test_flux_reconnect_fields_skip_inband_configure():
     assert stream._reconnect_event.is_set()
     assert stream._reconfigure_atask is None
     assert ws.sent == []
+
+
+async def test_flux_numerals_triggers_reconnect_not_configure():
+    from livekit.plugins.deepgram.stt_v2 import SpeechStreamv2
+
+    ws = _FakeWS()
+    stream = _make_flux_stream(ws=ws)
+    SpeechStreamv2.update_options(stream, numerals=True)
+
+    # Flux can't toggle numerals via Configure, only at connection time
+    assert stream._opts.numerals is True
+    assert stream._reconnect_event.is_set()
+    assert stream._reconfigure_atask is None
+    assert ws.sent == []
+
+
+async def test_flux_numerals_in_connection_config():
+    from livekit.plugins.deepgram.stt_v2 import SpeechStreamv2
+
+    assert SpeechStreamv2._live_config(_make_flux_stream(numerals=True))["numerals"] is True
+    assert "numerals" not in SpeechStreamv2._live_config(_make_flux_stream())
 
 
 async def test_flux_configure_sends_only_changed_fields():


### PR DESCRIPTION
Fixes #6992

Adds `numerals`, `profanity_filter`, and `redact` options to `STTv2`, wired through `STTOptions`, both `update_options` paths, and the websocket query string. Flux only accepts these at connection time (no `Configure` toggle), so changing any of them via `update_options` triggers a reconnect instead of an in-band `Configure` message. `redact` is typed to the two values Flux accepts, `numbers` and `aggressive_numbers`; entity redaction (pci, pii, ...) is not supported by Flux.

Verified against the live `/v2/listen` endpoint: all three params are accepted at handshake (including through this plugin's connection path), while unsupported values and Nova-only params are rejected with HTTP 400. Docs: https://developers.deepgram.com/docs/numerals, https://developers.deepgram.com/docs/profanity-filter, https://developers.deepgram.com/docs/redaction

The query-string construction in `_connect_ws` moved into a `_live_config` helper so tests can assert on it directly. Tests cover the reconnect behavior and the presence/absence of the new params in the connection config.

Supersedes #6506 (closed unmerged, unsigned CLA).