### PR TITLE
fix: resolve transcript-only amd greetings at eot

### DIFF
--- a/livekit-agents/livekit/agents/voice/amd/classifier.py
+++ b/livekit-agents/livekit/agents/voice/amd/classifier.py
@@ -260,10 +260,10 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
         The commit may be positive (predicted end of turn) or a negative
         prediction whose max endpointing delay elapsed — either one counts.
 
-        For every verdict except a confident human, both an end-of-turn and the
-        post-speech silence timer must fire before it is released (whichever
-        lands last unblocks the wait). Humans only require the silence timer so
-        we can respond quickly.
+        When VAD provides a speech end, every verdict except a confident human
+        requires both end-of-turn and the post-speech silence timer. If VAD does
+        not provide a valid speech end, end-of-turn also satisfies the silence
+        gate. Humans only require the silence gate so we can respond quickly.
 
         When the turn detector never calls this, the synthetic EOT timer
         provides the backstop. This gate matters most under
@@ -282,6 +282,9 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
         if self._eot_timer is not None:
             self._eot_timer.cancel()
             self._eot_timer = None
+        if self._speech_active or self._speech_ended_at is None:
+            self._speech_active = False
+            self._silence_reached = True
         self._eot_reached = True
         self._try_emit_result()
 
@@ -299,7 +302,8 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
     def _can_emit(self, verdict: AMDPredictionEvent) -> bool:
         """Release gate for a verdict (which verdict it is, is decided elsewhere).
 
-        - post-speech silence is required for every verdict
+        - post-speech silence, or the EOT fallback when VAD misses speech end,
+          is required for every verdict
         - end-of-turn is additionally required for everything except a human
           (machine and uncertain wait for the greeting to finish; humans
           release on silence alone so we can respond quickly)
@@ -370,7 +374,7 @@ class _AMDClassifier(EventEmitter[Literal["amd_prediction"]]):
                     speech_duration=speech_duration or self.speech_duration,
                     category=category,
                     reason=reason,
-                    transcript="",
+                    transcript=self._transcript,
                     delay=(time.time() - self._speech_ended_at) if self._speech_ended_at else 0.0,
                 )
             )

--- a/livekit-agents/livekit/agents/voice/amd/detector.py
+++ b/livekit-agents/livekit/agents/voice/amd/detector.py
@@ -126,7 +126,7 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
             if LiveKit inference credentials are available in the environment
             it uses ``"google/gemini-3.1-flash-lite"`` via the
             inference gateway; otherwise it falls back to the session's own
-            LLM.
+            LLM. Pass ``None`` to always reuse the session's LLM.
         interrupt_on_machine: If ``True`` (default), interrupt any pending
             agent speech immediately when a machine is detected.
         ivr_detection: If ``True`` (default), automatically start IVR
@@ -140,7 +140,8 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
             ``"cartesia/ink-whisper"``). When omitted, AMD auto-selects:
             if LiveKit inference credentials are available it uses
             ``"cartesia/ink-whisper"`` via the inference gateway; otherwise
-            it reuses the session's existing STT transcripts.
+            it reuses the session's existing STT transcripts. Pass ``None`` to
+            always reuse the session's STT transcripts.
         suppress_compatibility_warning: If ``True``, do not log a warning when
             the resolved STT or LLM is not among the bundled AMD-tested model
             strings. Has no effect on classification behavior.
@@ -169,8 +170,8 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
         self,
         session: AgentSession,
         *,
-        llm: NotGivenOr[LLM | LLMModels | str] = NOT_GIVEN,
-        stt: NotGivenOr[STT | str] = NOT_GIVEN,
+        llm: NotGivenOr[LLM | LLMModels | str | None] = NOT_GIVEN,
+        stt: NotGivenOr[STT | str | None] = NOT_GIVEN,
         interrupt_on_machine: bool = True,
         ivr_detection: bool = True,
         participant_identity: NotGivenOr[str] = NOT_GIVEN,
@@ -189,18 +190,18 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
                 is_cloud(os.getenv("LIVEKIT_URL", "")) and bool(api_key) and bool(api_secret)
             )
             if not is_given(llm):
-                llm = self._DEFAULT_LLM_MODEL if auto_select else NOT_GIVEN
+                llm = self._DEFAULT_LLM_MODEL if auto_select else None
             if not is_given(stt):
-                stt = self._DEFAULT_STT_MODEL if auto_select else NOT_GIVEN
+                stt = self._DEFAULT_STT_MODEL if auto_select else None
 
-        self._llm_config: NotGivenOr[LLM | LLMModels | str] = llm
+        self._llm_config: LLM | LLMModels | str | None = llm
         self._session: AgentSession = session
         self._interrupt_on_machine = interrupt_on_machine
         self._ivr_detection = ivr_detection
         self._wait_until_finished = wait_until_finished
         self._suppress_compatibility_warning = suppress_compatibility_warning
         self._participant_identity: NotGivenOr[str] = participant_identity
-        self._stt: NotGivenOr[_STT] = _InferenceSTT(stt) if isinstance(stt, str) else stt
+        self._stt: _STT | None = _InferenceSTT(stt) if isinstance(stt, str) else stt
 
         self._classifier: _AMDClassifier | None = None
         self._result: AMDPredictionEvent | None = None
@@ -216,7 +217,7 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
         }
 
         if not self._suppress_compatibility_warning:
-            if is_given(self._stt):
+            if self._stt is not None:
                 _warn_if_not_evaluated(
                     self._stt.model,
                     EVALUATED_STT_MODELS,
@@ -446,7 +447,7 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
             else:
                 self._start_listening()
 
-        if is_given(self._stt) and not self._closed:
+        if self._stt is not None and not self._closed:
             logger.debug("starting amd stt pipeline")
             await self._run_stt()
 
@@ -482,7 +483,7 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
             self._start_listening()
 
     async def _run_stt(self) -> None:
-        assert is_given(self._stt)
+        assert self._stt is not None
         assert self._classifier
 
         self._audio_ch = aio.Chan[rtc.AudioFrame]()
@@ -614,7 +615,7 @@ class AMD(EventEmitter[Literal["amd_prediction"]]):
                 no_speech_threshold=self._opts["no_speech_threshold"],
                 timeout=self._opts["timeout"],
                 prompt=self._opts["prompt"],
-                source="amd_stt" if is_given(self._stt) else "stt",
+                source="amd_stt" if self._stt is not None else "stt",
                 wait_until_finished=self._wait_until_finished,
                 max_endpointing_delay=max_endpointing_delay,
             )

--- a/tests/test_amd_classifier.py
+++ b/tests/test_amd_classifier.py
@@ -9,19 +9,15 @@ from __future__ import annotations
 
 import asyncio
 import time
-from types import SimpleNamespace
 
 import pytest
 
 from livekit.agents.llm import FunctionToolCall
-from livekit.agents.types import NOT_GIVEN
-from livekit.agents.voice.amd import detector as amd_detector
 from livekit.agents.voice.amd.classifier import (
     AMDCategory,
     AMDPredictionEvent,
     _AMDClassifier,
 )
-from livekit.agents.voice.amd.detector import AMD
 
 from .fake_llm import FakeLLM, FakeLLMResponse
 
@@ -51,22 +47,6 @@ def _make_classifier(
     )
 
 
-class _RecordingClassifier:
-    def __init__(self) -> None:
-        self.timer_calls = 0
-        self.listening = False
-        self.settled: list[tuple[AMDCategory, str]] = []
-
-    def start_detection_timer(self) -> None:
-        self.timer_calls += 1
-
-    def start_listening(self) -> None:
-        self.listening = True
-
-    def settle(self, category: AMDCategory, reason: str) -> None:
-        self.settled.append((category, reason))
-
-
 def _machine_vm_response(transcript: str = "voicemail greeting") -> FakeLLMResponse:
     return FakeLLMResponse(
         input=transcript,
@@ -77,6 +57,22 @@ def _machine_vm_response(transcript: str = "voicemail greeting") -> FakeLLMRespo
             FunctionToolCall(
                 name="save_prediction",
                 arguments='{"label": "machine-vm"}',
+                call_id="c1",
+            )
+        ],
+    )
+
+
+def _human_response(transcript: str = "hello") -> FakeLLMResponse:
+    return FakeLLMResponse(
+        input=transcript,
+        content="",
+        ttft=0.0,
+        duration=0.05,
+        tool_calls=[
+            FunctionToolCall(
+                name="save_prediction",
+                arguments='{"label": "human"}',
                 call_id="c1",
             )
         ],
@@ -602,6 +598,46 @@ class TestAMDClassifier:
 
         await clf.close()
 
+    async def test_detection_timeout_preserves_transcript(self) -> None:
+        llm = FakeLLM(
+            fake_responses=[
+                FakeLLMResponse(
+                    input="hello",
+                    content="",
+                    ttft=0.0,
+                    duration=0.05,
+                    tool_calls=[
+                        FunctionToolCall(
+                            name="save_prediction",
+                            arguments='{"label": "uncertain"}',
+                            call_id="c1",
+                        )
+                    ],
+                )
+            ]
+        )
+        clf = _make_classifier(
+            llm=llm,
+            timeout=0.4,
+            wait_until_finished=True,
+            max_endpointing_delay=0.2,
+        )
+        clf.start_listening()
+        clf.start_detection_timer()
+        results: list[AMDPredictionEvent] = []
+        clf.on("amd_prediction", results.append)
+
+        clf.push_text("hello")
+
+        await asyncio.wait_for(clf._verdict_ready.wait(), timeout=1.0)
+
+        assert len(results) == 1
+        assert results[0].category == AMDCategory.UNCERTAIN
+        assert results[0].reason == "detection_timeout"
+        assert results[0].transcript == "hello"
+
+        await clf.close()
+
     async def test_speech_restart_cancels_eot_backstop(self) -> None:
         """on_user_speech_started cancels the EOT timer and resets the gate."""
         clf = _make_classifier(human_speech_threshold=0.05, max_endpointing_delay=0.3)
@@ -623,18 +659,84 @@ class TestAMDClassifier:
 
         await clf.close()
 
-    async def test_max_endpointing_delay_starts_from_transcript_without_eos(self) -> None:
-        """A final transcript alone starts AMD's synthetic EOT timer."""
-        clf = _make_classifier(max_endpointing_delay=0.3)
+    async def test_max_endpointing_delay_emits_human_without_vad_boundaries(self) -> None:
+        """A final transcript can complete AMD without VAD boundaries."""
+        clf = _make_classifier(
+            llm=FakeLLM(fake_responses=[_human_response()]),
+            timeout=5.0,
+            max_endpointing_delay=0.3,
+        )
         clf.start_listening()
+        clf.start_detection_timer()
+        results: list[AMDPredictionEvent] = []
+        clf.on("amd_prediction", results.append)
 
-        clf.push_text("voicemail greeting")
+        clf.push_text("hello")
         assert clf._eot_timer is not None
 
         await asyncio.sleep(0.4)
 
         assert clf._eot_reached is True
         assert clf._eot_timer is None
+        assert len(results) == 1
+        assert results[0].category == AMDCategory.HUMAN
+        assert results[0].reason == "llm"
+
+        await clf.close()
+
+    async def test_max_endpointing_delay_emits_machine_without_vad_boundaries(self) -> None:
+        clf = _make_classifier(
+            llm=FakeLLM(fake_responses=[_machine_vm_response()]),
+            timeout=5.0,
+            max_endpointing_delay=0.3,
+        )
+        clf.start_listening()
+        clf.start_detection_timer()
+        results: list[AMDPredictionEvent] = []
+        clf.on("amd_prediction", results.append)
+
+        clf.push_text("voicemail greeting")
+
+        await asyncio.sleep(0.2)
+        assert clf._verdict_result is not None
+        assert results == []
+
+        await asyncio.sleep(0.2)
+
+        assert len(results) == 1
+        assert results[0].category == AMDCategory.MACHINE_VM
+
+        await clf.close()
+
+    async def test_transcript_eot_waits_for_latest_chunk(self) -> None:
+        llm = FakeLLM(
+            fake_responses=[
+                _human_response("hello"),
+                _machine_vm_response("hello you've reached"),
+            ]
+        )
+        clf = _make_classifier(llm=llm, timeout=5.0, max_endpointing_delay=0.3)
+        clf.start_listening()
+        clf.start_detection_timer()
+        results: list[AMDPredictionEvent] = []
+        clf.on("amd_prediction", results.append)
+
+        clf.push_text("hello")
+        await asyncio.sleep(0.2)
+        assert clf._verdict_result is not None
+        assert clf._verdict_result.category == AMDCategory.HUMAN
+        assert results == []
+
+        clf.push_text("you've reached")
+        await asyncio.sleep(0.2)
+        assert clf._verdict_result is not None
+        assert clf._verdict_result.category == AMDCategory.MACHINE_VM
+        assert results == []
+
+        await asyncio.sleep(0.2)
+
+        assert len(results) == 1
+        assert results[0].category == AMDCategory.MACHINE_VM
 
         await clf.close()
 
@@ -661,260 +763,6 @@ class TestAMDClassifier:
         assert clf._eot_reached is True
 
         await clf.close()
-
-    def test_detection_option_max_endpointing_delay_overrides_activity(self) -> None:
-        llm = FakeLLM()
-        session = SimpleNamespace(
-            llm=llm,
-            _activity=SimpleNamespace(max_endpointing_delay=9.0),
-        )
-        detector = AMD(
-            session,  # type: ignore[arg-type]
-            llm=llm,
-            detection_options={"max_endpointing_delay": 0.25},
-            suppress_compatibility_warning=True,
-        )
-
-        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
-
-        assert clf is not None
-        assert clf._max_endpointing_delay == 0.25
-
-    def test_detection_option_max_endpointing_delay_falls_back_to_activity(self) -> None:
-        llm = FakeLLM()
-        session = SimpleNamespace(
-            llm=llm,
-            _activity=SimpleNamespace(max_endpointing_delay=1.25),
-        )
-        detector = AMD(
-            session,  # type: ignore[arg-type]
-            llm=llm,
-            suppress_compatibility_warning=True,
-        )
-
-        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
-
-        assert clf is not None
-        assert clf._max_endpointing_delay == 1.25
-
-    def test_detection_option_max_endpointing_delay_falls_back_to_default(self) -> None:
-        llm = FakeLLM()
-        session = SimpleNamespace(llm=llm, _activity=None)
-        detector = AMD(
-            session,  # type: ignore[arg-type]
-            llm=llm,
-            suppress_compatibility_warning=True,
-        )
-
-        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
-
-        assert clf is not None
-        assert clf._max_endpointing_delay == detector._opts["max_endpointing_delay"]
-
-    def test_amd_defaults_to_wait_until_finished(self) -> None:
-        llm = FakeLLM()
-        session = SimpleNamespace(llm=llm, _activity=None)
-        detector = AMD(
-            session,  # type: ignore[arg-type]
-            llm=llm,
-            suppress_compatibility_warning=True,
-        )
-
-        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
-
-        assert clf is not None
-        assert clf._wait_until_finished is True
-
-    def test_amd_wait_until_finished_can_be_disabled(self) -> None:
-        llm = FakeLLM()
-        session = SimpleNamespace(llm=llm, _activity=None)
-        detector = AMD(
-            session,  # type: ignore[arg-type]
-            llm=llm,
-            wait_until_finished=False,
-            suppress_compatibility_warning=True,
-        )
-
-        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
-
-        assert clf is not None
-        assert clf._wait_until_finished is False
-
-    async def test_setup_arms_detection_timer_only_at_listening(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        classifier = _RecordingClassifier()
-
-        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
-            assert classifier.timer_calls == 0, (
-                "no detection timer must be armed while waiting for the track"
-            )
-            return SimpleNamespace(sid="track_sid")
-
-        monkeypatch.setattr(
-            amd_detector,
-            "wait_for_track_publication",
-            fake_wait_for_track_publication,
-        )
-
-        llm = FakeLLM()
-        publisher = SimpleNamespace(
-            kind=object(),
-            identity="callee",
-            track_publications={"track_sid": object()},
-        )
-        session = SimpleNamespace(
-            llm=llm,
-            _activity=None,
-            _room_io=SimpleNamespace(
-                room=SimpleNamespace(remote_participants={"callee": publisher})
-            ),
-        )
-        detector = AMD(
-            session,  # type: ignore[arg-type]
-            llm=llm,
-            suppress_compatibility_warning=True,
-        )
-        detector._stt = NOT_GIVEN
-        detector._classifier = classifier  # type: ignore[assignment]
-
-        await detector._setup(session)  # type: ignore[arg-type]
-
-        assert classifier.timer_calls == 1
-        assert classifier.listening is True
-        assert classifier.settled == []
-
-    async def test_setup_settles_when_participant_disconnects_before_track(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        classifier = _RecordingClassifier()
-
-        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
-            raise RuntimeError("participant 'callee' disconnected while waiting")
-
-        monkeypatch.setattr(
-            amd_detector,
-            "wait_for_track_publication",
-            fake_wait_for_track_publication,
-        )
-
-        llm = FakeLLM()
-        session = SimpleNamespace(
-            llm=llm,
-            _activity=None,
-            _room_io=SimpleNamespace(room=SimpleNamespace(remote_participants={})),
-        )
-        detector = AMD(
-            session,  # type: ignore[arg-type]
-            llm=llm,
-            suppress_compatibility_warning=True,
-        )
-        detector._stt = NOT_GIVEN
-        detector._classifier = classifier  # type: ignore[assignment]
-
-        await detector._setup(session)  # type: ignore[arg-type]
-
-        assert classifier.settled == [(AMDCategory.UNCERTAIN, "participant_missing")]
-        assert classifier.timer_calls == 0
-        assert classifier.listening is False
-
-    async def test_setup_settles_when_track_publication_times_out(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        classifier = _RecordingClassifier()
-
-        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
-            await asyncio.Future[None]()
-            raise AssertionError("unreachable")
-
-        monkeypatch.setattr(
-            amd_detector,
-            "wait_for_track_publication",
-            fake_wait_for_track_publication,
-        )
-        monkeypatch.setattr(amd_detector, "_TRACK_PUBLICATION_TIMEOUT", 0.1)
-
-        llm = FakeLLM()
-        session = SimpleNamespace(
-            llm=llm,
-            _activity=None,
-            _room_io=SimpleNamespace(room=SimpleNamespace(remote_participants={})),
-        )
-        detector = AMD(
-            session,  # type: ignore[arg-type]
-            llm=llm,
-            suppress_compatibility_warning=True,
-        )
-        detector._stt = NOT_GIVEN
-        detector._classifier = classifier  # type: ignore[assignment]
-
-        await detector._setup(session)  # type: ignore[arg-type]
-
-        assert classifier.settled == [(AMDCategory.UNCERTAIN, "participant_missing")]
-        assert classifier.timer_calls == 0
-        assert classifier.listening is False
-
-    async def test_setup_settles_when_participant_disappears_after_track(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        classifier = _RecordingClassifier()
-
-        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
-            return SimpleNamespace(sid="track_sid")
-
-        monkeypatch.setattr(
-            amd_detector,
-            "wait_for_track_publication",
-            fake_wait_for_track_publication,
-        )
-
-        llm = FakeLLM()
-        session = SimpleNamespace(
-            llm=llm,
-            _activity=None,
-            _room_io=SimpleNamespace(room=SimpleNamespace(remote_participants={})),
-        )
-        detector = AMD(
-            session,  # type: ignore[arg-type]
-            llm=llm,
-            participant_identity="callee",
-            suppress_compatibility_warning=True,
-        )
-        detector._stt = NOT_GIVEN
-        detector._classifier = classifier  # type: ignore[assignment]
-
-        await detector._setup(session)  # type: ignore[arg-type]
-
-        assert classifier.settled == [(AMDCategory.UNCERTAIN, "participant_missing")]
-        assert classifier.timer_calls == 0
-        assert classifier.listening is False
-
-    async def test_sip_answer_failure_settles(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        classifier = _RecordingClassifier()
-
-        async def fake_wait_for_participant_attribute(*_: object, **__: object) -> None:
-            raise RuntimeError("participant 'callee' disconnected while waiting for sip.callStatus")
-
-        monkeypatch.setattr(
-            amd_detector,
-            "wait_for_participant_attribute",
-            fake_wait_for_participant_attribute,
-        )
-
-        llm = FakeLLM()
-        session = SimpleNamespace(llm=llm, _activity=None)
-        detector = AMD(
-            session,  # type: ignore[arg-type]
-            llm=llm,
-            suppress_compatibility_warning=True,
-        )
-        detector._classifier = classifier  # type: ignore[assignment]
-
-        await detector._wait_for_sip_answer(SimpleNamespace(), "callee")  # type: ignore[arg-type]
-
-        assert classifier.settled == [(AMDCategory.UNCERTAIN, "participant_missing")]
-        assert classifier.timer_calls == 0
-        assert classifier.listening is False
 
     async def test_settle_emits_uncertain_before_listening(self) -> None:
         clf = _make_classifier()

--- a/tests/test_amd_detector.py
+++ b/tests/test_amd_detector.py
@@ -1,0 +1,407 @@
+"""Tests for AMD configuration and detector lifecycle behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from livekit.agents.voice.amd import detector as amd_detector
+from livekit.agents.voice.amd.classifier import AMDCategory
+from livekit.agents.voice.amd.detector import AMD
+
+from .fake_llm import FakeLLM
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+
+def _configure_cloud_inference(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(amd_detector, "is_cloud", lambda _: True)
+    monkeypatch.setenv("LIVEKIT_URL", "wss://test.livekit.cloud")
+    monkeypatch.setenv("LIVEKIT_API_KEY", "key")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "test-secret-that-is-at-least-32-bytes")
+
+
+class _RecordingClassifier:
+    def __init__(self) -> None:
+        self.timer_calls = 0
+        self.listening = False
+        self.settled: list[tuple[AMDCategory, str]] = []
+
+    def start_detection_timer(self) -> None:
+        self.timer_calls += 1
+
+    def start_listening(self) -> None:
+        self.listening = True
+
+    def settle(self, category: AMDCategory, reason: str) -> None:
+        self.settled.append((category, reason))
+
+
+class TestAMDDetector:
+    def test_detection_option_max_endpointing_delay_overrides_activity(self) -> None:
+        llm = FakeLLM()
+        session = SimpleNamespace(
+            llm=llm,
+            _activity=SimpleNamespace(max_endpointing_delay=9.0),
+        )
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            detection_options={"max_endpointing_delay": 0.25},
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert clf is not None
+        assert clf._max_endpointing_delay == 0.25
+
+    def test_detection_option_max_endpointing_delay_falls_back_to_activity(self) -> None:
+        llm = FakeLLM()
+        session = SimpleNamespace(
+            llm=llm,
+            _activity=SimpleNamespace(max_endpointing_delay=1.25),
+        )
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert clf is not None
+        assert clf._max_endpointing_delay == 1.25
+
+    def test_detection_option_max_endpointing_delay_falls_back_to_default(self) -> None:
+        llm = FakeLLM()
+        session = SimpleNamespace(llm=llm, _activity=None)
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert clf is not None
+        assert clf._max_endpointing_delay == detector._opts["max_endpointing_delay"]
+
+    def test_amd_defaults_to_wait_until_finished(self) -> None:
+        llm = FakeLLM()
+        session = SimpleNamespace(llm=llm, _activity=None)
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert clf is not None
+        assert clf._wait_until_finished is True
+
+    def test_amd_wait_until_finished_can_be_disabled(self) -> None:
+        llm = FakeLLM()
+        session = SimpleNamespace(llm=llm, _activity=None)
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            wait_until_finished=False,
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert clf is not None
+        assert clf._wait_until_finished is False
+
+    def test_none_reuses_session_models_on_cloud(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _configure_cloud_inference(monkeypatch)
+        llm = FakeLLM()
+        session = SimpleNamespace(llm=llm, _activity=None)
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=None,
+            stt=None,
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert detector._llm_config is None
+        assert detector._stt is None
+        assert clf is not None
+        assert clf._llm is llm
+        assert clf._source == "stt"
+
+    def test_omitted_models_inherit_session_without_cloud_inference(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(amd_detector, "is_cloud", lambda _: False)
+        llm = FakeLLM()
+        session = SimpleNamespace(llm=llm, _activity=None)
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert detector._llm_config is None
+        assert detector._stt is None
+        assert clf is not None
+        assert clf._llm is llm
+        assert clf._source == "stt"
+
+    def test_omitted_models_auto_select_cloud_defaults(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _configure_cloud_inference(monkeypatch)
+        session = SimpleNamespace(llm=FakeLLM(), _activity=None)
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            suppress_compatibility_warning=True,
+        )
+
+        assert detector._llm_config == detector._DEFAULT_LLM_MODEL
+        assert detector._stt is not None
+        assert detector._stt.model == detector._DEFAULT_STT_MODEL
+
+    def test_none_llm_inherits_session_and_omitted_stt_uses_cloud_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _configure_cloud_inference(monkeypatch)
+        llm = FakeLLM()
+        session = SimpleNamespace(llm=llm, _activity=None)
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=None,
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert detector._llm_config is None
+        assert detector._stt is not None
+        assert detector._stt.model == detector._DEFAULT_STT_MODEL
+        assert clf is not None
+        assert clf._llm is llm
+        assert clf._source == "amd_stt"
+
+    def test_omitted_llm_uses_cloud_default_and_none_stt_inherits_session(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _configure_cloud_inference(monkeypatch)
+        session = SimpleNamespace(llm=FakeLLM(), _activity=None)
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            stt=None,
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert detector._llm_config == detector._DEFAULT_LLM_MODEL
+        assert detector._stt is None
+        assert clf is not None
+        assert clf._llm.model == detector._DEFAULT_LLM_MODEL
+        assert clf._source == "stt"
+
+    def test_explicit_models_override_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _configure_cloud_inference(monkeypatch)
+        llm = FakeLLM()
+        session = SimpleNamespace(llm=FakeLLM(), _activity=None)
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            stt="deepgram/nova-3",
+            suppress_compatibility_warning=True,
+        )
+
+        clf = detector._resolve_classifier(session)  # type: ignore[arg-type]
+
+        assert detector._llm_config is llm
+        assert detector._stt is not None
+        assert detector._stt.model == "deepgram/nova-3"
+        assert clf is not None
+        assert clf._llm is llm
+        assert clf._source == "amd_stt"
+
+    async def test_setup_arms_detection_timer_only_at_listening(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        classifier = _RecordingClassifier()
+
+        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
+            assert classifier.timer_calls == 0, (
+                "no detection timer must be armed while waiting for the track"
+            )
+            return SimpleNamespace(sid="track_sid")
+
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_track_publication",
+            fake_wait_for_track_publication,
+        )
+
+        llm = FakeLLM()
+        publisher = SimpleNamespace(
+            kind=object(),
+            identity="callee",
+            track_publications={"track_sid": object()},
+        )
+        session = SimpleNamespace(
+            llm=llm,
+            _activity=None,
+            _room_io=SimpleNamespace(
+                room=SimpleNamespace(remote_participants={"callee": publisher})
+            ),
+        )
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            suppress_compatibility_warning=True,
+        )
+        detector._stt = None
+        detector._classifier = classifier  # type: ignore[assignment]
+
+        await detector._setup(session)  # type: ignore[arg-type]
+
+        assert classifier.timer_calls == 1
+        assert classifier.listening is True
+        assert classifier.settled == []
+
+    async def test_setup_settles_when_participant_disconnects_before_track(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        classifier = _RecordingClassifier()
+
+        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
+            raise RuntimeError("participant 'callee' disconnected while waiting")
+
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_track_publication",
+            fake_wait_for_track_publication,
+        )
+
+        llm = FakeLLM()
+        session = SimpleNamespace(
+            llm=llm,
+            _activity=None,
+            _room_io=SimpleNamespace(room=SimpleNamespace(remote_participants={})),
+        )
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            suppress_compatibility_warning=True,
+        )
+        detector._stt = None
+        detector._classifier = classifier  # type: ignore[assignment]
+
+        await detector._setup(session)  # type: ignore[arg-type]
+
+        assert classifier.settled == [(AMDCategory.UNCERTAIN, "participant_missing")]
+        assert classifier.timer_calls == 0
+        assert classifier.listening is False
+
+    async def test_setup_settles_when_track_publication_times_out(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        classifier = _RecordingClassifier()
+
+        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
+            await asyncio.Future[None]()
+            raise AssertionError("unreachable")
+
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_track_publication",
+            fake_wait_for_track_publication,
+        )
+        monkeypatch.setattr(amd_detector, "_TRACK_PUBLICATION_TIMEOUT", 0.1)
+
+        llm = FakeLLM()
+        session = SimpleNamespace(
+            llm=llm,
+            _activity=None,
+            _room_io=SimpleNamespace(room=SimpleNamespace(remote_participants={})),
+        )
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            suppress_compatibility_warning=True,
+        )
+        detector._stt = None
+        detector._classifier = classifier  # type: ignore[assignment]
+
+        await detector._setup(session)  # type: ignore[arg-type]
+
+        assert classifier.settled == [(AMDCategory.UNCERTAIN, "participant_missing")]
+        assert classifier.timer_calls == 0
+        assert classifier.listening is False
+
+    async def test_setup_settles_when_participant_disappears_after_track(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        classifier = _RecordingClassifier()
+
+        async def fake_wait_for_track_publication(**_: object) -> SimpleNamespace:
+            return SimpleNamespace(sid="track_sid")
+
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_track_publication",
+            fake_wait_for_track_publication,
+        )
+
+        llm = FakeLLM()
+        session = SimpleNamespace(
+            llm=llm,
+            _activity=None,
+            _room_io=SimpleNamespace(room=SimpleNamespace(remote_participants={})),
+        )
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            participant_identity="callee",
+            suppress_compatibility_warning=True,
+        )
+        detector._stt = None
+        detector._classifier = classifier  # type: ignore[assignment]
+
+        await detector._setup(session)  # type: ignore[arg-type]
+
+        assert classifier.settled == [(AMDCategory.UNCERTAIN, "participant_missing")]
+        assert classifier.timer_calls == 0
+        assert classifier.listening is False
+
+    async def test_sip_answer_failure_settles(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        classifier = _RecordingClassifier()
+
+        async def fake_wait_for_participant_attribute(*_: object, **__: object) -> None:
+            raise RuntimeError("participant 'callee' disconnected while waiting for sip.callStatus")
+
+        monkeypatch.setattr(
+            amd_detector,
+            "wait_for_participant_attribute",
+            fake_wait_for_participant_attribute,
+        )
+
+        llm = FakeLLM()
+        session = SimpleNamespace(llm=llm, _activity=None)
+        detector = AMD(
+            session,  # type: ignore[arg-type]
+            llm=llm,
+            suppress_compatibility_warning=True,
+        )
+        detector._classifier = classifier  # type: ignore[assignment]
+
+        await detector._wait_for_sip_answer(SimpleNamespace(), "callee")  # type: ignore[arg-type]
+
+        assert classifier.settled == [(AMDCategory.UNCERTAIN, "participant_missing")]
+        assert classifier.timer_calls == 0
+        assert classifier.listening is False


### PR DESCRIPTION
**Problem:** AMD can receive final transcripts without VAD boundaries. Its LLM verdict then remains behind the silence gate until the detection timeout.

**Behavior:** The existing transcript EOT backstop now supplies the missing silence signal only when no valid VAD end exists. None reuses session STT or LLM models, while omitted values keep cloud defaults. Timeout verdicts retain the transcript.

Fixes #6996
Addresses AGT-3382

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> Can you investigate https://github.com/livekit/agents/issues/6996?
>
> Yeah, EOT sounds good.
>
> we could have None means session STT or LLM, so NOT_GIVEN -> default, None -> Inherit, explicit -> explicit.
>
> Yeah, we should preserve the transcript and add tests against the regression cases.
>
> but eot requires VAD too, right?
>
> yes please.

</details>