### PR TITLE
fix(aws): preserve idle-timeout retry in STT stream cleanup

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -405,6 +405,10 @@ class SpeechStream(stt.SpeechStream):
                         await asyncio.wait_for(tasks[1], timeout=3.0)
                     except (asyncio.TimeoutError, asyncio.CancelledError):
                         await utils.aio.gracefully_cancel(tasks[1])
+                    except BadRequestException:
+                        # Already handled above (e.g. idle-timeout retry). Swallow so
+                        # re-awaiting the failed task here cannot override `continue`.
+                        pass
 
                 # Ensure gather future is retrieved to avoid "exception never retrieved"
                 with contextlib.suppress(Exception):


### PR DESCRIPTION
**Bug/Issue Observed:-** AWS Transcribe closes the stream after ~15s of silence with `BadRequestException: Your request timed out because no new audio was received for 15 seconds`. 
SpeechStream._run() already handles this. The outer except BadRequestException checks for that idle-timeout message, logs "restarting transcribe session", and continues so a new stream can start. But that retry never takes effect. The finally block always re-awaits the output task (tasks[1]) during cleanup. On idle timeout, tasks[1] has already failed with that same BadRequestException, which is why we entered the retry branch. Re-awaiting it in finally raises it again. In Python, an exception from finally overrides the continue from the except block, so the stream dies instead of restarting. In logs this shows up as "restarting transcribe session" immediately followed by the crash.

**Steps to reproduce:-**
1. Set a valid AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY with permissions to access AWS Transcribe.
2. Run the following Python code:
```python
import asyncio
import logging
import time
from livekit.plugins import aws
logging.basicConfig(level=logging.INFO)
logging.getLogger("livekit.plugins.aws").setLevel(logging.INFO)
async def main():
    print("Creating STT client...")
    stt = aws.STT(speech_region="us-east-1")  # credentials resolved via AWS_PROFILE
    print("Opening stream (waiting for AWS connection)...")
    stream = stt.stream()
    start = time.monotonic()
    print("Stream opened at t=0s. Waiting for idle timeout (~15s expected)...")
    try:
        # No audio frames are pushed — this reproduces the idle-timeout condition
        async for ev in stream:
            elapsed = time.monotonic() - start
            print(f"[{elapsed:.1f}s] Event: {ev}")
    except Exception as e:
        elapsed = time.monotonic() - start
        print(f"[{elapsed:.1f}s] EXCEPTION propagated: {type(e).__name__}: {e}")
    finally:
        print("Cleaning up...")
        await stream.aclose()
        await stt.aclose()
        print("Done.")
asyncio.run(main()) 
```
Current Behavior:- After approximately 15 seconds with no audio, AWS Transcribe terminates the session as expected. Here is the output I am getting from above script:- 
```
Creating STT client...
Opening stream (waiting for AWS connection)...
Stream opened at t=0s. Waiting for idle timeout (~15s expected)...
INFO:livekit.plugins.aws:restarting transcribe session
[18.3s] EXCEPTION propagated: BadRequestException: Your request timed out because no new audio was received for 15 seconds.
Cleaning up...
Done.
```
Expected Behaviour:-  After the "restarting transcribe session" log line, the stream should reconnect and continue running (or, if no audio ever arrives, keep retrying/idling — not raise).
**Fix:-** 
Catch that already-handled exception in the cleanup try so it cannot override the retry. Add except BadRequestException: pass next to the existing timeout/cancel handling when re-awaiting tasks[1]. The outer handler is unchanged: idle-timeout still retries, every other BadRequestException still raises so changes are non-breaking.