### PR TITLE
fix(aws): omit temperature for Claude Opus 4.7

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -40,8 +40,8 @@ if TYPE_CHECKING:
 DEFAULT_TEXT_MODEL = "amazon.nova-2-lite-v1:0"
 
 
-def _supports_temperature(model: str) -> bool:
-    """Return whether the Bedrock model accepts the common temperature field."""
+def _supports_inference_config(model: str) -> bool:
+    """Return whether the Bedrock model accepts the common sampling fields."""
     # Claude Opus 4.7 removed temperature, top_p, and top_k from its request
     # schema. Keep this check substring-based so inference profile ARNs work too.
     return "claude-opus-4-7" not in model.lower()
@@ -204,9 +204,9 @@ class LLM(llm.LLM):
         if is_given(self._opts.max_output_tokens):
             inference_config["maxTokens"] = self._opts.max_output_tokens
         temperature = temperature if is_given(temperature) else self._opts.temperature
-        if is_given(temperature) and _supports_temperature(self._opts.model):
+        if is_given(temperature) and _supports_inference_config(self._opts.model):
             inference_config["temperature"] = temperature
-        if is_given(self._opts.top_p):
+        if is_given(self._opts.top_p) and _supports_inference_config(self._opts.model):
             inference_config["topP"] = self._opts.top_p
 
         opts["inferenceConfig"] = inference_config

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/llm.py
@@ -40,6 +40,13 @@ if TYPE_CHECKING:
 DEFAULT_TEXT_MODEL = "amazon.nova-2-lite-v1:0"
 
 
+def _supports_temperature(model: str) -> bool:
+    """Return whether the Bedrock model accepts the common temperature field."""
+    # Claude Opus 4.7 removed temperature, top_p, and top_k from its request
+    # schema. Keep this check substring-based so inference profile ARNs work too.
+    return "claude-opus-4-7" not in model.lower()
+
+
 @dataclass
 class _LLMOptions:
     model: str
@@ -197,7 +204,7 @@ class LLM(llm.LLM):
         if is_given(self._opts.max_output_tokens):
             inference_config["maxTokens"] = self._opts.max_output_tokens
         temperature = temperature if is_given(temperature) else self._opts.temperature
-        if is_given(temperature):
+        if is_given(temperature) and _supports_temperature(self._opts.model):
             inference_config["temperature"] = temperature
         if is_given(self._opts.top_p):
             inference_config["topP"] = self._opts.top_p

--- a/livekit-plugins/livekit-plugins-aws/tests/test_llm_request_options.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_llm_request_options.py
@@ -1,4 +1,8 @@
+import pytest
+
 from livekit.plugins.aws.llm import _supports_inference_config
+
+pytestmark = pytest.mark.unit
 
 
 def test_claude_opus_47_does_not_receive_temperature():

--- a/livekit-plugins/livekit-plugins-aws/tests/test_llm_request_options.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_llm_request_options.py
@@ -1,0 +1,12 @@
+from livekit.plugins.aws.llm import _supports_temperature
+
+
+def test_claude_opus_47_does_not_receive_temperature():
+    assert not _supports_temperature("anthropic.claude-opus-4-7-v1:0")
+    assert not _supports_temperature(
+        "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-opus-4-7"
+    )
+
+
+def test_other_models_keep_temperature_support():
+    assert _supports_temperature("anthropic.claude-sonnet-4-20250514-v1:0")

--- a/livekit-plugins/livekit-plugins-aws/tests/test_llm_request_options.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_llm_request_options.py
@@ -1,12 +1,16 @@
-from livekit.plugins.aws.llm import _supports_temperature
+from livekit.plugins.aws.llm import _supports_inference_config
 
 
 def test_claude_opus_47_does_not_receive_temperature():
-    assert not _supports_temperature("anthropic.claude-opus-4-7-v1:0")
-    assert not _supports_temperature(
+    assert not _supports_inference_config("anthropic.claude-opus-4-7-v1:0")
+    assert not _supports_inference_config(
         "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-opus-4-7"
     )
 
 
+def test_claude_opus_47_does_not_receive_top_p():
+    assert not _supports_inference_config("anthropic.claude-opus-4-7-v1:0")
+
+
 def test_other_models_keep_temperature_support():
-    assert _supports_temperature("anthropic.claude-sonnet-4-20250514-v1:0")
+    assert _supports_inference_config("anthropic.claude-sonnet-4-20250514-v1:0")


### PR DESCRIPTION
Fixes #6581.\n\nAmazon Bedrock Claude Opus 4.7 rejects the standard 	emperature inference parameter, causing requests to fail with a ValidationException. This change detects the model ID (including inference profile ARNs) and omits 	emperature only for Claude Opus 4.7; all other Bedrock models retain the existing behavior.\n\nAdded offline unit coverage for direct model IDs, inference profile ARNs, and a compatible Claude model. Syntax checking and git diff --check pass. The repository's frozen dependency setup could not complete its network download, and the system pytest run was blocked during collection by a missing compatible LiveKit runtime dependency.