### PR TITLE
fix(openai): close the STT's websocket connection pool

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/stt.py
@@ -595,6 +595,14 @@ class STT(stt.STT):
     async def _close_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:
         await ws.close()
 
+    async def aclose(self) -> None:
+        """Close the websocket connection pool this STT owns.
+
+        Without this the pool's ``close_cb`` never runs for pooled sockets, so
+        they stay open after the STT is closed.
+        """
+        await self._pool.aclose()
+
     def _ensure_session(self) -> aiohttp.ClientSession:
         if not self._session:
             self._session = utils.http_context.http_session()


### PR DESCRIPTION
Found by reading the plugins rather than from a report, so there is no issue to close.

## The leak

`STT.__init__` owns a websocket connection pool (`stt.py:322`):

```python
self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
    max_session_duration=_max_session_duration,
    connect_cb=self._connect_ws,
    close_cb=self._close_ws,
)
```

but `class STT` never defined `aclose()`, so `STT.aclose()` resolved to the abstract no-op on the base class and `ConnectionPool.aclose()` was never called. The pool's own `close_cb` — here just `await ws.close()` — therefore never ran for pooled sockets, and they stayed open after the STT was closed.

What makes this easy to miss is that the file *does* contain an `aclose`, at line 733 — but that one belongs to `class SpeechStream` (line 665), which **receives** the pool rather than owning it. A `grep -c "async def aclose"` on this file returns 1 and looks satisfied; the mismatch only shows up when you check which class that line falls inside.

## Why this reads as an omission

Nineteen plugins in this repo hold a `ConnectionPool`. Eighteen of them close it in `aclose`. This was the only one that didn't.

`mistralai/stt.py:153` is the same two lines:

```python
async def aclose(self) -> None:
    await self._pool.aclose()
```

and `google/stt.py`, `deepgram/tts.py`, `rime/tts.py`, `neuphonic/tts.py` and the rest do the equivalent.

## Scope

Only the pool needs handling. `_ensure_session()` resolves through `utils.http_context.http_session()`, which the STT does not own, so there is nothing else to release. `stt.py` is also the only file in this plugin that constructs a pool.

`_streams` is untouched — it is read at 501/552/568 for settings propagation and is working as intended.

## Verification, and its limits

`ruff check` and `ruff format --check` pass at the repo's `line-length = 100` / `target-version = py310`, and the file compiles.

Being straight about what I did **not** do: I have not run the test suite locally and there is no test in this PR. The argument is that the pool is constructed with a `close_cb`, nothing was invoking it, and eighteen sibling plugins call `aclose()` on theirs. If you would like a regression test, tell me where it belongs and I will add one.
