### PR TITLE
fix: keep VAD from cancelling a manually committed user turn

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1362,7 +1362,11 @@ class AudioRecognition:
             self._turn_detector_prediction_fut = None
             self._turn_detector_flushed = False
 
-            if self._end_of_turn_task is not None:
+            # a manually committed turn is authoritative: VAD activity must not
+            # cancel its pending end-of-turn
+            if self._end_of_turn_task is not None and not (
+                self._turn_detection_mode == "manual" and self._user_turn_committed
+            ):
                 self._end_of_turn_task.cancel()
 
             if self._session.amd is not None:
@@ -1756,6 +1760,16 @@ class AudioRecognition:
                 self._user_turn_start,
             )
         )
+        self._end_of_turn_task.add_done_callback(self._on_eou_task_done)
+
+    def _on_eou_task_done(self, task: asyncio.Task[None]) -> None:
+        # a cancelled eou task skips the turn-scoped resets at the end of
+        # _bounce_eou_task; left set, _user_turn_committed makes _on_stt_event
+        # discard every later transcript. skip if a newer task took over.
+        if task.cancelled() and self._end_of_turn_task is task:
+            self._turn_backchannel_over_agent = False
+            self._overlap_in_current_turn = False
+            self._user_turn_committed = False
 
     def _check_user_turn_limit(self, transcript: str) -> None:
         """Check if the user turn exceeds configured limits.

--- a/tests/test_audio_recognition_turn_detection.py
+++ b/tests/test_audio_recognition_turn_detection.py
@@ -235,6 +235,77 @@ def _end_of_speech() -> vad.VADEvent:
     )
 
 
+class TestManualCommitSurvivesVadActivity:
+    """In ``turn_detection="manual"`` the application owns turn boundaries: an
+    eou task only exists for a turn the app already committed, so VAD activity
+    (a breath or click in the audio tail after commit) must neither cancel it
+    nor, when some other site cancels it, leave ``_user_turn_committed`` set —
+    stranded, that flag makes ``_on_stt_event`` discard every later transcript
+    until the next commit."""
+
+    def _make_manual_recognition(self) -> AudioRecognition:
+        ar = _make_full_recognition_for_eou()
+        ar._turn_detection_mode = "manual"
+        ar._turn_detector = None
+        ar._turn_detector_stream = None
+        ar._user_turn_committed = True
+        ar._turn_backchannel_over_agent = False
+        ar._overlap_in_current_turn = False
+        # park the bounce long enough for mid-sleep events to land
+        ar._endpointing.min_delay = 0.5
+        return ar
+
+    async def test_sos_does_not_cancel_committed_turn(self) -> None:
+        ar = self._make_manual_recognition()
+        ar._run_eou_detection(_make_chat_ctx_stub(), trigger="manual")
+        task = ar._end_of_turn_task
+        assert task is not None
+
+        await asyncio.sleep(0.05)
+        await ar._on_vad_event(_start_of_speech())
+
+        await task
+        assert not task.cancelled()
+        ar._hooks.on_end_of_turn.assert_called_once()
+        assert ar._user_turn_committed is False
+
+    async def test_cancelled_bounce_resets_committed_flag(self) -> None:
+        ar = self._make_manual_recognition()
+        ar._run_eou_detection(_make_chat_ctx_stub(), trigger="manual")
+        task = ar._end_of_turn_task
+        assert task is not None
+
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        await asyncio.sleep(0)  # let the done callback run
+
+        assert ar._user_turn_committed is False
+
+    async def test_superseded_bounce_leaves_the_new_commit_intact(self) -> None:
+        ar = self._make_manual_recognition()
+        ar._run_eou_detection(_make_chat_ctx_stub(), trigger="manual")
+        old_task = ar._end_of_turn_task
+        assert old_task is not None
+
+        # a second commit reschedules: the old task's callback must not reset
+        # the flag out from under the new bounce
+        await asyncio.sleep(0.05)
+        ar._user_turn_committed = True
+        ar._run_eou_detection(_make_chat_ctx_stub(), trigger="manual")
+        with contextlib.suppress(asyncio.CancelledError):
+            await old_task
+        await asyncio.sleep(0)
+
+        assert ar._user_turn_committed is True
+        new_task = ar._end_of_turn_task
+        assert new_task is not None and not new_task.cancelled()
+        new_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await new_task
+
+
 class TestSubThresholdSpeakingSpike:
     """A noise spike can push ``raw_accumulated_speech`` above zero on ``INFERENCE_DONE``
     without ever reaching ``START_OF_SPEECH`` — so no SOS/EOS fires. Resumed speech is


### PR DESCRIPTION
Fixes #7010.

## Summary

- In manual turn detection, VAD `START_OF_SPEECH` no longer cancels the pending end-of-turn task. An eou task in manual mode always belongs to a turn the application already committed.
- A cancelled eou task now resets the turn-scoped flags via a done callback, unless a newer task superseded it. Stranded, `_user_turn_committed` makes `_on_stt_event` discard every later transcript until the next commit.
- Add regression tests for both behaviors and for supersession safety.

## Why

`commit_user_turn()` resolves after scheduling the end-of-turn bounce, which sleeps the endpointing delay before delivery. Audio tail around a push-to-talk release can raise `START_OF_SPEECH` inside that window. The cancel is silent: no reply, no log, and the skipped cleanup leaves the session discarding all later transcripts. Same cancellation-poisoning class as #6913 and #6897.

## Testing

- `pytest tests/test_audio_recognition_turn_detection.py --audio_eot -q`: the two behavior tests fail without the fix and pass with it
- `ruff check` and `ruff format --check` on both changed files
- `mypy -p livekit.agents.voice.audio_recognition`: clean
