### PR TITLE
fix(aws): restore realtime plugin imports across SDK releases

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -15,11 +15,12 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
 import boto3
+from aws_sdk_bedrock_runtime.auth import HTTPAuthSchemeResolver
 from aws_sdk_bedrock_runtime.client import (
-    BedrockRuntimeClient,
+    AsyncBedrockRuntimeClient,
     InvokeModelWithBidirectionalStreamOperationInput,
 )
-from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
+from aws_sdk_bedrock_runtime.config import AsyncBedrockRuntimeConfig
 from aws_sdk_bedrock_runtime.models import (
     BidirectionalInputPayloadPart,
     InvokeModelWithBidirectionalStreamInputChunk,
@@ -30,6 +31,7 @@ from aws_sdk_bedrock_runtime.models import (
     ThrottlingException,
     ValidationException,
 )
+from smithy_aws_core.auth import SigV4AuthScheme
 from smithy_aws_core.identity import AWSCredentialsIdentity
 from smithy_aws_event_stream.exceptions import InvalidEventBytes
 from smithy_core.aio.interfaces.identity import IdentityResolver
@@ -591,7 +593,7 @@ class RealtimeSession(  # noqa: F811
     @utils.log_exceptions(logger=logger)
     def _initialize_client(self) -> None:
         """Instantiate the Bedrock runtime client"""
-        config = Config(
+        config = AsyncBedrockRuntimeConfig(
             endpoint_uri=f"https://bedrock-runtime.{self._realtime_model._opts.region}.amazonaws.com",
             region=self._realtime_model._opts.region,
             aws_credentials_identity_resolver=_get_credentials_resolver(),
@@ -599,7 +601,7 @@ class RealtimeSession(  # noqa: F811
             auth_schemes={"aws.auth#sigv4": SigV4AuthScheme(service="bedrock")},
             user_agent_extra="x-client-framework:livekit-plugins-aws[realtime]",
         )
-        self._bedrock_client = BedrockRuntimeClient(config=config)
+        self._bedrock_client = AsyncBedrockRuntimeClient(config=config)
 
     def _calculate_session_duration(self) -> float:
         """Calculate session duration based on credential expiry and AWS 8-min limit."""

--- a/livekit-plugins/livekit-plugins-aws/tests/test_realtime_validation_errors.py
+++ b/livekit-plugins/livekit-plugins-aws/tests/test_realtime_validation_errors.py
@@ -1,8 +1,17 @@
 from types import SimpleNamespace
 
+from aws_sdk_bedrock_runtime.client import AsyncBedrockRuntimeClient
+from aws_sdk_bedrock_runtime.config import AsyncBedrockRuntimeConfig
+
 from livekit.plugins.aws.experimental.realtime.realtime_model import (
     _is_recoverable_validation_error,
 )
+
+
+def test_realtime_sdk_uses_async_bedrock_client_api() -> None:
+    """The realtime plugin must use the SDK API available in supported releases."""
+    assert AsyncBedrockRuntimeClient is not None
+    assert AsyncBedrockRuntimeConfig is not None
 
 
 def test_system_instability_validation_error_is_recoverable() -> None:


### PR DESCRIPTION
## Summary

The AWS Realtime plugin imported the removed synchronous Bedrock client and configuration symbols, so it could not be imported with the supported `aws-sdk-bedrock-runtime` releases.

This changes the plugin to use the async Bedrock client API and the generated SDK's authentication/configuration modules. A regression test verifies the supported async client/configuration surface.

## Validation

- `ruff check` passed for the changed Python files.
- `python -m compileall` passed for the changed module.
- `git diff --check` passed.
- The focused pytest command could not run because the repository's frozen environment setup timed out while downloading large optional dependencies; the created environment does not contain pytest.

Closes #6994.
