### PR TITLE
feat(spatius): warm up region, TLS, and session token at process init

### DIFF
--- a/livekit-plugins/livekit-plugins-spatius/README.md
+++ b/livekit-plugins/livekit-plugins-spatius/README.md
@@ -34,3 +34,36 @@ await avatar.start(session, room=ctx.room)
 
 The plugin reads `SPATIUS_API_KEY`, `SPATIUS_APP_ID`, and `SPATIUS_AVATAR_ID` from the
 environment when constructor arguments are omitted.
+
+## Warm-up
+
+At session start, the Spatius SDK resolves the ingress region via the bootstrap API
+(with the default `region="auto"`) and exchanges the API key for a session token —
+two sequential HTTPS round trips on the room-join critical path. Register the
+plugin's `prewarm` function to move that work into process warm-up, before a job is
+dispatched:
+
+```python
+from livekit import agents
+from livekit.plugins import spatius
+
+
+def prewarm(proc: agents.JobProcess):
+    spatius.prewarm(proc)
+
+
+if __name__ == "__main__":
+    agents.cli.run_app(
+        agents.WorkerOptions(entrypoint_fnc=entrypoint, prewarm_fnc=prewarm)
+    )
+```
+
+The spatius SDK caches the resolved region (5 minutes) and the prefetched session
+token (until shortly before expiry) process-wide, so `AvatarSession.start()` in the
+dispatched job reuses them and goes straight to the ingress WebSocket connect. It
+also opens throwaway TLS connections to the console and ingress endpoints to prime
+DNS and the shared TLS session cache. Warm-up is best-effort and never fails
+process initialization; without it, everything resolves inline as before.
+
+Session-token prefetch assumes the Spatius backend allows a token to back more than
+one session; opt out with `spatius.prewarm(proc, prefetch_session_token=False)`.

--- a/livekit-plugins/livekit-plugins-spatius/livekit/plugins/spatius/__init__.py
+++ b/livekit-plugins/livekit-plugins-spatius/livekit/plugins/spatius/__init__.py
@@ -18,11 +18,13 @@ from spatius import AudioFormat
 
 from .avatar import AvatarSession, SpatiusException
 from .version import __version__
+from .warmup import prewarm
 
 __all__ = [
     "AudioFormat",
     "AvatarSession",
     "SpatiusException",
+    "prewarm",
     "__version__",
 ]
 

--- a/livekit-plugins/livekit-plugins-spatius/livekit/plugins/spatius/warmup.py
+++ b/livekit-plugins/livekit-plugins-spatius/livekit/plugins/spatius/warmup.py
@@ -1,0 +1,117 @@
+# Copyright 2026 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Process warm-up helpers for the Spatius plugin.
+
+At session start the Spatius SDK resolves the ingress region through the global
+bootstrap API (when ``region="auto"``, the default) and exchanges the API key
+for a session token — two sequential HTTPS round trips on the room-join critical
+path. Wiring ``prewarm`` into the worker moves that work to process
+initialization, before a job is dispatched:
+
+```python
+from livekit import agents
+from livekit.plugins import spatius
+
+
+def prewarm(proc: agents.JobProcess) -> None:
+    spatius.prewarm(proc)
+
+
+if __name__ == "__main__":
+    agents.cli.run_app(
+        agents.WorkerOptions(entrypoint_fnc=entrypoint, prewarm_fnc=prewarm)
+    )
+```
+
+The spatius SDK caches the resolved region and the session token process-wide,
+so ``AvatarSession.start()`` in the dispatched job reuses them. Warm-up is
+best-effort: failures are logged and never raised, so process initialization and
+the dispatch-time behavior are unaffected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from livekit.agents import JobProcess
+
+from .log import logger
+
+# keep in sync with the environment variables read by AvatarSession
+_ENV_API_KEY = "SPATIUS_API_KEY"
+_ENV_APP_ID = "SPATIUS_APP_ID"
+_ENV_REGION = "SPATIUS_REGION"
+_ENV_CONSOLE_ENDPOINT = "SPATIUS_CONSOLE_ENDPOINT"
+_ENV_INGRESS_ENDPOINT = "SPATIUS_INGRESS_ENDPOINT"
+
+# "auto" sentinel, mirrors spatius.session_config.DEFAULT_REGION_REQUEST
+_AUTO_REGION = "auto"
+
+
+def prewarm(proc: JobProcess, *, prefetch_session_token: bool = True) -> None:
+    """Warm Spatius connection state for this job process.
+
+    Pass to ``WorkerOptions(prewarm_fnc=...)``. Reads the same SPATIUS_*
+    environment variables as ``AvatarSession`` and delegates to
+    ``spatius.prewarm()``, which resolves and caches the ``auto`` region, warms
+    TLS to the console and ingress endpoints, and (by default) prefetches a
+    session token so the first ``AvatarSession.start()`` in this process skips
+    both HTTPS round trips.
+
+    Args:
+        proc: The job process being initialized.
+        prefetch_session_token: Prefetch and cache a session token. Assumes the
+            Spatius backend allows a token to back more than one session; pass
+            False if tokens are single-use.
+
+    Never raises; a failed warm-up just means the dispatch-time path resolves
+    and fetches inline as usual.
+    """
+    app_id = os.getenv(_ENV_APP_ID, "")
+    if not app_id:
+        return  # misconfiguration surfaces in the entrypoint instead
+
+    api_key = os.getenv(_ENV_API_KEY, "")
+    if prefetch_session_token and not api_key:
+        logger.warning("SPATIUS_API_KEY not set; skipping Spatius session-token prefetch")
+        prefetch_session_token = False
+
+    import spatius
+
+    try:
+        result = asyncio.run(
+            spatius.prewarm(
+                app_id=app_id,
+                api_key=api_key or None,
+                region=os.getenv(_ENV_REGION, _AUTO_REGION),
+                console_endpoint_url=os.getenv(_ENV_CONSOLE_ENDPOINT, ""),
+                ingress_endpoint_url=os.getenv(_ENV_INGRESS_ENDPOINT, ""),
+                prefetch_session_token=prefetch_session_token,
+            )
+        )
+    except Exception:
+        # warm-up must never fail process initialization
+        logger.warning("Spatius warm-up failed", exc_info=True)
+        return
+
+    logger.debug(
+        "Spatius warm-up finished",
+        extra={
+            "region": result.region,
+            "tls_warmed": result.tls_warmed,
+            "session_token_prefetched": result.session_token_prefetched,
+        },
+    )

--- a/livekit-plugins/livekit-plugins-spatius/livekit/plugins/spatius/warmup.py
+++ b/livekit-plugins/livekit-plugins-spatius/livekit/plugins/spatius/warmup.py
@@ -100,6 +100,9 @@ def prewarm(proc: JobProcess, *, prefetch_session_token: bool = True) -> None:
                 console_endpoint_url=os.getenv(_ENV_CONSOLE_ENDPOINT, ""),
                 ingress_endpoint_url=os.getenv(_ENV_INGRESS_ENDPOINT, ""),
                 prefetch_session_token=prefetch_session_token,
+                # Bound region resolution and token prefetch below the worker's
+                # default 10-second process initialization timeout.
+                timeout=4.0,
             )
         )
     except Exception:

--- a/livekit-plugins/livekit-plugins-spatius/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-spatius/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "livekit-agents>=1.8.0",
-    "spatius[opus]>=1.0.5",
+    "spatius[opus]>=1.1.0",
 ]
 
 [project.urls]

--- a/livekit-plugins/livekit-plugins-spatius/tests/test_warmup.py
+++ b/livekit-plugins/livekit-plugins-spatius/tests/test_warmup.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import spatius as spatius_sdk
+
+from livekit.plugins.spatius import warmup
+
+pytestmark = pytest.mark.unit
+
+
+def _sdk_prewarm_result() -> MagicMock:
+    result = MagicMock()
+    result.region = "us-east"
+    result.tls_warmed = ["console.us-east.spatius.ai", "api.us-east.spatius.ai"]
+    result.session_token_prefetched = True
+    return result
+
+
+def _patch_sdk_prewarm():
+    return patch.object(spatius_sdk, "prewarm", new=AsyncMock(return_value=_sdk_prewarm_result()))
+
+
+def test_prewarm_delegates_to_sdk_with_env_config() -> None:
+    proc = MagicMock()
+    with (
+        patch.dict(
+            os.environ,
+            {"SPATIUS_APP_ID": "test-app", "SPATIUS_API_KEY": "test-key"},
+            clear=True,
+        ),
+        _patch_sdk_prewarm() as sdk_prewarm,
+    ):
+        warmup.prewarm(proc)
+
+    sdk_prewarm.assert_awaited_once()
+    kwargs = sdk_prewarm.await_args.kwargs
+    assert kwargs["app_id"] == "test-app"
+    assert kwargs["api_key"] == "test-key"
+    assert kwargs["region"] == "auto"
+    assert kwargs["console_endpoint_url"] == ""
+    assert kwargs["ingress_endpoint_url"] == ""
+    assert kwargs["prefetch_session_token"] is True
+
+
+def test_prewarm_forwards_region_and_endpoints() -> None:
+    proc = MagicMock()
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "SPATIUS_APP_ID": "test-app",
+                "SPATIUS_API_KEY": "test-key",
+                "SPATIUS_REGION": "us-west",
+                "SPATIUS_CONSOLE_ENDPOINT": "https://console.example.com",
+                "SPATIUS_INGRESS_ENDPOINT": "wss://api.example.com",
+            },
+            clear=True,
+        ),
+        _patch_sdk_prewarm() as sdk_prewarm,
+    ):
+        warmup.prewarm(proc, prefetch_session_token=False)
+
+    kwargs = sdk_prewarm.await_args.kwargs
+    assert kwargs["region"] == "us-west"
+    assert kwargs["console_endpoint_url"] == "https://console.example.com"
+    assert kwargs["ingress_endpoint_url"] == "wss://api.example.com"
+    assert kwargs["prefetch_session_token"] is False
+
+
+def test_prewarm_skips_without_app_id() -> None:
+    proc = MagicMock()
+    with patch.dict(os.environ, {}, clear=True), _patch_sdk_prewarm() as sdk_prewarm:
+        warmup.prewarm(proc)
+
+    sdk_prewarm.assert_not_awaited()
+
+
+def test_prewarm_disables_token_prefetch_without_api_key() -> None:
+    proc = MagicMock()
+    with (
+        patch.dict(os.environ, {"SPATIUS_APP_ID": "test-app"}, clear=True),
+        _patch_sdk_prewarm() as sdk_prewarm,
+    ):
+        warmup.prewarm(proc)
+
+    kwargs = sdk_prewarm.await_args.kwargs
+    assert kwargs["api_key"] is None
+    assert kwargs["prefetch_session_token"] is False
+
+
+def test_prewarm_never_raises_on_sdk_failure() -> None:
+    proc = MagicMock()
+    with (
+        patch.dict(
+            os.environ,
+            {"SPATIUS_APP_ID": "test-app", "SPATIUS_API_KEY": "test-key"},
+            clear=True,
+        ),
+        patch.object(spatius_sdk, "prewarm", new=AsyncMock(side_effect=RuntimeError("boom"))),
+    ):
+        warmup.prewarm(proc)  # logs and swallows

--- a/livekit-plugins/livekit-plugins-spatius/tests/test_warmup.py
+++ b/livekit-plugins/livekit-plugins-spatius/tests/test_warmup.py
@@ -43,6 +43,7 @@ def test_prewarm_delegates_to_sdk_with_env_config() -> None:
     assert kwargs["console_endpoint_url"] == ""
     assert kwargs["ingress_endpoint_url"] == ""
     assert kwargs["prefetch_session_token"] is True
+    assert kwargs["timeout"] == 4.0
 
 
 def test_prewarm_forwards_region_and_endpoints() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3432,7 +3432,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "livekit-agents", editable = "livekit-agents" },
-    { name = "spatius", extras = ["opus"], specifier = ">=1.0.5" },
+    { name = "spatius", extras = ["opus"], specifier = ">=1.1.0" },
 ]
 
 [[package]]
@@ -5773,7 +5773,7 @@ wheels = [
 
 [[package]]
 name = "spatius"
-version = "1.0.5"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -5784,9 +5784,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/10/d1b4b523c0b20e6bea62c3f8497ea12339bc0532804ffe9d9fba7c1b00e9/spatius-1.0.5.tar.gz", hash = "sha256:bc9a2d66156e5eec65f45847d4d19be1b0cbc0bbe91011150a58f931ad681500", size = 152920, upload-time = "2026-08-16T22:13:26.215Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/e5/bcc84a81d1aa7254d91869f2ebac0bfdf6e9d3c43510ee98abee6b478d04/spatius-1.1.0.tar.gz", hash = "sha256:5b2d6ce92ce58172dc2ed98f5184de0e961f781ed390f7466b471836c2d04658", size = 160375, upload-time = "2026-08-28T11:45:57.494Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/c9/4b2ba01d29595f9da903519588bfee8f06982bc5836a61bb81646c1998a0/spatius-1.0.5-py3-none-any.whl", hash = "sha256:114a19897ed96a6f6a7fac7edece0f204f9fe166776d8ca253119c9bf05c8371", size = 31489, upload-time = "2026-08-16T22:13:24.954Z" },
+    { url = "https://files.pythonhosted.org/packages/22/73/b13dda4c6376aaeb4cd61eb0c0f340afa35582b81b9c97262f85f2d32064/spatius-1.1.0-py3-none-any.whl", hash = "sha256:887ee65021a7dd52470a29bd341b40b4a2ee9c21e423e59d011097329a460b34", size = 38519, upload-time = "2026-08-28T11:45:56.303Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds `spatius.prewarm(proc)` to the Spatius avatar plugin, for use with
`WorkerOptions(prewarm_fnc=...)`. It moves the Spatius SDK's connection setup off
the room-join critical path and into worker process initialization, before a job
is dispatched.

## Problem

Every `AvatarSession.start()` at room join performs two sequential HTTPS round
trips before connecting the ingress WebSocket:

1. `POST /bootstrap` — `auto` region scheduling
2. `POST /session-tokens` — API key → session token exchange

## Change

`spatius.prewarm(proc)` delegates to the spatius SDK's `prewarm()`, which at
process init:

- resolves and caches the `auto` ingress region (5-min TTL),
- prefetches and caches a session token (on by default; opt out with
  `prefetch_session_token=False`),
- warms TLS to the console and ingress endpoints, priming DNS and the shared TLS
  session cache used by both the HTTP and WebSocket connects.

The SDK reuses these process-wide, so `AvatarSession.start()` in a dispatched job
skips both HTTPS round trips and goes straight to the room-bound ingress
WebSocket connect.

Best-effort by design: it never raises, no-ops without `SPATIUS_APP_ID`, and a
warm-up miss falls back to today's inline behavior.

## Usage

```python
from livekit import agents
from livekit.plugins import spatius


def prewarm(proc: agents.JobProcess):
    spatius.prewarm(proc)


if __name__ == "__main__":
    agents.cli.run_app(
        agents.WorkerOptions(entrypoint_fnc=entrypoint, prewarm_fnc=prewarm)
    )
```