### PR TITLE
fix: cancel parked preemptive generation during handoff

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2562,6 +2562,7 @@ class AgentActivity(RecognitionHooks):
                     "skipping reply to user input, current speech generation cannot be interrupted",
                     extra={"lk.pii.user_input": info.new_transcript},
                 )
+                self._cancel_preemptive_generation()
                 return
             await self._cancel_speech_pause(self._cancel_speech_pause_task)
 

--- a/tests/test_wait_for_idle_cancellation.py
+++ b/tests/test_wait_for_idle_cancellation.py
@@ -97,3 +97,23 @@ async def test_cancelling_latest_user_turn_does_not_cancel_predecessor() -> None
 
     predecessor.cancel()
     await asyncio.gather(predecessor, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_skipping_uninterruptible_speech_cancels_preemptive_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = AgentSession()
+    activity = AgentActivity(Agent(instructions="test"), session)
+    activity._current_speech = cast(Any, SimpleNamespace(allow_interruptions=False))
+    cancelled = False
+
+    def cancel_preemptive_generation() -> None:
+        nonlocal cancelled
+        cancelled = True
+
+    monkeypatch.setattr(activity, "_cancel_preemptive_generation", cancel_preemptive_generation)
+
+    await activity._user_turn_completed_task(None, _end_of_turn(1))
+
+    assert cancelled


### PR DESCRIPTION
## Summary

When an uninterruptible speech is active, a preemptive generation cannot be used and must be cancelled before the user-turn task returns. This prevents AgentTask handoffs from waiting on orphaned speech work.

## Changes

- Cancel parked preemptive generation when an uninterruptible speech causes a user reply to be skipped.
- Add a deterministic regression test for the cleanup path.

## Tests

- uv run --frozen pytest tests/test_wait_for_idle_cancellation.py -q
- uv run --frozen ruff check livekit-agents/livekit/agents/voice/agent_activity.py tests/test_wait_for_idle_cancellation.py
- uv run --frozen ruff format --check livekit-agents/livekit/agents/voice/agent_activity.py tests/test_wait_for_idle_cancellation.py
- git diff --check

Closes #6858.