### PR TITLE
feat(openai): add with_audexum() to the OpenAI TTS and STT plugins

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -400,6 +400,38 @@ class STT(stt.STT):
         )
 
     @staticmethod
+    def with_audexum(
+        *,
+        model: str = "whisper-1",
+        api_key: NotGivenOr[str] = NOT_GIVEN,
+        base_url: str = "https://audexum.com/v1",
+        client: openai.AsyncClient | None = None,
+        language: str | list[str] = "en",
+        detect_language: bool = False,
+        prompt: NotGivenOr[str] = NOT_GIVEN,
+    ) -> STT:
+        """
+        Create a new instance of Audexum STT.
+
+        ``api_key`` must be set to your Audexum API key, either using the argument or by setting
+        the ``AUDEXUM_API_KEY`` environmental variable.
+        """
+        audexum_api_key = api_key if is_given(api_key) else os.environ.get("AUDEXUM_API_KEY")
+        if not audexum_api_key:
+            raise ValueError("Audexum API key is required")
+
+        return STT(
+            model=model,
+            api_key=audexum_api_key,
+            base_url=base_url,
+            client=client,
+            language=language,
+            detect_language=detect_language,
+            prompt=prompt,
+            use_realtime=False,
+        )
+
+    @staticmethod
     def with_ovhcloud(
         *,
         model: str = "whisper-large-v3-turbo",

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import os
 from dataclasses import dataclass, replace
 from typing import Literal
 
@@ -158,6 +159,35 @@ class TTS(tts.TTS):
             self._opts.speed = speed
         if is_given(instructions):
             self._opts.instructions = instructions
+
+    @staticmethod
+    def with_audexum(
+        *,
+        model: str = "tts-1",
+        voice: str = "nova",
+        speed: float = 1.0,
+        api_key: NotGivenOr[str] = NOT_GIVEN,
+        base_url: str = "https://audexum.com/v1",
+        client: openai.AsyncClient | None = None,
+    ) -> TTS:
+        """
+        Create a new instance of Audexum TTS.
+
+        ``api_key`` must be set to your Audexum API key, either using the argument or by setting
+        the ``AUDEXUM_API_KEY`` environmental variable.
+        """
+        audexum_api_key = api_key if is_given(api_key) else os.environ.get("AUDEXUM_API_KEY")
+        if not audexum_api_key:
+            raise ValueError("Audexum API key is required")
+
+        return TTS(
+            model=model,
+            voice=voice,
+            speed=speed,
+            api_key=audexum_api_key,
+            base_url=base_url,
+            client=client,
+        )
 
     @staticmethod
     def with_azure(


### PR DESCRIPTION
Audexum serves the OpenAI audio shape — `POST /v1/audio/speech` and `POST /v1/audio/transcriptions` — so it already works through `livekit-plugins-openai` today by passing `base_url`. These two helpers just follow the existing `with_azure` / `with_ovhcloud` pattern so the endpoint and the `AUDEXUM_API_KEY` lookup are not repeated at every call site.

```python
from livekit.plugins import openai

tts = openai.TTS.with_audexum(voice="nova")
stt = openai.STT.with_audexum(language="en")
```

61 lines across the two files, plus `import os` in `tts.py` (`stt.py` already had it). No new dependency, no behaviour change for existing users, and nothing outside the two `with_audexum` methods is touched.

Scope, so it is clear what this is not: 43 TTS voices over 32 languages and STT over 25 languages, EU-hosted. OpenAI's voice names (`alloy`, `nova`, `shimmer`, …) are mapped on the server side, so a config left on an OpenAI default still produces audio.

Disclosure: I maintain Audexum, and this PR was drafted with an AI assistant. If you would rather have a standalone `livekit-plugins-audexum` package than helpers on the OpenAI plugin, say so and I will close this and write that instead.