### PR TITLE
fix(plugins): redact API keys from rejected websocket handshakes

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -775,14 +775,6 @@ class SpeechStream(stt.SpeechStream):
                 ),
                 self._conn_options.timeout,
             )
-            self._report_connection_acquired(time.perf_counter() - t0, False)
-            ws_headers = {
-                k: v for k, v in ws._response.headers.items() if k.startswith("dg-") or k == "Date"
-            }
-            logger.debug(
-                "Established new Deepgram STT WebSocket connection:",
-                extra={"headers": ws_headers},
-            )
         except asyncio.TimeoutError:
             raise APIConnectionError("failed to connect to deepgram") from None
         except aiohttp.ClientResponseError as e:
@@ -795,6 +787,15 @@ class SpeechStream(stt.SpeechStream):
             raise APIConnectionError(
                 f"failed to connect to deepgram ({type(e).__name__})"
             ) from None
+
+        self._report_connection_acquired(time.perf_counter() - t0, False)
+        ws_headers = {
+            k: v for k, v in ws._response.headers.items() if k.startswith("dg-") or k == "Date"
+        }
+        logger.debug(
+            "Established new Deepgram STT WebSocket connection:",
+            extra={"headers": ws_headers},
+        )
         return ws
 
     def _on_audio_duration_report(self, duration: float) -> None:

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -783,8 +783,18 @@ class SpeechStream(stt.SpeechStream):
                 "Established new Deepgram STT WebSocket connection:",
                 extra={"headers": ws_headers},
             )
-        except (aiohttp.ClientConnectorError, asyncio.TimeoutError) as e:
-            raise APIConnectionError("failed to connect to deepgram") from e
+        except asyncio.TimeoutError:
+            raise APIConnectionError("failed to connect to deepgram") from None
+        except aiohttp.ClientResponseError as e:
+            # RequestInfo carries the request headers, so chaining this error or
+            # formatting it puts the API key in the exception repr (#6739).
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except Exception as e:
+            raise APIConnectionError(
+                f"failed to connect to deepgram ({type(e).__name__})"
+            ) from None
         return ws
 
     def _on_audio_duration_report(self, duration: float) -> None:

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -580,8 +580,18 @@ class SpeechStreamv2(stt.SpeechStream):
                 "Established new Deepgram STT WebSocket connection:",
                 extra={"headers": ws_headers},
             )
-        except (aiohttp.ClientConnectorError, asyncio.TimeoutError) as e:
-            raise APIConnectionError("failed to connect to deepgram") from e
+        except asyncio.TimeoutError:
+            raise APIConnectionError("failed to connect to deepgram") from None
+        except aiohttp.ClientResponseError as e:
+            # RequestInfo carries the request headers, so chaining this error or
+            # formatting it puts the API key in the exception repr (#6739).
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except Exception as e:
+            raise APIConnectionError(
+                f"failed to connect to deepgram ({type(e).__name__})"
+            ) from None
         return ws
 
     def _on_audio_duration_report(self, duration: float) -> None:

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt_v2.py
@@ -573,13 +573,6 @@ class SpeechStreamv2(stt.SpeechStream):
                 ),
                 self._conn_options.timeout,
             )
-            ws_headers = {
-                k: v for k, v in ws._response.headers.items() if k.startswith("dg-") or k == "Date"
-            }
-            logger.debug(
-                "Established new Deepgram STT WebSocket connection:",
-                extra={"headers": ws_headers},
-            )
         except asyncio.TimeoutError:
             raise APIConnectionError("failed to connect to deepgram") from None
         except aiohttp.ClientResponseError as e:
@@ -592,6 +585,14 @@ class SpeechStreamv2(stt.SpeechStream):
             raise APIConnectionError(
                 f"failed to connect to deepgram ({type(e).__name__})"
             ) from None
+
+        ws_headers = {
+            k: v for k, v in ws._response.headers.items() if k.startswith("dg-") or k == "Date"
+        }
+        logger.debug(
+            "Established new Deepgram STT WebSocket connection:",
+            extra={"headers": ws_headers},
+        )
         return ws
 
     def _on_audio_duration_report(self, duration: float) -> None:

--- a/livekit-plugins/livekit-plugins-simplismart/livekit/plugins/simplismart/stt.py
+++ b/livekit-plugins/livekit-plugins-simplismart/livekit/plugins/simplismart/stt.py
@@ -421,8 +421,18 @@ class SpeechStream(stt.SpeechStream):
                 ),
                 self._conn_options.timeout,
             )
-        except (aiohttp.ClientConnectorError, asyncio.TimeoutError) as e:
-            raise APIConnectionError("failed to connect to simplismart") from e
+        except asyncio.TimeoutError:
+            raise APIConnectionError("failed to connect to simplismart") from None
+        except aiohttp.ClientResponseError as e:
+            # RequestInfo carries the request headers, so chaining this error or
+            # formatting it puts the API key in the exception repr (#6739).
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except Exception as e:
+            raise APIConnectionError(
+                f"failed to connect to simplismart ({type(e).__name__})"
+            ) from None
         return ws
 
     async def aclose(self) -> None:

--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
@@ -575,8 +575,18 @@ class SpeechStream(stt.SpeechStream):
             )
             self._report_connection_acquired(time.perf_counter() - t0, False)
             logger.debug("established Smallest AI STT WebSocket connection")
-        except (aiohttp.ClientConnectorError, asyncio.TimeoutError) as e:
-            raise APIConnectionError("failed to connect to Smallest AI STT") from e
+        except asyncio.TimeoutError:
+            raise APIConnectionError("failed to connect to Smallest AI STT") from None
+        except aiohttp.ClientResponseError as e:
+            # RequestInfo carries the request headers, so chaining this error or
+            # formatting it puts the API key in the exception repr (#6739).
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except Exception as e:
+            raise APIConnectionError(
+                f"failed to connect to Smallest AI STT ({type(e).__name__})"
+            ) from None
         return ws
 
     def _on_audio_duration_report(self, duration: float) -> None:

--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/stt.py
@@ -573,8 +573,6 @@ class SpeechStream(stt.SpeechStream):
                 ),
                 self._conn_options.timeout,
             )
-            self._report_connection_acquired(time.perf_counter() - t0, False)
-            logger.debug("established Smallest AI STT WebSocket connection")
         except asyncio.TimeoutError:
             raise APIConnectionError("failed to connect to Smallest AI STT") from None
         except aiohttp.ClientResponseError as e:
@@ -587,6 +585,9 @@ class SpeechStream(stt.SpeechStream):
             raise APIConnectionError(
                 f"failed to connect to Smallest AI STT ({type(e).__name__})"
             ) from None
+
+        self._report_connection_acquired(time.perf_counter() - t0, False)
+        logger.debug("established Smallest AI STT WebSocket connection")
         return ws
 
     def _on_audio_duration_report(self, duration: float) -> None:

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/stt.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/stt.py
@@ -444,8 +444,16 @@ class SpeechStream(stt.RecognizeStream):
                 ),
                 self._conn_options.timeout,
             )
-        except (aiohttp.ClientConnectorError, asyncio.TimeoutError) as e:
-            raise APIConnectionError("failed to connect to xAI") from e
+        except asyncio.TimeoutError:
+            raise APIConnectionError("failed to connect to xAI") from None
+        except aiohttp.ClientResponseError as e:
+            # RequestInfo carries the request headers, so chaining this error or
+            # formatting it puts the API key in the exception repr (#6739).
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except Exception as e:
+            raise APIConnectionError(f"failed to connect to xAI ({type(e).__name__})") from None
         return ws
 
     def _on_audio_duration_report(self, duration: float) -> None:

--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/tts.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/tts.py
@@ -156,12 +156,16 @@ class TTS(tts.TTS):
                 ),
                 timeout,
             )
-        except (
-            aiohttp.ClientConnectorError,
-            aiohttp.ClientConnectionResetError,
-            asyncio.TimeoutError,
-        ) as e:
-            raise APIConnectionError("failed to connect to xAI") from e
+        except asyncio.TimeoutError:
+            raise APIConnectionError("failed to connect to xAI") from None
+        except aiohttp.ClientResponseError as e:
+            # RequestInfo carries the request headers, so chaining this error or
+            # formatting it puts the API key in the exception repr (#6739).
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except Exception as e:
+            raise APIConnectionError(f"failed to connect to xAI ({type(e).__name__})") from None
         return ws
 
     async def _close_ws(self, ws: aiohttp.ClientWebSocketResponse) -> None:

--- a/tests/test_ws_handshake_credential_redaction.py
+++ b/tests/test_ws_handshake_credential_redaction.py
@@ -1,0 +1,77 @@
+"""A rejected websocket upgrade must not put the API key in the exception.
+
+`WSServerHandshakeError` subclasses `ClientResponseError`, so it is neither a
+`ClientConnectorError` nor an `asyncio.TimeoutError`. Plugins that caught only those two let a
+401/403 upgrade escape carrying `RequestInfo`, whose headers hold the credential (#6739, #7031).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import RequestInfo, WSServerHandshakeError
+from multidict import CIMultiDict, CIMultiDictProxy
+from yarl import URL
+
+from livekit.agents import APIStatusError
+
+SECRET_API_KEY = "secret-api-key-do-not-log"
+
+
+def _handshake_error(host: str, header: str, api_key: str) -> WSServerHandshakeError:
+    url = URL(f"wss://{host}/listen")
+    headers = CIMultiDict({"Host": host, header: api_key})
+    request_info = RequestInfo(
+        url=url, method="GET", headers=CIMultiDictProxy(headers), real_url=url
+    )
+    return WSServerHandshakeError(request_info, (), status=401, message="Unauthorized")
+
+
+def _session_raising(err: Exception) -> MagicMock:
+    async def _raise(*_args, **_kwargs):
+        raise err
+
+    session = MagicMock()
+    session.ws_connect = MagicMock(side_effect=_raise)
+    return session
+
+
+def _assert_redacted(err: APIStatusError) -> None:
+    assert err.status_code == 401
+    assert SECRET_API_KEY not in repr(err)
+    assert SECRET_API_KEY not in str(err)
+    assert err.__cause__ is None
+
+
+@pytest.mark.plugin("deepgram")
+@pytest.mark.asyncio
+async def test_deepgram_stt_redacts_api_key_from_handshake_error():
+    from livekit.plugins.deepgram import STT
+
+    stt = STT(api_key=SECRET_API_KEY)
+    stream = stt.stream()
+    stream._session = _session_raising(
+        _handshake_error("api.deepgram.com", "Authorization", f"Token {SECRET_API_KEY}")
+    )
+
+    with pytest.raises(APIStatusError) as exc_info:
+        await stream._connect_ws()
+
+    _assert_redacted(exc_info.value)
+
+
+@pytest.mark.plugin("xai")
+@pytest.mark.asyncio
+async def test_xai_tts_redacts_api_key_from_handshake_error():
+    from livekit.plugins.xai import TTS
+
+    tts = TTS(api_key=SECRET_API_KEY)
+    tts._session = _session_raising(
+        _handshake_error("api.x.ai", "Authorization", f"Bearer {SECRET_API_KEY}")
+    )
+
+    with pytest.raises(APIStatusError) as exc_info:
+        await tts._connect_ws(timeout=5.0, opts=tts._opts)
+
+    _assert_redacted(exc_info.value)


### PR DESCRIPTION
## Summary

`WSServerHandshakeError` subclasses `aiohttp.ClientResponseError`, so it is neither an `aiohttp.ClientConnectorError` nor an `asyncio.TimeoutError`. Six credentialed `ws_connect` sites still wrapped the connect in `except (aiohttp.ClientConnectorError, asyncio.TimeoutError)`, so a rejected upgrade matched neither handler and escaped uncaught, carrying `RequestInfo` and therefore the auth header.

Same failure as #6739, which #6740 fixed for cartesia. That reporter asked whether it was "the cartesia plugin, or more g[enerally]"; these are the sites where it was still reachable.

| plugin | file |
|---|---|
| deepgram | `stt.py`, `stt_v2.py` |
| simplismart | `stt.py` |
| smallestai | `stt.py` |
| xai | `stt.py`, `tts.py` |

Fixes #7031

## Approach

The shape from #6740, applied unchanged: handle `asyncio.TimeoutError` and `aiohttp.ClientResponseError` separately, re-raise with `from None`, and surface only the status and `type(e).__name__` rather than `str(e)` or `repr(e)`.

I scoped this by parsing every `try` block containing a credentialed `ws_connect` and reading which exception types its handlers actually name, rather than grepping. My first grep pass wrongly cleared `deepgram/stt.py`, which is why the count is from the AST walk. The other ten credentialed sites already catch the response error or re-raise with `from None`, and are untouched here.

## Verification

A local server refusing the upgrade with 401, called with deepgram's exact call shape.

Before:

```
WSServerHandshakeError escaped the handler
WSServerHandshakeError(RequestInfo(url=URL('http://127.0.0.1:8781/v1/listen?model=nova-2'),
method='GET', headers=<CIMultiDictProxy('Host': '127.0.0.1:8781',
'Authorization': 'Token dg_live_SUPERSECRET_abcdef0123456789', ...
API KEY PRESENT IN EXCEPTION REPR: True
```

After, the same request raises `APIStatusError: Invalid response status`, status_code 401, `__cause__` None, and the key appears in neither `str()` nor `repr()`.

Checked what actually reaches a log, since that was the reported symptom:

```
KEY in traceback.print_exc() output:   False
KEY in logger.exception() output:      False
```

One thing worth stating plainly: `raise ... from None` suppresses `__cause__` and sets `__suppress_context__`, so tracebacks and `logging.exception` omit the original error, which is the #6739 symptom. The original exception object does remain on `__context__`, so an error reporter that walks the context chain and ignores the suppress flag could still reach it. That is equally true of the cartesia fix in #6740; I have kept the same shape rather than diverge. Happy to go further if you would rather these paths scrub `RequestInfo` explicitly.

## Tests

`tests/test_ws_handshake_credential_redaction.py`, mirroring `tests/test_plugin_cartesia_tts.py` from #6740: construct a `WSServerHandshakeError` whose `RequestInfo` headers carry the key, drive the real `_connect_ws`, and assert `APIStatusError` with the status preserved, the key absent from `str` and `repr`, and `__cause__` None. Marked per plugin so they run under the existing `--plugin` filtering.

`ruff check` and `ruff format` clean on all seven files.
