### PR TITLE
fix(aws): import AsyncBedrockRuntimeClient for bedrock-runtime 0.10+

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -15,11 +15,23 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
 import boto3
-from aws_sdk_bedrock_runtime.client import (
-    BedrockRuntimeClient,
-    InvokeModelWithBidirectionalStreamOperationInput,
-)
-from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
+
+try:
+    from aws_sdk_bedrock_runtime.client import (
+        AsyncBedrockRuntimeClient as _BedrockRuntimeClient,
+        InvokeModelWithBidirectionalStreamOperationInput,
+    )
+    from aws_sdk_bedrock_runtime.config import AsyncBedrockRuntimeConfig as _BedrockRuntimeConfig
+
+    _BEDROCK_CONFIG_USES_RESOLVE = True
+except ImportError:  # aws-sdk-bedrock-runtime < 0.10
+    from aws_sdk_bedrock_runtime.client import (
+        BedrockRuntimeClient as _BedrockRuntimeClient,
+        InvokeModelWithBidirectionalStreamOperationInput,
+    )
+    from aws_sdk_bedrock_runtime.config import Config as _BedrockRuntimeConfig
+
+    _BEDROCK_CONFIG_USES_RESOLVE = False
 from aws_sdk_bedrock_runtime.models import (
     BidirectionalInputPayloadPart,
     InvokeModelWithBidirectionalStreamInputChunk,
@@ -589,17 +601,32 @@ class RealtimeSession(  # noqa: F811
         )
 
     @utils.log_exceptions(logger=logger)
-    def _initialize_client(self) -> None:
-        """Instantiate the Bedrock runtime client"""
-        config = Config(
-            endpoint_uri=f"https://bedrock-runtime.{self._realtime_model._opts.region}.amazonaws.com",
-            region=self._realtime_model._opts.region,
-            aws_credentials_identity_resolver=_get_credentials_resolver(),
-            auth_scheme_resolver=HTTPAuthSchemeResolver(),
-            auth_schemes={"aws.auth#sigv4": SigV4AuthScheme(service="bedrock")},
-            user_agent_extra="x-client-framework:livekit-plugins-aws[realtime]",
-        )
-        self._bedrock_client = BedrockRuntimeClient(config=config)
+    async def _initialize_client(self) -> None:
+        """Instantiate the Bedrock runtime client.
+
+        aws-sdk-bedrock-runtime 0.10 renamed ``Config`` / ``BedrockRuntimeClient``
+        to the async types and requires ``await AsyncBedrockRuntimeConfig.resolve``.
+        0.11 then dropped the old names entirely. Keep both construction paths so
+        the locked 0.7 extra and a fresh pip install of 0.11 both import.
+        See https://github.com/livekit/agents/issues/6994.
+        """
+        kwargs: dict[str, Any] = {
+            "endpoint_uri": (
+                f"https://bedrock-runtime.{self._realtime_model._opts.region}.amazonaws.com"
+            ),
+            "region": self._realtime_model._opts.region,
+            "aws_credentials_identity_resolver": _get_credentials_resolver(),
+            "user_agent_extra": "x-client-framework:livekit-plugins-aws[realtime]",
+        }
+        if _BEDROCK_CONFIG_USES_RESOLVE:
+            config = await _BedrockRuntimeConfig.resolve(**kwargs)
+        else:
+            from aws_sdk_bedrock_runtime.config import HTTPAuthSchemeResolver, SigV4AuthScheme
+
+            kwargs["auth_scheme_resolver"] = HTTPAuthSchemeResolver()
+            kwargs["auth_schemes"] = {"aws.auth#sigv4": SigV4AuthScheme(service="bedrock")}
+            config = _BedrockRuntimeConfig(**kwargs)
+        self._bedrock_client = _BedrockRuntimeClient(config=config)
 
     def _calculate_session_duration(self) -> float:
         """Calculate session duration based on credential expiry and AWS 8-min limit."""
@@ -889,7 +916,7 @@ class RealtimeSession(  # noqa: F811
         try:
             if not self._bedrock_client:
                 logger.info("Creating Bedrock client")
-                self._initialize_client()
+                await self._initialize_client()
             assert self._bedrock_client is not None, "bedrock_client is None"
 
             logger.info("Initializing Bedrock stream")

--- a/livekit-plugins/livekit-plugins-aws/tests/test_realtime_validation_errors.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_realtime_validation_errors.py
@@ -5,6 +5,18 @@ from livekit.plugins.aws.experimental.realtime.realtime_model import (
 )
 
 
+def test_realtime_package_imports_against_current_bedrock_sdk() -> None:
+    """The realtime extra must import on aws-sdk-bedrock-runtime 0.10+ / 0.11.
+
+    0.10 dropped ``Config`` and 0.11 dropped ``BedrockRuntimeClient``, so the old
+    top-level imports failed before a session was created. Regression for
+    https://github.com/livekit/agents/issues/6994.
+    """
+    from livekit.plugins.aws.experimental.realtime import RealtimeModel
+
+    assert RealtimeModel.__name__ == "RealtimeModel"
+
+
 def test_system_instability_validation_error_is_recoverable() -> None:
     exc = SimpleNamespace(message="System instability detected. Please retry your request.")
 


### PR DESCRIPTION
## Summary

- `livekit-plugins-aws[realtime]` imported `BedrockRuntimeClient` and `Config` at module load. `aws-sdk-bedrock-runtime` 0.10 renamed those to `AsyncBedrockRuntimeClient` / `AsyncBedrockRuntimeConfig` (construct via `await resolve()`), and 0.11 dropped the old names, so `from livekit.plugins.aws.experimental.realtime import RealtimeModel` raises `ImportError` on a fresh pip install.
- Prefer the 0.10+ async types when present; fall back to the old constructor (including explicit SigV4 kwargs) so the workspace-locked 0.7 extra still imports.
- Add a regression test that imports `RealtimeModel` the way the issue reproduces.

Fixes #6994

## Test plan

- [x] `python -c "from livekit.plugins.aws.experimental.realtime import RealtimeModel"` against `aws-sdk-bedrock-runtime==0.11.0`
- [x] `pytest livekit-plugins/livekit-plugins-aws/tests/test_realtime_validation_errors.py`
