### PR TITLE
fix(xai): reject FileSearch plus collections_search or file_search

### DIFF
--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py
@@ -45,7 +45,7 @@ from livekit.plugins import openai
 from livekit.plugins.openai.realtime.realtime_model import _DiscardedGeneration
 
 from ..log import logger
-from ..tools import XAITool
+from ..tools import XAITool, _raise_if_xai_tool_reserved_name_conflict
 from ..types import GrokRealtimeModels, GrokVoices
 
 XAI_BASE_URL = "wss://api.x.ai/v1/realtime"
@@ -231,6 +231,7 @@ class RealtimeSession(openai.realtime.RealtimeSession):
         return super()._wrap_session_update(event_id=event_id, session=session)
 
     def _create_tools_update_event(self, tools: list[llm.Tool]) -> dict[str, Any]:
+        _raise_if_xai_tool_reserved_name_conflict(tools)
         event = super()._create_tools_update_event(tools)
         xai_tools: list[dict[str, Any]] = []
         for tool in tools:

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/tools.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/tools.py
@@ -54,8 +54,8 @@ class XSearch(XAITool):
 class FileSearch(XAITool):
     """Enable file search tool for searching uploaded document collections.
 
-    Do not also register a function named ``collections_search``; xAI's FileSearch
-    already uses that name.
+    Do not also register a function named ``collections_search`` or ``file_search``;
+    xAI's FileSearch already uses those names.
     """
 
     vector_store_ids: list[str] = field(default_factory=list)
@@ -82,7 +82,7 @@ _XAI_TOOL_RESERVED_FUNCTION_NAMES: dict[type[XAITool], frozenset[str]] = {
     XSearch: frozenset(
         {"x_keyword_search", "x_semantic_search", "x_user_search", "x_thread_fetch"}
     ),
-    FileSearch: frozenset({"collections_search"}),
+    FileSearch: frozenset({"collections_search", "file_search"}),
 }
 
 

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/tools.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/tools.py
@@ -1,8 +1,10 @@
 from abc import abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
 from livekit.agents import ProviderTool
+from livekit.agents.llm.tool_context import Tool, Toolset, get_fnc_tool_names
 
 
 class XAITool(ProviderTool):
@@ -14,7 +16,11 @@ class XAITool(ProviderTool):
 
 @dataclass
 class WebSearch(XAITool):
-    """Enable web search tool for real-time internet searches."""
+    """Enable web search tool for real-time internet searches.
+
+    Do not also register a function named ``web_search`` or ``browse_page``;
+    xAI's WebSearch already uses those names.
+    """
 
     def __post_init__(self) -> None:
         super().__init__(id="xai_web_search")
@@ -25,7 +31,12 @@ class WebSearch(XAITool):
 
 @dataclass
 class XSearch(XAITool):
-    """Enable X (Twitter) search tool for searching posts."""
+    """Enable X (Twitter) search tool for searching posts.
+
+    Do not also register a function named ``x_keyword_search``,
+    ``x_semantic_search``, ``x_user_search``, or ``x_thread_fetch``;
+    xAI's XSearch already uses those names.
+    """
 
     allowed_x_handles: list[str] | None = None
 
@@ -41,7 +52,11 @@ class XSearch(XAITool):
 
 @dataclass
 class FileSearch(XAITool):
-    """Enable file search tool for searching uploaded document collections."""
+    """Enable file search tool for searching uploaded document collections.
+
+    Do not also register a function named ``collections_search``; xAI's FileSearch
+    already uses that name.
+    """
 
     vector_store_ids: list[str] = field(default_factory=list)
     max_num_results: int | None = None
@@ -58,3 +73,35 @@ class FileSearch(XAITool):
             result["max_num_results"] = self.max_num_results
 
         return result
+
+
+# Measured against grok-voice-latest: a client function of these names plus the
+# matching provider tool makes the first response.create return server_error.
+_XAI_TOOL_RESERVED_FUNCTION_NAMES: dict[type[XAITool], frozenset[str]] = {
+    WebSearch: frozenset({"web_search", "browse_page"}),
+    XSearch: frozenset(
+        {"x_keyword_search", "x_semantic_search", "x_user_search", "x_thread_fetch"}
+    ),
+    FileSearch: frozenset({"collections_search"}),
+}
+
+
+def _raise_if_xai_tool_reserved_name_conflict(tools: Sequence[Tool | Toolset]) -> None:
+    reserved: set[str] = set()
+    owners: dict[str, str] = {}
+    for tool in tools:
+        for tool_cls, names in _XAI_TOOL_RESERVED_FUNCTION_NAMES.items():
+            if isinstance(tool, tool_cls):
+                reserved |= names
+                for name in names:
+                    owners[name] = tool_cls.__name__
+    if not reserved:
+        return
+    for name in get_fnc_tool_names(tools):
+        if name in reserved:
+            raise ValueError(
+                f"xAI {owners[name]} already uses the function name {name!r}. "
+                "Rename or remove the function; mixing the provider tool with a "
+                "client function of a reserved name makes grok-voice-latest "
+                "return server_error/internal_error on the first response.create."
+            )

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/tools.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/tools.py
@@ -1,14 +1,19 @@
 from abc import abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
 from livekit.agents import ProviderTool
-from livekit.agents.llm.tool_context import Tool, Toolset, get_fnc_tool_names
+from livekit.agents.llm.tool_context import FunctionTool, RawFunctionTool, Tool
 
 
 class XAITool(ProviderTool):
     """Base class for xAI server-side provider tools."""
+
+    # function names the server answers to once this tool is enabled. Measured against
+    # grok-voice-latest: a client function of the same name makes the first
+    # response.create return server_error.
+    _reserved_function_names: ClassVar[frozenset[str]] = frozenset()
 
     @abstractmethod
     def to_dict(self) -> dict[str, Any]: ...
@@ -21,6 +26,8 @@ class WebSearch(XAITool):
     Do not also register a function named ``web_search`` or ``browse_page``;
     xAI's WebSearch already uses those names.
     """
+
+    _reserved_function_names: ClassVar[frozenset[str]] = frozenset({"web_search", "browse_page"})
 
     def __post_init__(self) -> None:
         super().__init__(id="xai_web_search")
@@ -38,6 +45,9 @@ class XSearch(XAITool):
     xAI's XSearch already uses those names.
     """
 
+    _reserved_function_names: ClassVar[frozenset[str]] = frozenset(
+        {"x_keyword_search", "x_semantic_search", "x_user_search", "x_thread_fetch"}
+    )
     allowed_x_handles: list[str] | None = None
 
     def __post_init__(self) -> None:
@@ -58,6 +68,9 @@ class FileSearch(XAITool):
     xAI's FileSearch already uses those names.
     """
 
+    _reserved_function_names: ClassVar[frozenset[str]] = frozenset(
+        {"collections_search", "file_search"}
+    )
     vector_store_ids: list[str] = field(default_factory=list)
     max_num_results: int | None = None
 
@@ -75,33 +88,19 @@ class FileSearch(XAITool):
         return result
 
 
-# Measured against grok-voice-latest: a client function of these names plus the
-# matching provider tool makes the first response.create return server_error.
-_XAI_TOOL_RESERVED_FUNCTION_NAMES: dict[type[XAITool], frozenset[str]] = {
-    WebSearch: frozenset({"web_search", "browse_page"}),
-    XSearch: frozenset(
-        {"x_keyword_search", "x_semantic_search", "x_user_search", "x_thread_fetch"}
-    ),
-    FileSearch: frozenset({"collections_search", "file_search"}),
-}
-
-
-def _raise_if_xai_tool_reserved_name_conflict(tools: Sequence[Tool | Toolset]) -> None:
-    reserved: set[str] = set()
-    owners: dict[str, str] = {}
+def _raise_if_xai_tool_reserved_name_conflict(tools: Sequence[Tool]) -> None:
+    """Reject a client function whose name an enabled xAI provider tool already answers to."""
+    fnc_names = {
+        tool.info.name for tool in tools if isinstance(tool, (FunctionTool, RawFunctionTool))
+    }
     for tool in tools:
-        for tool_cls, names in _XAI_TOOL_RESERVED_FUNCTION_NAMES.items():
-            if isinstance(tool, tool_cls):
-                reserved |= names
-                for name in names:
-                    owners[name] = tool_cls.__name__
-    if not reserved:
-        return
-    for name in get_fnc_tool_names(tools):
-        if name in reserved:
+        if not isinstance(tool, XAITool):
+            continue
+        if conflicts := sorted(tool._reserved_function_names & fnc_names):
+            names = ", ".join(repr(name) for name in conflicts)
             raise ValueError(
-                f"xAI {owners[name]} already uses the function name {name!r}. "
-                "Rename or remove the function; mixing the provider tool with a "
-                "client function of a reserved name makes grok-voice-latest "
-                "return server_error/internal_error on the first response.create."
+                f"xAI {type(tool).__name__} already uses the function name(s) {names}. "
+                "Rename or remove them; a client function that shadows a provider tool's "
+                "own name makes grok-voice-latest return server_error/internal_error on "
+                "the first response.create."
             )

--- a/tests/test_realtime/test_xai_realtime_model.py
+++ b/tests/test_realtime/test_xai_realtime_model.py
@@ -31,8 +31,117 @@ from livekit.plugins.xai.realtime.realtime_model import (
     RealtimeModel,
     RealtimeSession,
 )
+from livekit.plugins.xai.tools import (
+    FileSearch,
+    WebSearch,
+    XSearch,
+    _raise_if_xai_tool_reserved_name_conflict,
+)
 
 pytestmark = pytest.mark.unit
+
+
+def _named(name: str) -> llm.FunctionTool:
+    @llm.function_tool(name=name)
+    async def tool() -> str:
+        return "ok"
+
+    return tool
+
+
+def _raw(name: str) -> llm.RawFunctionTool:
+    @llm.function_tool(
+        raw_schema={
+            "name": name,
+            "description": "test",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    )
+    async def tool() -> str:
+        return "ok"
+
+    return tool
+
+
+@llm.function_tool
+async def collections_search() -> str:
+    """A function that collides with xAI FileSearch."""
+    return "hit"
+
+
+_RESERVED_PAIRS: list[tuple[llm.ProviderTool, str]] = [
+    (WebSearch(), "web_search"),
+    (WebSearch(), "browse_page"),
+    (XSearch(), "x_keyword_search"),
+    (XSearch(), "x_semantic_search"),
+    (XSearch(), "x_user_search"),
+    (XSearch(), "x_thread_fetch"),
+    (FileSearch(), "collections_search"),
+]
+
+
+@pytest.mark.parametrize(
+    ("provider_tool", "function_name"),
+    _RESERVED_PAIRS,
+    ids=[f"{t.__class__.__name__}-{name}" for t, name in _RESERVED_PAIRS],
+)
+def test_provider_tool_plus_reserved_function_raises(
+    provider_tool: llm.ProviderTool, function_name: str
+) -> None:
+    with pytest.raises(ValueError, match="Rename or remove"):
+        _raise_if_xai_tool_reserved_name_conflict([provider_tool, _named(function_name)])
+
+
+def test_file_search_plus_plain_collections_search_raises() -> None:
+    with pytest.raises(ValueError, match="Rename or remove"):
+        _raise_if_xai_tool_reserved_name_conflict([FileSearch(), collections_search])
+
+
+def test_file_search_plus_raw_collections_search_raises() -> None:
+    with pytest.raises(ValueError, match="Rename or remove"):
+        _raise_if_xai_tool_reserved_name_conflict([FileSearch(), _raw("collections_search")])
+
+
+def test_file_search_plus_nested_toolset_reserved_name_raises() -> None:
+    toolset = llm.Toolset(id="nested", tools=[collections_search])
+    with pytest.raises(ValueError, match="Rename or remove"):
+        _raise_if_xai_tool_reserved_name_conflict([FileSearch(), toolset])
+
+
+_HARMLESS_PAIRS: list[tuple[llm.ProviderTool | None, str]] = [
+    (WebSearch(), "view_image"),
+    (WebSearch(), "harmless_control"),
+    (WebSearch(), "collections_search"),
+    (XSearch(), "x_search"),
+    (XSearch(), "harmless_control"),
+    (FileSearch(), "file_search"),
+    (FileSearch(), "view_document"),
+    (FileSearch(), "harmless_control"),
+    (FileSearch(), "web_search"),
+    (None, "collections_search"),
+    (None, "web_search"),
+    (None, "browse_page"),
+]
+
+
+@pytest.mark.parametrize(
+    ("provider_tool", "function_name"),
+    _HARMLESS_PAIRS,
+    ids=[
+        f"{t.__class__.__name__ if t is not None else 'none'}-{name}" for t, name in _HARMLESS_PAIRS
+    ],
+)
+def test_non_reserved_combinations_are_ok(
+    provider_tool: llm.ProviderTool | None, function_name: str
+) -> None:
+    tools: list[llm.Tool] = [_named(function_name)]
+    if provider_tool is not None:
+        tools.insert(0, provider_tool)
+    _raise_if_xai_tool_reserved_name_conflict(tools)
+
+
+def test_file_search_alone_is_ok() -> None:
+    _raise_if_xai_tool_reserved_name_conflict([FileSearch()])
 
 
 def test_default_model_is_grok_voice_latest() -> None:

--- a/tests/test_realtime/test_xai_realtime_model.py
+++ b/tests/test_realtime/test_xai_realtime_model.py
@@ -77,6 +77,7 @@ _RESERVED_PAIRS: list[tuple[llm.ProviderTool, str]] = [
     (XSearch(), "x_user_search"),
     (XSearch(), "x_thread_fetch"),
     (FileSearch(), "collections_search"),
+    (FileSearch(), "file_search"),
 ]
 
 
@@ -114,11 +115,11 @@ _HARMLESS_PAIRS: list[tuple[llm.ProviderTool | None, str]] = [
     (WebSearch(), "collections_search"),
     (XSearch(), "x_search"),
     (XSearch(), "harmless_control"),
-    (FileSearch(), "file_search"),
     (FileSearch(), "view_document"),
     (FileSearch(), "harmless_control"),
     (FileSearch(), "web_search"),
     (None, "collections_search"),
+    (None, "file_search"),
     (None, "web_search"),
     (None, "browse_page"),
 ]

--- a/tests/test_realtime/test_xai_realtime_model.py
+++ b/tests/test_realtime/test_xai_realtime_model.py
@@ -105,8 +105,9 @@ def test_file_search_plus_raw_collections_search_raises() -> None:
 
 def test_file_search_plus_nested_toolset_reserved_name_raises() -> None:
     toolset = llm.Toolset(id="nested", tools=[collections_search])
+    tools = llm.ToolContext([FileSearch(), toolset]).flatten()
     with pytest.raises(ValueError, match="Rename or remove"):
-        _raise_if_xai_tool_reserved_name_conflict([FileSearch(), toolset])
+        _raise_if_xai_tool_reserved_name_conflict(tools)
 
 
 _HARMLESS_PAIRS: list[tuple[llm.ProviderTool | None, str]] = [


### PR DESCRIPTION
## Summary
- Fail fast in xAI realtime `session.update` when `FileSearch` is mixed with a client function named `collections_search` or `file_search` (including names nested in a Toolset).
- Reported to support@x.ai (no public ticket). xAI docs already alias native `collections_search` to OpenAI-compat `file_search`. Mixing FileSearch with a client function of either name makes grok-voice-latest return `server_error` / `internal_error` / `param=null` on the first `response.create`; hello still works; the socket stays up.

## Test plan
- [x] Unit tests for both reserved names: plain `@function_tool`, `name=` override, and `raw_schema`
- [x] Nested Toolset: FileSearch on top + reserved name inside the set
- [x] FileSearch alone, reserved name without FileSearch, and other function names still pass
- [x] `uv run pytest tests/test_realtime/test_xai_realtime_model.py --unit`


Made with [Cursor](https://cursor.com)