### PR TITLE
fix(simplismart): close the streams the STT collects

### DIFF
--- a/livekit-plugins/livekit-plugins-simplismart/livekit/plugins/simplismart/stt.py
+++ b/livekit-plugins/livekit-plugins-simplismart/livekit/plugins/simplismart/stt.py
@@ -23,7 +23,6 @@ import contextlib
 import json
 import os
 import traceback
-import weakref
 from typing import Any, Literal
 from urllib.parse import urlparse
 
@@ -184,7 +183,10 @@ class STT(stt.STT):
         )
         self._base_url = base_url
         self._session = http_session
-        self._streams = weakref.WeakSet[SpeechStream]()
+        # Strong ownership: a stream that finishes and gets garbage collected would
+        # otherwise take its still-open per-stream aiohttp.ClientSession with it.
+        # Streams discard themselves in SpeechStream.aclose() once closed.
+        self._streams: set[SpeechStream] = set()
 
     @property
     def provider(self) -> str:
@@ -303,6 +305,22 @@ class STT(stt.STT):
         )
         self._streams.add(stream)
         return stream
+
+    async def aclose(self) -> None:
+        """Close every stream this instance created.
+
+        ``stream()`` gives each ``SpeechStream`` its own ``aiohttp.ClientSession``,
+        and only ``SpeechStream.aclose()`` closes it. Streams are owned strongly
+        (see ``self._streams``) so a finished, garbage-collected stream cannot take
+        its open session with it; closed streams discard themselves, so the set
+        never grows without bound.
+        """
+        closed = list(self._streams)
+        for stream in closed:
+            await stream.aclose()
+        # Remove only what this call closed: a stream created concurrently (or one
+        # whose aclose was cancelled mid-cleanup) stays tracked for a later close.
+        self._streams.difference_update(closed)
 
 
 class SpeechStream(stt.SpeechStream):
@@ -439,6 +457,10 @@ class SpeechStream(stt.SpeechStream):
         await super().aclose()
         if self._session and not self._session.closed:
             await self._session.close()
+        # Release the STT's strong ownership only after session cleanup succeeds.
+        stt = self._stt
+        if self._session.closed and isinstance(stt, STT):
+            stt._streams.discard(self)
 
     async def _send_initial_config(self, ws: aiohttp.ClientWebSocketResponse) -> None:
         """Send initial configuration message with language for Simplismart models."""

--- a/tests/test_plugin_simplismart_stt.py
+++ b/tests/test_plugin_simplismart_stt.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+import gc
+
+import pytest
+
+from livekit.plugins.simplismart import stt as simplismart_stt
+
+pytestmark = pytest.mark.unit
+
+
+async def _idle_run(self: object) -> None:
+    del self
+    await asyncio.Event().wait()  # cancelled by aclose()
+
+
+@pytest.mark.asyncio
+async def test_simplismart_stt_aclose_closes_tracked_stream_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(simplismart_stt.SpeechStream, "_run", _idle_run)
+
+    stt = simplismart_stt.STT(api_key="sk_test")
+    stream_a = stt.stream()
+    stream_b = stt.stream()
+    sessions = [stream_a._session, stream_b._session]
+
+    assert all(not s.closed for s in sessions)
+    assert len(stt._streams) == 2
+
+    await stt.aclose()
+
+    assert all(s.closed for s in sessions), (
+        "STT.aclose() must close every per-stream aiohttp session"
+    )
+    assert len(stt._streams) == 0
+
+
+@pytest.mark.asyncio
+async def test_simplismart_stt_async_context_closes_stream_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(simplismart_stt.SpeechStream, "_run", _idle_run)
+
+    async with simplismart_stt.STT(api_key="sk_test") as stt:
+        stream = stt.stream()
+        session = stream._session
+        assert not session.closed
+
+    assert session.closed, "exiting `async with` must close per-stream sessions"
+
+
+@pytest.mark.asyncio
+async def test_simplismart_stt_aclose_tolerates_already_closed_streams(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(simplismart_stt.SpeechStream, "_run", _idle_run)
+
+    stt = simplismart_stt.STT(api_key="sk_test")
+    stream = stt.stream()
+    session = stream._session
+
+    await stream.aclose()
+    await stt.aclose()  # must not raise on an already-closed stream
+
+    assert session.closed
+
+
+@pytest.mark.asyncio
+async def test_simplismart_stt_aclose_closes_session_of_dropped_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A finished stream the caller dropped must not take its session to the GC.
+
+    With weak tracking, a completed SpeechStream can be collected before
+    STT.aclose() snapshots the set, leaving its per-stream ClientSession
+    unreachable and unclosed. Strong ownership keeps it reachable until
+    aclose closes it.
+    """
+
+    async def _immediate_run(self: object) -> None:
+        del self  # return immediately: the stream task finishes on its own
+
+    monkeypatch.setattr(simplismart_stt.SpeechStream, "_run", _immediate_run)
+
+    stt = simplismart_stt.STT(api_key="sk_test")
+    stream = stt.stream()
+    session = stream._session
+
+    del stream
+    gc.collect()
+
+    assert len(stt._streams) == 1, "a dropped stream must stay tracked until aclose"
+
+    await stt.aclose()
+
+    assert session.closed, "aclose() must close the session of a dropped stream"
+    assert len(stt._streams) == 0


### PR DESCRIPTION
> **Rescoped to simplismart.** This PR originally covered sarvam and simplismart. @dhruvladia-sarvam's #7058 fixes the sarvam half properly, with a correction I had missed and a full test suite, so that half is dropped here. simplismart has the identical bug and is not covered by #7058, so this keeps it — and follows #7058's approach so the two plugins stay consistent.

## The leak

`STT.stream()` gives every `SpeechStream` its own `aiohttp.ClientSession` ("a fresh session for this stream to avoid conflicts"), and only `SpeechStream.aclose()` closes it. The `STT` collects its streams into `self._streams`, but nothing ever reads that set and the class defines no `aclose()` — so `STT.aclose()` resolves to the no-op on the base class. The streams are never closed, their sessions stay open, and aiohttp reports unclosed client sessions once the streams are dropped.

The base contract asks for this: `STT.aclose` is documented as *"Close the STT, and every stream/requests associated with it"*, and `STT.__aexit__` delegates to it, so `async with stt:` currently leaks the streams.

## The change

An `aclose()` on `STT` that closes what it collected, plus the ownership fix from #7058:

- `self._streams` becomes a strong `set` instead of a `weakref.WeakSet`. A stream that finishes and is garbage collected would otherwise take its still-open session with it, before `aclose()` could ever reach it — which is the case most likely to leak in practice.
- `SpeechStream.aclose()` discards itself from the STT once its session is actually closed, so the set does not grow without bound.
- `aclose()` removes only the streams it closed, so one created concurrently (or one whose cleanup was cancelled) stays tracked for a later close.

## Validation

New hermetic tests in `tests/test_plugin_simplismart_stt.py` — `_run` is stubbed, no network:

- `aclose()` closes every per-stream session and empties the set
- the `async with` path closes them via `__aexit__`
- `aclose()` tolerates an already-closed stream
- a stream the caller dropped and that was garbage collected still has its session closed — the `WeakSet` case

With the fix reverted, three of the four fail and aiohttp's `Unclosed client session` appears exactly as the leak predicts. With the fix, all four pass.

`ruff check` and `ruff format --check` pass on both changed files.
