### PR TITLE
fix(gradium): update parameters

### DIFF
--- a/livekit-plugins/livekit-plugins-gradium/livekit/plugins/gradium/__init__.py
+++ b/livekit-plugins/livekit-plugins-gradium/livekit/plugins/gradium/__init__.py
@@ -16,7 +16,6 @@ from .tts import TTS
 from .version import __version__
 
 __all__ = [
-    "LLM",
     "STT",
     "SpeechStream",
     "logger",

--- a/livekit-plugins/livekit-plugins-gradium/livekit/plugins/gradium/stt.py
+++ b/livekit-plugins/livekit-plugins-gradium/livekit/plugins/gradium/stt.py
@@ -57,7 +57,6 @@ class STTOptions:
     buffer_size_seconds: float = 0.08
     encoding: str = "pcm_s16le"
     temperature: float | None = None
-    # TODO(laurent): support language detection
     language: LanguageCode = LanguageCode("en")
     vad_threshold: float = 0.6
     vad_bucket: int | None = 2
@@ -71,7 +70,7 @@ class STT(stt.STT):
         self,
         *,
         api_key: str | None = None,
-        model_endpoint: str | None = "wss://api.gradium.ai/api/speech/asr",
+        model_endpoint: str | None = None,
         model_name: str = "default",
         sample_rate: int = SUPPORTED_SAMPLE_RATE,
         encoding: NotGivenOr[STTEncoding] = NOT_GIVEN,
@@ -106,12 +105,11 @@ class STT(stt.STT):
 
         self._api_key = api_key
 
-        model_endpoint = model_endpoint or os.environ.get("GRADIUM_MODEL_ENDPOINT")
-
-        if not model_endpoint:
-            raise ValueError(
-                "The model endpoint is required, you can find it in the Gradium dashboard"
-            )
+        model_endpoint = (
+            model_endpoint
+            or os.environ.get("GRADIUM_MODEL_ENDPOINT")
+            or "wss://api.gradium.ai/api/speech/asr"
+        )
 
         self._model_endpoint = model_endpoint
         self._model_name = model_name

--- a/livekit-plugins/livekit-plugins-gradium/livekit/plugins/gradium/tts.py
+++ b/livekit-plugins/livekit-plugins-gradium/livekit/plugins/gradium/tts.py
@@ -54,10 +54,10 @@ class TTS(tts.TTS):
         self,
         *,
         api_key: str | None = None,
-        model_endpoint: str | None = "wss://api.gradium.ai/api/speech/tts",
+        model_endpoint: str | None = None,
         model_name: str = "default",
         voice: str | None = None,
-        voice_id: str | None = "YTpq7expH9539ERJ",
+        voice_id: str | None = "4SZHfMpw-p46Ywgs",
         pronunciation_id: str | None = None,
         json_config: dict[str, Any] | None = None,
         http_session: aiohttp.ClientSession | None = None,
@@ -90,12 +90,11 @@ class TTS(tts.TTS):
                 "or set it as the `GRADIUM_API_KEY` environment variable"
             )
 
-        model_endpoint = model_endpoint or os.environ.get("GRADIUM_MODEL_ENDPOINT")
-
-        if not model_endpoint:
-            raise ValueError(
-                "The model endpoint is required, you can find it in the Gradium dashboard"
-            )
+        model_endpoint = (
+            model_endpoint
+            or os.environ.get("GRADIUM_MODEL_ENDPOINT")
+            or "wss://api.gradium.ai/api/speech/tts"
+        )
 
         self._api_key = api_key
         self._model_endpoint = model_endpoint
@@ -142,10 +141,13 @@ class TTS(tts.TTS):
         self,
         *,
         voice: NotGivenOr[str] = NOT_GIVEN,
+        voice_id: NotGivenOr[str] = NOT_GIVEN,
         json_config: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
     ) -> None:
         if is_given(voice):
             self._opts.voice = voice
+        if is_given(voice_id):
+            self._opts.voice_id = voice_id
         if is_given(json_config):
             self._opts.json_config = json_config
 


### PR DESCRIPTION

- Remove "LLM" from __all__: the plugin exports no LLM, so 'from livekit.plugins.gradium import *' raised AttributeError.
- Make GRADIUM_MODEL_ENDPOINT effective for TTS and STT: the parameter's non-None default meant the documented env var was never consulted. Default endpoints are unchanged when neither is set.
- Allow switching voices via update_options(voice_id=...): the existing voice parameter is a fallback that the voice_id default always shadowed.
- Change the default TTS voice to 4SZHfMpw-p46Ywgs (Harper), a voice from the public flagship catalog, matching the published LiveKit docs.