### PR TITLE
avoid shutting down third-party otel providers

### DIFF
--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -39,7 +39,12 @@ from livekit.protocol import agent, models
 from .log import logger
 from .observability import Tagger
 from .telemetry import _upload_session_report, otel_metrics
-from .telemetry.traces import _BufferingHandler, _setup_cloud_tracer, _shutdown_telemetry
+from .telemetry.traces import (
+    _BufferingHandler,
+    _cloud_log_handler,
+    _setup_cloud_tracer,
+    _shutdown_telemetry,
+)
 from .types import (
     ATTRIBUTE_REDACTION_ENABLED,
     ATTRIBUTE_SIMULATION_ENABLED,
@@ -276,14 +281,13 @@ class JobContext:
         if not replay:
             return
 
-        # find the OTLP LoggingHandler that _setup_cloud_tracer just added
-        from opentelemetry.sdk._logs import LoggingHandler
-
-        for h in logging.getLogger().handlers:
-            if isinstance(h, LoggingHandler):
-                for record in handler.buffer:
-                    h.emit(record)
-                break
+        # replay through the framework's own OTLP handler that _setup_cloud_tracer
+        # just attached — the integrator may have their own OTel LoggingHandler on
+        # the root logger, and the buffered records must not be routed into it
+        otlp_handler = _cloud_log_handler()
+        if otlp_handler is not None and otlp_handler in logging.getLogger().handlers:
+            for record in handler.buffer:
+                otlp_handler.emit(record)
 
     async def _on_session_end(self) -> None:
         from .cli import AgentsConsole

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -244,6 +244,10 @@ class JobContext:
         self._recording_initialized = False
         self._redaction_enabled = info.job.enable_redaction
         self._early_log_handler: _BufferingHandler | None = None
+        # per-measurement metric attribution, set by init_recording(): the meter
+        # provider outlives the job, so each measurement carries the job's
+        # identity and session metadata (see otel_metrics._job_attrs)
+        self._otel_measurement_attrs: dict[str, Any] | None = None
 
     def _on_setup(self) -> None:
         root_logger = logging.getLogger()
@@ -827,6 +831,12 @@ class JobContext:
             return
 
         logger.debug("configuring session recording")
+        session_metadata = self._otel_metadata(options)
+        self._otel_measurement_attrs = {
+            "room_id": self.job.room.sid,
+            "job_id": self.job.id,
+            **(session_metadata or {}),
+        }
         _setup_cloud_tracer(
             room_id=self.job.room.sid,
             job_id=self.job.id,
@@ -834,7 +844,7 @@ class JobContext:
             observability_url=obs_url,
             enable_traces=options["traces"],
             enable_logs=options["logs"],
-            metadata=self._otel_metadata(options),
+            metadata=session_metadata,
         )
         # init_recording is typically called during session.start(), at which point a bunch of
         # the logs would have already been emitted. we want to capture all of the logs as it

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -248,6 +248,15 @@ class JobContext:
         # provider outlives the job, so each measurement carries the job's
         # identity and session metadata (see otel_metrics._job_attrs)
         self._otel_measurement_attrs: dict[str, Any] | None = None
+        # per-record span/log state, set by init_recording(): providers are
+        # shared across (possibly concurrent) jobs, so stamping and upload
+        # gating resolve from the originating job (see traces._job_telemetry_state)
+        self._otel_session_metadata: dict[str, Any] | None = None
+        self._otel_traces_enabled = False
+        self._otel_logs_enabled = False
+        # whether this job registered with the process-wide telemetry (so
+        # _on_cleanup only releases a registration this job actually made)
+        self._telemetry_configured = False
 
     def _on_setup(self) -> None:
         root_logger = logging.getLogger()
@@ -357,7 +366,11 @@ class JobContext:
                 self._stop_log_buffering()
 
         self._tempdir.cleanup()
-        _shutdown_telemetry()
+        # release only a registration this job made: _on_cleanup runs for every
+        # job, and in THREAD mode an unconfigured job's release would otherwise
+        # decrement a concurrent recorded job's registration and stop its export
+        if self._telemetry_configured:
+            _shutdown_telemetry()
 
         for handler in self._handlers_with_filter:
             handler.removeFilter(self._log_filter)
@@ -831,21 +844,28 @@ class JobContext:
             return
 
         logger.debug("configuring session recording")
-        session_metadata = self._otel_metadata(options)
+        user_metadata = self._otel_metadata(options)
         self._otel_measurement_attrs = {
             "room_id": self.job.room.sid,
             "job_id": self.job.id,
-            **(session_metadata or {}),
+            **(user_metadata or {}),
         }
-        _setup_cloud_tracer(
+        session_metadata = _setup_cloud_tracer(
             room_id=self.job.room.sid,
             job_id=self.job.id,
             agent_name=self.job.agent_name,
             observability_url=obs_url,
             enable_traces=options["traces"],
             enable_logs=options["logs"],
-            metadata=session_metadata,
+            metadata=user_metadata,
         )
+        # per-record telemetry state: spans/logs are stamped and gated from the
+        # originating job's context (THREAD-mode jobs run concurrently on shared
+        # providers), and _on_cleanup releases only what this job registered
+        self._otel_session_metadata = session_metadata
+        self._otel_traces_enabled = options["traces"]
+        self._otel_logs_enabled = options["logs"]
+        self._telemetry_configured = True
         # init_recording is typically called during session.start(), at which point a bunch of
         # the logs would have already been emitted. we want to capture all of the logs as it
         # relates to the job

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -245,11 +245,10 @@ class JobContext:
         self._recording_initialized = False
         self._redaction_enabled = info.job.enable_redaction
         self._early_log_handler: _BufferingHandler | None = None
-        # per-job telemetry state, set by init_recording(): providers are shared
-        # across (possibly concurrent) jobs, so span/log/metric attribution and
-        # upload gating resolve from the originating job. None also means this
-        # job never registered with the process-wide telemetry, so _on_cleanup
-        # must not release another job's registration.
+        # this job's cloud-telemetry registration, set by init_recording():
+        # span/log/metric attribution and upload gating resolve from it (the
+        # OTel providers are shared across possibly-concurrent jobs). None while
+        # the job has no registration to release.
         self._telemetry_state: _JobTelemetry | None = None
 
     def _on_setup(self) -> None:
@@ -360,9 +359,8 @@ class JobContext:
                 self._stop_log_buffering()
 
         self._tempdir.cleanup()
-        # per-job release: _on_cleanup runs for every job, and in THREAD mode a
-        # concurrent recorded job must keep exporting — release() only removes
-        # this job's own registration (a no-op if it never configured telemetry)
+        # telemetry registrations are per job: releasing this job's flushes its
+        # remaining telemetry and leaves any concurrent job's export untouched
         if self._telemetry_state is not None:
             _shutdown_telemetry(self.job.id)
 

--- a/livekit-agents/livekit/agents/job.py
+++ b/livekit-agents/livekit/agents/job.py
@@ -42,6 +42,7 @@ from .telemetry import _upload_session_report, otel_metrics
 from .telemetry.traces import (
     _BufferingHandler,
     _cloud_log_handler,
+    _JobTelemetry,
     _setup_cloud_tracer,
     _shutdown_telemetry,
 )
@@ -244,19 +245,12 @@ class JobContext:
         self._recording_initialized = False
         self._redaction_enabled = info.job.enable_redaction
         self._early_log_handler: _BufferingHandler | None = None
-        # per-measurement metric attribution, set by init_recording(): the meter
-        # provider outlives the job, so each measurement carries the job's
-        # identity and session metadata (see otel_metrics._job_attrs)
-        self._otel_measurement_attrs: dict[str, Any] | None = None
-        # per-record span/log state, set by init_recording(): providers are
-        # shared across (possibly concurrent) jobs, so stamping and upload
-        # gating resolve from the originating job (see traces._job_telemetry_state)
-        self._otel_session_metadata: dict[str, Any] | None = None
-        self._otel_traces_enabled = False
-        self._otel_logs_enabled = False
-        # whether this job registered with the process-wide telemetry (so
-        # _on_cleanup only releases a registration this job actually made)
-        self._telemetry_configured = False
+        # per-job telemetry state, set by init_recording(): providers are shared
+        # across (possibly concurrent) jobs, so span/log/metric attribution and
+        # upload gating resolve from the originating job. None also means this
+        # job never registered with the process-wide telemetry, so _on_cleanup
+        # must not release another job's registration.
+        self._telemetry_state: _JobTelemetry | None = None
 
     def _on_setup(self) -> None:
         root_logger = logging.getLogger()
@@ -366,11 +360,11 @@ class JobContext:
                 self._stop_log_buffering()
 
         self._tempdir.cleanup()
-        # release only a registration this job made: _on_cleanup runs for every
-        # job, and in THREAD mode an unconfigured job's release would otherwise
-        # decrement a concurrent recorded job's registration and stop its export
-        if self._telemetry_configured:
-            _shutdown_telemetry()
+        # per-job release: _on_cleanup runs for every job, and in THREAD mode a
+        # concurrent recorded job must keep exporting — release() only removes
+        # this job's own registration (a no-op if it never configured telemetry)
+        if self._telemetry_state is not None:
+            _shutdown_telemetry(self.job.id)
 
         for handler in self._handlers_with_filter:
             handler.removeFilter(self._log_filter)
@@ -844,28 +838,15 @@ class JobContext:
             return
 
         logger.debug("configuring session recording")
-        user_metadata = self._otel_metadata(options)
-        self._otel_measurement_attrs = {
-            "room_id": self.job.room.sid,
-            "job_id": self.job.id,
-            **(user_metadata or {}),
-        }
-        session_metadata = _setup_cloud_tracer(
+        self._telemetry_state = _setup_cloud_tracer(
             room_id=self.job.room.sid,
             job_id=self.job.id,
             agent_name=self.job.agent_name,
             observability_url=obs_url,
             enable_traces=options["traces"],
             enable_logs=options["logs"],
-            metadata=user_metadata,
+            metadata=self._otel_metadata(options),
         )
-        # per-record telemetry state: spans/logs are stamped and gated from the
-        # originating job's context (THREAD-mode jobs run concurrently on shared
-        # providers), and _on_cleanup releases only what this job registered
-        self._otel_session_metadata = session_metadata
-        self._otel_traces_enabled = options["traces"]
-        self._otel_logs_enabled = options["logs"]
-        self._telemetry_configured = True
         # init_recording is typically called during session.start(), at which point a bunch of
         # the logs would have already been emitted. we want to capture all of the logs as it
         # relates to the job

--- a/livekit-agents/livekit/agents/telemetry/otel_metrics.py
+++ b/livekit-agents/livekit/agents/telemetry/otel_metrics.py
@@ -88,17 +88,17 @@ def _job_attrs() -> dict[str, Any]:
     The meter provider has process lifetime (the OTel metrics global is
     set-once) and worker processes are reused across jobs, so per-job fields
     cannot live on the provider's resource. Instead, each measurement carries
-    the job's identity plus the same session metadata that is stamped on spans
-    and logs (simulation ids, redaction flag, ...), which is also correct for
-    concurrent jobs in THREAD mode. Returns a fresh dict — callers may add to it.
+    the same per-job attributes that are stamped on spans and logs (identity,
+    simulation ids, redaction flag, ...), which is also correct for concurrent
+    jobs in THREAD mode. Returns a fresh dict — callers may add to it.
     """
     from ..job import get_job_context  # local import: job.py imports this module
 
     ctx = get_job_context(required=False)
     if ctx is None:
         return {}
-    if ctx._otel_measurement_attrs is not None:
-        return dict(ctx._otel_measurement_attrs)
+    if (state := ctx._telemetry_state) is not None:
+        return dict(state.attributes)
     # recording was not initialized (disabled, or the crash path); keep identity
     return {"room_id": ctx.job.room.sid, "job_id": ctx.job.id}
 

--- a/livekit-agents/livekit/agents/telemetry/otel_metrics.py
+++ b/livekit-agents/livekit/agents/telemetry/otel_metrics.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from opentelemetry import metrics as metrics_api
 
@@ -82,8 +82,29 @@ _connection_acquire_time = _meter.create_histogram(
 )
 
 
-def _model_attrs(metadata: Metadata | None) -> dict[str, str]:
-    attrs: dict[str, str] = {}
+def _job_attrs() -> dict[str, Any]:
+    """Per-measurement job attribution.
+
+    The meter provider has process lifetime (the OTel metrics global is
+    set-once) and worker processes are reused across jobs, so per-job fields
+    cannot live on the provider's resource. Instead, each measurement carries
+    the job's identity plus the same session metadata that is stamped on spans
+    and logs (simulation ids, redaction flag, ...), which is also correct for
+    concurrent jobs in THREAD mode. Returns a fresh dict — callers may add to it.
+    """
+    from ..job import get_job_context  # local import: job.py imports this module
+
+    ctx = get_job_context(required=False)
+    if ctx is None:
+        return {}
+    if ctx._otel_measurement_attrs is not None:
+        return dict(ctx._otel_measurement_attrs)
+    # recording was not initialized (disabled, or the crash path); keep identity
+    return {"room_id": ctx.job.room.sid, "job_id": ctx.job.id}
+
+
+def _model_attrs(metadata: Metadata | None) -> dict[str, Any]:
+    attrs = _job_attrs()
     if metadata:
         if metadata.model_provider:
             attrs["model_provider"] = metadata.model_provider
@@ -98,19 +119,20 @@ def flush_turn_metrics(chat_ctx: ChatContext) -> None:
         _record_turn_metrics(msg.metrics)
 
 
-def _metadata_to_attrs(metadata: MetricsMetadata) -> dict[str, str]:
-    attrs: dict[str, str] = {}
-    if "model_name" in metadata:
-        attrs["model_name"] = metadata["model_name"]
-    if "model_provider" in metadata:
-        attrs["model_provider"] = metadata["model_provider"]
+def _metadata_to_attrs(metadata: MetricsMetadata | None) -> dict[str, Any]:
+    attrs = _job_attrs()
+    if metadata:
+        if "model_name" in metadata:
+            attrs["model_name"] = metadata["model_name"]
+        if "model_provider" in metadata:
+            attrs["model_provider"] = metadata["model_provider"]
     return attrs
 
 
 def _record_turn_metrics(report: MetricsReport) -> None:
-    llm_attrs = _metadata_to_attrs(report["llm_metadata"]) if "llm_metadata" in report else {}
-    tts_attrs = _metadata_to_attrs(report["tts_metadata"]) if "tts_metadata" in report else {}
-    stt_attrs = _metadata_to_attrs(report["stt_metadata"]) if "stt_metadata" in report else {}
+    llm_attrs = _metadata_to_attrs(report.get("llm_metadata"))
+    tts_attrs = _metadata_to_attrs(report.get("tts_metadata"))
+    stt_attrs = _metadata_to_attrs(report.get("stt_metadata"))
 
     if "e2e_latency" in report:
         _turn_e2e_latency.record(report["e2e_latency"], attributes=llm_attrs)

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -496,10 +496,6 @@ class _CloudTelemetry:
         self._owned_meter_provider: SdkMeterProvider | None = None
         self._metrics_unavailable = False
 
-        # batch processors orphaned by a mid-process tracer provider swap; they
-        # are flushed on release and shut down at process exit
-        self._abandoned_processors: list[BatchSpanProcessor] = []
-
     @property
     def logger_provider(self) -> LoggerProvider | None:
         """The logger provider the framework exports through (ours or adopted)."""
@@ -575,7 +571,15 @@ class _CloudTelemetry:
                     if self._log_handler not in root.handlers:
                         root.addHandler(self._log_handler)
 
-            self._ensure_meter_provider(resource, url)
+            # the meter provider outlives the job (the OTel metrics global is
+            # set-once), so its resource carries only process-stable identity;
+            # per-job room_id/job_id ride on each measurement instead
+            # (otel_metrics._job_identity_attrs)
+            process_metadata = {
+                k: v for k, v in base_metadata.items() if k not in ("room_id", "job_id")
+            }
+            meter_resource = Resource.create({SERVICE_NAME: "livekit-agents", **process_metadata})
+            self._ensure_meter_provider(meter_resource, url)
 
             if not self._atexit_registered:
                 self._atexit_registered = True
@@ -612,12 +616,18 @@ class _CloudTelemetry:
             # called after a job already exported); re-attach to the new one and
             # retire the old pipeline
             logger.warning("tracer provider changed; re-attaching LiveKit Cloud span exporter")
-            if self._span_gate is not None:
-                self._span_gate.enabled = False
             if self._span_metadata_processor is not None:
                 self._span_metadata_processor.clear_metadata()
             if self._span_batch_processor is not None:
-                self._abandoned_processors.append(self._span_batch_processor)
+                # shut the old pipeline down in the background: shutdown drains its
+                # queue through its still-enabled gate, exporting the prior jobs'
+                # remaining spans, then goes quiet. shutdown() is idempotent, so
+                # the owned provider shutting it down again at exit is harmless.
+                threading.Thread(
+                    target=self._span_batch_processor.shutdown,
+                    name="livekit-telemetry-retire-BatchSpanProcessor",
+                    daemon=True,
+                ).start()
 
         assert self._session is not None
         span_exporter = OTLPSpanExporter(
@@ -724,8 +734,6 @@ class _CloudTelemetry:
                 flush_targets.append(("logs", self._log_batch_processor.force_flush))
             if self._owned_meter_provider is not None:
                 flush_targets.append(("metrics", self._owned_meter_provider.force_flush))
-            for p in self._abandoned_processors:
-                flush_targets.append(("abandoned-spans", p.force_flush))
 
         # flush before gating off, so the job's remaining telemetry is exported
         _run_bounded("flush", flush_targets, timeout)
@@ -760,17 +768,24 @@ class _CloudTelemetry:
         with self._lock:
             targets: list[tuple[str, Callable[[], Any]]] = []
             if self._owned_tracer_provider is not None:
+                # shutting the provider down also shuts down every processor
+                # attached to it
                 targets.append(("TracerProvider", self._owned_tracer_provider.shutdown))
-            elif self._span_batch_processor is not None:
+            if self._span_batch_processor is not None and (
+                self._trace_provider_attached is not self._owned_tracer_provider
+            ):
+                # the current pipeline is attached to a provider we do not own
+                # (adopted from the integrator, possibly after a mid-process swap
+                # away from our own provider) — its shutdown is on us
                 targets.append(("BatchSpanProcessor", self._span_batch_processor.shutdown))
             if self._owned_logger_provider is not None:
                 targets.append(("LoggerProvider", self._owned_logger_provider.shutdown))
-            elif self._log_batch_processor is not None:
+            if self._log_batch_processor is not None and (
+                self._logger_provider is not self._owned_logger_provider
+            ):
                 targets.append(("BatchLogRecordProcessor", self._log_batch_processor.shutdown))
             if self._owned_meter_provider is not None:
                 targets.append(("MeterProvider", self._owned_meter_provider.shutdown))
-            for p in self._abandoned_processors:
-                targets.append(("AbandonedBatchSpanProcessor", p.shutdown))
             handler = self._log_handler
 
         if handler is not None:

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -210,10 +210,30 @@ class _AuthRefreshingSession(requests.Session):
         return resp
 
 
+# Internal marker stamped on spans/log records created by a job that disabled
+# their upload; the gated exporters drop marked items. THREAD-mode workers run
+# jobs concurrently on shared providers, so per-record marking — not a process
+# gate alone — is what keeps a recorded job from exporting a disabled job's data.
+_ATTR_EXPORT_SUPPRESSED = "lk.cloud.export_suppressed"
+
+
+def _job_telemetry_state() -> tuple[dict[str, AttributeValue] | None, bool, bool] | None:
+    """(span/log metadata, traces_enabled, logs_enabled) of the job on this
+    context, or None when outside a job or before its recording was initialized."""
+    from ..job import get_job_context  # local import: job.py imports this module
+
+    ctx = get_job_context(required=False)
+    if ctx is None or not ctx._recording_initialized:
+        return None
+    return ctx._otel_session_metadata, ctx._otel_traces_enabled, ctx._otel_logs_enabled
+
+
 class _MetadataSpanProcessor(SpanProcessor):
-    """Stamps per-job metadata on every span. The processor itself has process
-    lifetime (there is no API to detach it from a provider); the metadata it
-    stamps is swapped per job and cleared between jobs."""
+    """Stamps per-job metadata on every span, resolved from the originating
+    job's context — THREAD-mode jobs run concurrently on one shared provider, so
+    a single metadata slot would stamp another job's identity. The process-wide
+    slot remains as a fallback for spans created outside a job context. Spans of
+    a job that disabled trace upload are marked for the gated exporter to drop."""
 
     def __init__(self, metadata: dict[str, AttributeValue] | None = None) -> None:
         self._metadata = dict(metadata) if metadata else {}
@@ -226,12 +246,21 @@ class _MetadataSpanProcessor(SpanProcessor):
         self._metadata = {}
 
     def on_start(self, span: Span, parent_context: otel_context.Context | None = None) -> None:
+        if (state := _job_telemetry_state()) is not None:
+            metadata, traces_enabled, _ = state
+            if not traces_enabled:
+                span.set_attribute(_ATTR_EXPORT_SUPPRESSED, True)
+                return
+            if metadata:
+                span.set_attributes(metadata)
+            return
         if self._metadata:
             span.set_attributes(self._metadata)
 
 
 class _MetadataLogProcessor(LogRecordProcessor):
-    """Log counterpart of :class:`_MetadataSpanProcessor` — same lifetime split."""
+    """Log counterpart of :class:`_MetadataSpanProcessor` — same per-job
+    resolution with the process-wide slot as fallback."""
 
     def __init__(self, metadata: dict[str, AttributeValue] | None = None) -> None:
         self._metadata = dict(metadata) if metadata else {}
@@ -243,10 +272,20 @@ class _MetadataLogProcessor(LogRecordProcessor):
         self._metadata = {}
 
     def on_emit(self, log_data: ReadWriteLogRecord) -> None:
-        if log_data.log_record.attributes:
-            log_data.log_record.attributes.update(self._metadata)  # type: ignore
+        stamped: dict[str, AttributeValue]
+        if (state := _job_telemetry_state()) is not None:
+            metadata, _, logs_enabled = state
+            if not logs_enabled:
+                stamped = {_ATTR_EXPORT_SUPPRESSED: True}
+            else:
+                stamped = dict(metadata) if metadata else {}
         else:
-            log_data.log_record.attributes = dict(self._metadata)
+            stamped = dict(self._metadata)
+
+        if log_data.log_record.attributes:
+            log_data.log_record.attributes.update(stamped)  # type: ignore
+        else:
+            log_data.log_record.attributes = stamped
 
         if log_data.instrumentation_scope:
             log_data.log_record.attributes.update(  # type: ignore
@@ -273,7 +312,10 @@ class _GatedSpanExporter(SpanExporter):
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         if not self.enabled:
             return SpanExportResult.SUCCESS
-        return self._inner.export(spans)
+        exportable = [s for s in spans if not (s.attributes or {}).get(_ATTR_EXPORT_SUPPRESSED)]
+        if not exportable:
+            return SpanExportResult.SUCCESS
+        return self._inner.export(exportable)
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         return self._inner.force_flush(timeout_millis)
@@ -292,7 +334,12 @@ class _GatedLogExporter(LogRecordExporter):
     def export(self, batch: Sequence[ReadableLogRecord]) -> LogRecordExportResult:
         if not self.enabled:
             return LogRecordExportResult.SUCCESS
-        return self._inner.export(batch)
+        exportable = [
+            r for r in batch if not (r.log_record.attributes or {}).get(_ATTR_EXPORT_SUPPRESSED)
+        ]
+        if not exportable:
+            return LogRecordExportResult.SUCCESS
+        return self._inner.export(exportable)
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         return True
@@ -516,7 +563,10 @@ class _CloudTelemetry:
         enable_traces: bool = True,
         enable_logs: bool = True,
         metadata: dict[str, AttributeValue] | None = None,
-    ) -> None:
+    ) -> dict[str, AttributeValue]:
+        """Set up (or reuse) the pipelines for a job. Returns the session
+        metadata stamped on the job's spans and logs, for the caller to keep on
+        the JobContext (per-record stamping resolves it from there)."""
         base_metadata: dict[str, AttributeValue] = {"room_id": room_id, "job_id": job_id}
         if agent_name:
             # identifies the agent for LiveKit Cloud agent insights (explicit dispatch
@@ -586,6 +636,8 @@ class _CloudTelemetry:
                 atexit.register(self.shutdown_at_exit)
 
             self._active_jobs += 1
+
+        return session_metadata
 
     def _ensure_trace_pipeline(self, resource: Resource, url: str) -> None:
         # Check if a tracer provider is not set and set one up
@@ -811,9 +863,9 @@ def _setup_cloud_tracer(
     enable_traces: bool = True,
     enable_logs: bool = True,
     metadata: dict[str, AttributeValue] | None = None,
-) -> None:
+) -> dict[str, AttributeValue]:
     _upload_gate.reset()
-    _cloud.configure(
+    return _cloud.configure(
         room_id=room_id,
         job_id=job_id,
         agent_name=agent_name,

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 import json
 import logging
 import os
 import random
 import threading
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -22,14 +23,25 @@ from opentelemetry.exporter.otlp.proto.http import Compression
 from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.metrics import NoOpMeterProvider
+
+# _ProxyMeterProvider is what get_meter_provider() returns before anyone calls
+# set_meter_provider; there is no public alias for it (opentelemetry-api is
+# pinned <1.45, where this import is stable).
+from opentelemetry.metrics._internal import _ProxyMeterProvider
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk._logs import (
     LoggerProvider,
     LoggingHandler,
     LogRecordProcessor,
+    ReadableLogRecord,
     ReadWriteLogRecord,
 )
-from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk._logs.export import (
+    BatchLogRecordProcessor,
+    LogRecordExporter,
+    LogRecordExportResult,
+)
 from opentelemetry.sdk.metrics import (
     Counter as SdkCounter,
     Histogram as SdkHistogram,
@@ -41,8 +53,8 @@ from opentelemetry.sdk.metrics import (
 )
 from opentelemetry.sdk.metrics.export import AggregationTemporality, PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.sdk.trace import SpanProcessor
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter, SpanExportResult
 from opentelemetry.trace import Span, Tracer
 from opentelemetry.util._decorator import _agnosticcontextmanager
 from opentelemetry.util.types import Attributes, AttributeValue
@@ -199,16 +211,36 @@ class _AuthRefreshingSession(requests.Session):
 
 
 class _MetadataSpanProcessor(SpanProcessor):
-    def __init__(self, metadata: dict[str, AttributeValue]) -> None:
-        self._metadata = metadata
+    """Stamps per-job metadata on every span. The processor itself has process
+    lifetime (there is no API to detach it from a provider); the metadata it
+    stamps is swapped per job and cleared between jobs."""
+
+    def __init__(self, metadata: dict[str, AttributeValue] | None = None) -> None:
+        self._metadata = dict(metadata) if metadata else {}
+
+    def set_metadata(self, metadata: dict[str, AttributeValue]) -> None:
+        # rebind rather than mutate: on_start may read it from another thread
+        self._metadata = dict(metadata)
+
+    def clear_metadata(self) -> None:
+        self._metadata = {}
 
     def on_start(self, span: Span, parent_context: otel_context.Context | None = None) -> None:
-        span.set_attributes(self._metadata)
+        if self._metadata:
+            span.set_attributes(self._metadata)
 
 
 class _MetadataLogProcessor(LogRecordProcessor):
-    def __init__(self, metadata: dict[str, AttributeValue]) -> None:
-        self._metadata = metadata
+    """Log counterpart of :class:`_MetadataSpanProcessor` — same lifetime split."""
+
+    def __init__(self, metadata: dict[str, AttributeValue] | None = None) -> None:
+        self._metadata = dict(metadata) if metadata else {}
+
+    def set_metadata(self, metadata: dict[str, AttributeValue]) -> None:
+        self._metadata = dict(metadata)
+
+    def clear_metadata(self) -> None:
+        self._metadata = {}
 
     def on_emit(self, log_data: ReadWriteLogRecord) -> None:
         if log_data.log_record.attributes:
@@ -226,6 +258,48 @@ class _MetadataLogProcessor(LogRecordProcessor):
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         return True
+
+
+class _GatedSpanExporter(SpanExporter):
+    """Wraps the OTLP span exporter so per-job recording options can turn export
+    off without shutting anything down: the exporter and its batch processor have
+    process lifetime, but a job that disabled traces (or the gap between two jobs)
+    must not upload spans."""
+
+    def __init__(self, inner: SpanExporter) -> None:
+        self._inner = inner
+        self.enabled = False
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        if not self.enabled:
+            return SpanExportResult.SUCCESS
+        return self._inner.export(spans)
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return self._inner.force_flush(timeout_millis)
+
+    def shutdown(self) -> None:
+        self._inner.shutdown()
+
+
+class _GatedLogExporter(LogRecordExporter):
+    """Log counterpart of :class:`_GatedSpanExporter`."""
+
+    def __init__(self, inner: LogRecordExporter) -> None:
+        self._inner = inner
+        self.enabled = False
+
+    def export(self, batch: Sequence[ReadableLogRecord]) -> LogRecordExportResult:
+        if not self.enabled:
+            return LogRecordExportResult.SUCCESS
+        return self._inner.export(batch)
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
+
+    def shutdown(self) -> None:
+        # LogRecordExporter.shutdown is untyped in the OTel SDK
+        self._inner.shutdown()  # type: ignore[no-untyped-call]
 
 
 class _BufferingHandler(logging.Handler):
@@ -279,6 +353,440 @@ def set_tracer_provider(
     tracer.set_provider(tracer_provider)
 
 
+_TOKEN_TTL = timedelta(hours=6)
+_TOKEN_REFRESH_MARGIN = timedelta(minutes=5)
+
+
+class _AuthHeaderProvider:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._auth_header = ""
+        self._expires_at = datetime.min.replace(tzinfo=timezone.utc)
+        self._refresh()
+
+    def _refresh(self) -> None:
+        access_token = (
+            api.AccessToken()
+            .with_observability_grants(api.ObservabilityGrants(write=True))
+            .with_ttl(_TOKEN_TTL)
+        )
+        self._auth_header = f"Bearer {access_token.to_jwt()}"
+        self._expires_at = datetime.now(timezone.utc) + _TOKEN_TTL
+
+    def __call__(self) -> dict[str, str]:
+        now = datetime.now(timezone.utc)
+        if now >= self._expires_at - _TOKEN_REFRESH_MARGIN:
+            with self._lock:
+                if now >= self._expires_at - _TOKEN_REFRESH_MARGIN:
+                    self._refresh()
+        return {"Authorization": self._auth_header}
+
+
+_TELEMETRY_SHUTDOWN_TIMEOUT = 10.0
+
+
+def _run_bounded(action: str, targets: list[tuple[str, Callable[[], Any]]], timeout: float) -> None:
+    """Run each target on its own daemon thread with a hard wall-clock bound.
+
+    ``provider.shutdown()`` internally joins its exporter worker with a 30s
+    default timeout per provider (and ``force_flush`` ignores its timeout arg
+    in the current SDK — see #4623). Across tracer/logger/meter that's up to
+    ~90s, enough to stall the caller's event loop past the supervisor's 60s
+    ping/pong deadline when the OTLP endpoint is rate-limiting or unreachable.
+
+    Each target runs in its *own* daemon thread, in parallel. That matters for
+    two reasons:
+      1) Main-thread wait is bounded by ``max`` of the targets, not the ``sum``.
+      2) ``BatchProcessor.shutdown()`` sets ``_shutdown = True`` as its first
+         action; running in parallel guarantees that flag gets set on every
+         processor within milliseconds, even if one hangs in
+         ``worker_thread.join``. Any later re-entry (e.g. Python's
+         ``logging.shutdown()`` may spawn a *non-daemon* thread via
+         ``LoggingHandler.flush`` → ``force_flush`` — see opentelemetry-python
+         PR #4636) then short-circuits instead of hanging process exit.
+
+    Any unfinished work stays on the daemon threads and is discarded at
+    process exit.
+
+    Upstream context:
+    - https://github.com/open-telemetry/opentelemetry-python/issues/4623
+      (TracerProvider.shutdown() has no configurable timeout — still open)
+    """
+    if not targets:
+        return
+
+    def _run_one(name: str, fn: Callable[[], Any]) -> None:
+        try:
+            fn()
+        except Exception:
+            logger.exception("telemetry %s failed (%s)", action, name)
+
+    threads = [
+        threading.Thread(
+            target=_run_one,
+            args=(name, fn),
+            name=f"livekit-telemetry-{action}-{name}",
+            daemon=True,
+        )
+        for name, fn in targets
+    ]
+    for t in threads:
+        t.start()
+
+    deadline = time.monotonic() + timeout
+    for t in threads:
+        t.join(max(0.0, deadline - time.monotonic()))
+
+    if any(t.is_alive() for t in threads):
+        logger.warning("telemetry %s exceeded %.1fs; continuing", action, timeout)
+
+
+class _CloudTelemetry:
+    """Process-lifetime LiveKit Cloud telemetry infrastructure.
+
+    ``configure()`` and ``release()`` run once per job (from
+    ``JobContext.init_recording`` and ``JobContext._on_cleanup``), but worker
+    processes outlive jobs: the THREAD executor runs every job of the worker in
+    one shared process, and an integrator's OTel providers (e.g. the Langfuse
+    setup in the tracing docs, Logfire, dd-trace) are configured once at process
+    start. Telemetry state is therefore split by lifetime:
+
+    * **process-lifetime** — the OTLP exporters, the framework's batch and
+      metadata processors, any provider the framework itself creates, and the
+      root-logger handler instance. Created lazily on first use and shut down
+      exactly once, at process exit (bounded, via atexit). A provider supplied
+      by the integrator is *adopted*: the framework attaches its own processors
+      to it and NEVER shuts it down.
+    * **per-job** — the metadata stamped on spans/logs, the export gates
+      (a job that disabled traces/logs must not upload them), and whether the
+      root-logger handler is attached. ``release()`` flushes the framework's
+      batch processors (bounded) so LiveKit Cloud receives the job's telemetry
+      at job end, then disables export until the next job.
+
+    The ``Resource`` on a framework-created provider is built by the first
+    configuring job; per-job attribution (room_id/job_id) rides on the metadata
+    processors, which stamp every span/log. Concurrent jobs in THREAD mode share
+    the single metadata slot — last configured wins, matching the previous
+    behavior of stacking one metadata processor per job on a shared provider.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._active_jobs = 0
+        self._atexit_registered = False
+        self._session: _AuthRefreshingSession | None = None
+        self._observability_url: str | None = None
+
+        # traces
+        self._trace_provider_attached: trace_sdk.TracerProvider | None = None
+        self._owned_tracer_provider: trace_sdk.TracerProvider | None = None
+        self._span_metadata_processor: _MetadataSpanProcessor | None = None
+        self._span_gate: _GatedSpanExporter | None = None
+        self._span_batch_processor: BatchSpanProcessor | None = None
+
+        # logs
+        self._logger_provider: LoggerProvider | None = None
+        self._owned_logger_provider: LoggerProvider | None = None
+        self._log_metadata_processor: _MetadataLogProcessor | None = None
+        self._log_gate: _GatedLogExporter | None = None
+        self._log_batch_processor: BatchLogRecordProcessor | None = None
+        self._log_handler: _TraceLevelLoggingHandler | None = None
+
+        # metrics
+        self._owned_meter_provider: SdkMeterProvider | None = None
+        self._metrics_unavailable = False
+
+        # batch processors orphaned by a mid-process tracer provider swap; they
+        # are flushed on release and shut down at process exit
+        self._abandoned_processors: list[BatchSpanProcessor] = []
+
+    @property
+    def logger_provider(self) -> LoggerProvider | None:
+        """The logger provider the framework exports through (ours or adopted)."""
+        return self._logger_provider
+
+    @property
+    def log_handler(self) -> _TraceLevelLoggingHandler | None:
+        """The framework's own root-logger OTLP handler, if logs were configured."""
+        return self._log_handler
+
+    def configure(
+        self,
+        *,
+        room_id: str,
+        job_id: str,
+        agent_name: str = "",
+        observability_url: str,
+        enable_traces: bool = True,
+        enable_logs: bool = True,
+        metadata: dict[str, AttributeValue] | None = None,
+    ) -> None:
+        base_metadata: dict[str, AttributeValue] = {"room_id": room_id, "job_id": job_id}
+        if agent_name:
+            # identifies the agent for LiveKit Cloud agent insights (explicit dispatch
+            # only; the default dispatch has no agent name). Included in both the
+            # resource (traces) and the session metadata (spans + logs).
+            base_metadata[trace_types.ATTR_AGENT_NAME] = agent_name
+        # cloud agent id and deployment provided by LiveKit Cloud via env vars.
+        # Included in both the resource and the session metadata like agent_name;
+        # omitted when unset.
+        if cloud_agent_id := os.environ.get("LIVEKIT_AGENT_ID"):
+            base_metadata[trace_types.ATTR_CLOUD_AGENT_ID] = cloud_agent_id
+        if deployment_id := os.environ.get("LIVEKIT_AGENT_DEPLOYMENT"):
+            base_metadata[trace_types.ATTR_DEPLOYMENT_ID] = deployment_id
+        session_metadata = dict(base_metadata)
+        if metadata:
+            session_metadata.update(metadata)
+
+        with self._lock:
+            if self._observability_url is None:
+                self._observability_url = observability_url
+            elif observability_url != self._observability_url:
+                logger.warning(
+                    "observability endpoint changed across jobs; keeping %s",
+                    self._observability_url,
+                )
+            url = self._observability_url
+
+            if self._session is None:
+                self._session = _AuthRefreshingSession(_AuthHeaderProvider())
+
+            resource = Resource.create({SERVICE_NAME: "livekit-agents", **base_metadata})
+
+            if enable_traces:
+                self._ensure_trace_pipeline(resource, url)
+                if self._span_metadata_processor is not None:
+                    self._span_metadata_processor.set_metadata(session_metadata)
+                if self._span_gate is not None:
+                    self._span_gate.enabled = True
+
+            # Always set up the logger provider — it's needed for session reports,
+            # evaluations, and chat history, not just Python log export.
+            self._ensure_logger_provider()
+
+            if enable_logs:
+                self._ensure_log_pipeline(url)
+                if self._log_metadata_processor is not None:
+                    self._log_metadata_processor.set_metadata(session_metadata)
+                if self._log_gate is not None:
+                    self._log_gate.enabled = True
+                if self._log_handler is not None:
+                    root = logging.getLogger()
+                    if self._log_handler not in root.handlers:
+                        root.addHandler(self._log_handler)
+
+            self._ensure_meter_provider(resource, url)
+
+            if not self._atexit_registered:
+                self._atexit_registered = True
+                atexit.register(self.shutdown_at_exit)
+
+            self._active_jobs += 1
+
+    def _ensure_trace_pipeline(self, resource: Resource, url: str) -> None:
+        # Check if a tracer provider is not set and set one up
+        # below shows how the ProxyTracerProvider is returned when none have been setup
+        # https://github.com/open-telemetry/opentelemetry-python/blob/0018c0030bac9bdce4487fe5fcb3ec6a542ec904/opentelemetry-api/src/opentelemetry/trace/__init__.py#L555
+        provider: trace_api.TracerProvider
+        if isinstance(
+            tracer._tracer_provider,
+            (trace_api.ProxyTracerProvider, trace_api.NoOpTracerProvider),
+        ):
+            owned = trace_sdk.TracerProvider(resource=resource, shutdown_on_exit=False)
+            self._owned_tracer_provider = owned
+            set_tracer_provider(owned)
+            provider = owned
+        else:
+            # the integrator's provider (or ours, from an earlier job)
+            provider = tracer._tracer_provider
+
+        if not isinstance(provider, trace_sdk.TracerProvider):
+            # processors can only be attached to an SDK provider
+            return
+
+        if provider is self._trace_provider_attached:
+            return
+
+        if self._trace_provider_attached is not None:
+            # the tracer provider was replaced mid-process (set_tracer_provider
+            # called after a job already exported); re-attach to the new one and
+            # retire the old pipeline
+            logger.warning("tracer provider changed; re-attaching LiveKit Cloud span exporter")
+            if self._span_gate is not None:
+                self._span_gate.enabled = False
+            if self._span_metadata_processor is not None:
+                self._span_metadata_processor.clear_metadata()
+            if self._span_batch_processor is not None:
+                self._abandoned_processors.append(self._span_batch_processor)
+
+        assert self._session is not None
+        span_exporter = OTLPSpanExporter(
+            endpoint=f"{url}/observability/traces/otlp/v0",
+            compression=Compression.Gzip,
+            session=self._session,
+        )
+        self._span_gate = _GatedSpanExporter(span_exporter)
+        self._span_metadata_processor = _MetadataSpanProcessor()
+        self._span_batch_processor = BatchSpanProcessor(self._span_gate)
+        provider.add_span_processor(self._span_metadata_processor)
+        provider.add_span_processor(self._span_batch_processor)
+        self._trace_provider_attached = provider
+
+    def _ensure_logger_provider(self) -> None:
+        if self._logger_provider is not None:
+            return
+        current = get_logger_provider()
+        if isinstance(current, LoggerProvider):
+            # an SDK provider the integrator set up — adopt it
+            self._logger_provider = current
+        else:
+            owned = LoggerProvider(shutdown_on_exit=False)
+            set_logger_provider(owned)
+            self._owned_logger_provider = owned
+            self._logger_provider = owned
+
+    def _ensure_log_pipeline(self, url: str) -> None:
+        if self._log_batch_processor is not None or self._logger_provider is None:
+            return
+        assert self._session is not None
+        log_exporter = OTLPLogExporter(
+            endpoint=f"{url}/observability/logs/otlp/v0",
+            compression=Compression.Gzip,
+            session=self._session,
+        )
+        self._log_gate = _GatedLogExporter(log_exporter)
+        self._log_metadata_processor = _MetadataLogProcessor()
+        self._log_batch_processor = BatchLogRecordProcessor(self._log_gate)
+        self._logger_provider.add_log_record_processor(self._log_metadata_processor)
+        self._logger_provider.add_log_record_processor(self._log_batch_processor)
+        self._log_handler = _TraceLevelLoggingHandler(
+            level=logging.NOTSET, logger_provider=self._logger_provider
+        )
+
+    def _ensure_meter_provider(self, resource: Resource, url: str) -> None:
+        if self._owned_meter_provider is not None or self._metrics_unavailable:
+            return
+        current = metrics_api.get_meter_provider()
+        if not isinstance(current, (_ProxyMeterProvider, NoOpMeterProvider)):
+            # the integrator configured their own meter provider; the metrics API
+            # has no way to attach a reader to it, so Cloud metrics are skipped
+            self._metrics_unavailable = True
+            return
+        assert self._session is not None
+        metric_exporter = OTLPMetricExporter(
+            endpoint=f"{url}/observability/metrics/otlp/v0",
+            compression=Compression.Gzip,
+            session=self._session,
+            preferred_temporality={
+                SdkCounter: AggregationTemporality.DELTA,
+                SdkUpDownCounter: AggregationTemporality.DELTA,
+                SdkHistogram: AggregationTemporality.DELTA,
+                SdkObservableCounter: AggregationTemporality.DELTA,
+                SdkObservableUpDownCounter: AggregationTemporality.DELTA,
+                SdkObservableGauge: AggregationTemporality.DELTA,
+            },
+        )
+        reader = PeriodicExportingMetricReader(metric_exporter, export_interval_millis=30000)
+        provider = SdkMeterProvider(
+            resource=resource, metric_readers=[reader], shutdown_on_exit=False
+        )
+        metrics_api.set_meter_provider(provider)
+        if metrics_api.get_meter_provider() is not provider:
+            # the set-once global was already consumed (e.g. by a NoOp provider):
+            # no instrument would ever reach our provider, so don't leave its
+            # periodic reader running
+            threading.Thread(
+                target=provider.shutdown,
+                name="livekit-telemetry-orphan-meter-shutdown",
+                daemon=True,
+            ).start()
+            self._metrics_unavailable = True
+            return
+        self._owned_meter_provider = provider
+
+    def release(self, timeout: float = _TELEMETRY_SHUTDOWN_TIMEOUT) -> None:
+        """Per-job teardown: flush the framework's exporters (bounded), then —
+        when no other job is running — disable export and detach the log handler.
+
+        Nothing is shut down here: providers (ours or the integrator's) and the
+        batch processors keep running for the next job in the process. Final
+        shutdown happens once, at process exit (:meth:`shutdown_at_exit`).
+        """
+        with self._lock:
+            if self._active_jobs == 0:
+                return
+            self._active_jobs -= 1
+
+            flush_targets: list[tuple[str, Callable[[], Any]]] = []
+            if self._span_batch_processor is not None:
+                flush_targets.append(("spans", self._span_batch_processor.force_flush))
+            if self._log_batch_processor is not None:
+                flush_targets.append(("logs", self._log_batch_processor.force_flush))
+            if self._owned_meter_provider is not None:
+                flush_targets.append(("metrics", self._owned_meter_provider.force_flush))
+            for p in self._abandoned_processors:
+                flush_targets.append(("abandoned-spans", p.force_flush))
+
+        # flush before gating off, so the job's remaining telemetry is exported
+        _run_bounded("flush", flush_targets, timeout)
+
+        with self._lock:
+            if self._active_jobs > 0:
+                # another job is still running in this process; keep exporting
+                return
+            if self._span_gate is not None:
+                self._span_gate.enabled = False
+            if self._log_gate is not None:
+                self._log_gate.enabled = False
+            if self._span_metadata_processor is not None:
+                self._span_metadata_processor.clear_metadata()
+            if self._log_metadata_processor is not None:
+                self._log_metadata_processor.clear_metadata()
+            handler = self._log_handler
+
+        if handler is not None:
+            # detach only our own handler — the integrator may have their own
+            # OTel LoggingHandler on the root logger
+            logging.getLogger().removeHandler(handler)
+
+    def shutdown_at_exit(self, timeout: float = _TELEMETRY_SHUTDOWN_TIMEOUT) -> None:
+        """Shut down what the framework created — once, at process exit, bounded.
+
+        Providers the framework created are shut down in full (they were built
+        with ``shutdown_on_exit=False``, so this is the only shutdown they get).
+        For an adopted provider, only the batch processors the framework attached
+        to it are shut down; the integrator's own pipeline is never touched.
+        """
+        with self._lock:
+            targets: list[tuple[str, Callable[[], Any]]] = []
+            if self._owned_tracer_provider is not None:
+                targets.append(("TracerProvider", self._owned_tracer_provider.shutdown))
+            elif self._span_batch_processor is not None:
+                targets.append(("BatchSpanProcessor", self._span_batch_processor.shutdown))
+            if self._owned_logger_provider is not None:
+                targets.append(("LoggerProvider", self._owned_logger_provider.shutdown))
+            elif self._log_batch_processor is not None:
+                targets.append(("BatchLogRecordProcessor", self._log_batch_processor.shutdown))
+            if self._owned_meter_provider is not None:
+                targets.append(("MeterProvider", self._owned_meter_provider.shutdown))
+            for p in self._abandoned_processors:
+                targets.append(("AbandonedBatchSpanProcessor", p.shutdown))
+            handler = self._log_handler
+
+        if handler is not None:
+            logging.getLogger().removeHandler(handler)
+
+        _run_bounded("shutdown", targets, timeout)
+
+
+_cloud = _CloudTelemetry()
+
+
+def _cloud_log_handler() -> _TraceLevelLoggingHandler | None:
+    """The framework's own root-logger OTLP handler, if configured for this job."""
+    return _cloud.log_handler
+
+
 def _setup_cloud_tracer(
     *,
     room_id: str,
@@ -290,123 +798,15 @@ def _setup_cloud_tracer(
     metadata: dict[str, AttributeValue] | None = None,
 ) -> None:
     _upload_gate.reset()
-
-    token_ttl = timedelta(hours=6)
-    refresh_margin = timedelta(minutes=5)
-
-    class _AuthHeaderProvider:
-        def __init__(self) -> None:
-            self._lock = threading.Lock()
-            self._auth_header = ""
-            self._expires_at = datetime.min.replace(tzinfo=timezone.utc)
-            self._refresh()
-
-        def _refresh(self) -> None:
-            access_token = (
-                api.AccessToken()
-                .with_observability_grants(api.ObservabilityGrants(write=True))
-                .with_ttl(token_ttl)
-            )
-            self._auth_header = f"Bearer {access_token.to_jwt()}"
-            self._expires_at = datetime.now(timezone.utc) + token_ttl
-
-        def __call__(self) -> dict[str, str]:
-            now = datetime.now(timezone.utc)
-            if now >= self._expires_at - refresh_margin:
-                with self._lock:
-                    if now >= self._expires_at - refresh_margin:
-                        self._refresh()
-            return {"Authorization": self._auth_header}
-
-    header_provider = _AuthHeaderProvider()
-    session = _AuthRefreshingSession(header_provider)
-    otlp_compression = Compression.Gzip
-    base_metadata: dict[str, AttributeValue] = {"room_id": room_id, "job_id": job_id}
-    if agent_name:
-        # identifies the agent for LiveKit Cloud agent insights (explicit dispatch
-        # only; the default dispatch has no agent name). Included in both the
-        # resource (traces) and the session metadata (spans + logs).
-        base_metadata[trace_types.ATTR_AGENT_NAME] = agent_name
-    # cloud agent id and deployment provided by LiveKit Cloud via env vars.
-    # Included in both the resource and the session metadata like agent_name;
-    # omitted when unset.
-    if cloud_agent_id := os.environ.get("LIVEKIT_AGENT_ID"):
-        base_metadata[trace_types.ATTR_CLOUD_AGENT_ID] = cloud_agent_id
-    if deployment_id := os.environ.get("LIVEKIT_AGENT_DEPLOYMENT"):
-        base_metadata[trace_types.ATTR_DEPLOYMENT_ID] = deployment_id
-    session_metadata = dict(base_metadata)
-    if metadata:
-        session_metadata.update(metadata)
-
-    resource = Resource.create({SERVICE_NAME: "livekit-agents", **base_metadata})
-
-    if enable_traces:
-        # Check if a tracer provider is not set and set one up
-        # below shows how the ProxyTracerProvider is returned when none have been setup
-        # https://github.com/open-telemetry/opentelemetry-python/blob/0018c0030bac9bdce4487fe5fcb3ec6a542ec904/opentelemetry-api/src/opentelemetry/trace/__init__.py#L555
-        tracer_provider: trace_api.TracerProvider
-        if isinstance(
-            tracer._tracer_provider,
-            (trace_api.ProxyTracerProvider, trace_api.NoOpTracerProvider),
-        ):
-            tracer_provider = trace_sdk.TracerProvider(resource=resource)
-            set_tracer_provider(tracer_provider)
-        else:
-            # attach the processor to the existing tracer provider
-            tracer_provider = tracer._tracer_provider
-            if isinstance(tracer_provider, trace_sdk.TracerProvider):
-                tracer_provider.resource.merge(resource)
-
-        span_exporter = OTLPSpanExporter(
-            endpoint=f"{observability_url}/observability/traces/otlp/v0",
-            compression=otlp_compression,
-            session=session,
-        )
-
-        if isinstance(tracer_provider, trace_sdk.TracerProvider):
-            tracer_provider.add_span_processor(_MetadataSpanProcessor(session_metadata))
-            tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter))
-
-    # Always set up the logger provider — it's needed for session reports,
-    # evaluations, and chat history, not just Python log export.
-    logger_provider = get_logger_provider()
-    if not isinstance(logger_provider, LoggerProvider):
-        logger_provider = LoggerProvider()
-        set_logger_provider(logger_provider)
-
-    if enable_logs:
-        log_exporter = OTLPLogExporter(
-            endpoint=f"{observability_url}/observability/logs/otlp/v0",
-            compression=otlp_compression,
-            session=session,
-        )
-        logger_provider.add_log_record_processor(_MetadataLogProcessor(session_metadata))
-        logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
-
-        handler = _TraceLevelLoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
-
-        root = logging.getLogger()
-        root.addHandler(handler)
-
-    # Set up the MeterProvider for OTEL metrics export
-    current_meter_provider = metrics_api.get_meter_provider()
-    if not isinstance(current_meter_provider, SdkMeterProvider):
-        metric_exporter = OTLPMetricExporter(
-            endpoint=f"{observability_url}/observability/metrics/otlp/v0",
-            compression=otlp_compression,
-            session=session,
-            preferred_temporality={
-                SdkCounter: AggregationTemporality.DELTA,
-                SdkUpDownCounter: AggregationTemporality.DELTA,
-                SdkHistogram: AggregationTemporality.DELTA,
-                SdkObservableCounter: AggregationTemporality.DELTA,
-                SdkObservableUpDownCounter: AggregationTemporality.DELTA,
-                SdkObservableGauge: AggregationTemporality.DELTA,
-            },
-        )
-        reader = PeriodicExportingMetricReader(metric_exporter, export_interval_millis=30000)
-        meter_provider = SdkMeterProvider(resource=resource, metric_readers=[reader])
-        metrics_api.set_meter_provider(meter_provider)
+    _cloud.configure(
+        room_id=room_id,
+        job_id=job_id,
+        agent_name=agent_name,
+        observability_url=observability_url,
+        enable_traces=enable_traces,
+        enable_logs=enable_logs,
+        metadata=metadata,
+    )
 
 
 def _chat_ctx_to_otel_events(chat_ctx: ChatContext) -> list[tuple[str, Attributes]]:
@@ -498,7 +898,10 @@ async def _upload_session_report(
     metadata = metadata or {}
 
     def _get_logger(name: str) -> Any:
-        return get_logger_provider().get_logger(
+        # prefer the provider the framework exports through; the OTel global may
+        # have been claimed by an integrator provider we could not adopt
+        provider = _cloud.logger_provider or get_logger_provider()
+        return provider.get_logger(
             name=name,
             attributes={
                 "room_id": report.room_id,
@@ -729,72 +1132,16 @@ async def _upload_session_report(
     logger.debug("finished uploading")
 
 
-_TELEMETRY_SHUTDOWN_TIMEOUT = 10.0
-
-
 def _shutdown_telemetry(timeout: float = _TELEMETRY_SHUTDOWN_TIMEOUT) -> None:
-    """Shut down OTel providers with a hard wall-clock bound.
+    """Per-job telemetry teardown, with a hard wall-clock bound.
 
-    ``provider.shutdown()`` internally joins its exporter worker with a 30s
-    default timeout per provider (and ``force_flush`` ignores its timeout arg
-    in the current SDK — see #4623). Across tracer/logger/meter that's up to
-    ~90s, enough to stall the caller's event loop past the supervisor's 60s
-    ping/pong deadline when the OTLP endpoint is rate-limiting or unreachable.
-
-    Each provider is shut down in its *own* daemon thread, run in parallel.
-    That matters for two reasons:
-      1) Main-thread wait is bounded by ``max`` of the three, not the ``sum``.
-      2) ``BatchProcessor.shutdown()`` sets ``_shutdown = True`` as its first
-         action; running in parallel guarantees that flag gets set on every
-         provider within milliseconds, even if one hangs in ``worker_thread.join``.
-         Any later atexit re-entry (OTel registers one, and Python's
-         ``logging.shutdown()`` may spawn a *non-daemon* thread via
-         ``LoggingHandler.flush`` → ``force_flush`` — see opentelemetry-python
-         PR #4636) then short-circuits instead of hanging process exit.
-
-    Any unfinished work stays on existing daemon threads and is discarded at
-    process exit.
-
-    Upstream context:
-    - https://github.com/open-telemetry/opentelemetry-python/issues/4623
-      (TracerProvider.shutdown() has no configurable timeout — still open)
+    This flushes the exporters the framework attached, so LiveKit Cloud receives
+    the job's telemetry at job end — it does NOT shut providers down. Worker
+    processes are reused across jobs (the THREAD executor runs every job in one
+    shared process), and a provider configured by the integrator at process
+    start (Langfuse, Logfire, dd-trace) must keep running for later jobs; the
+    framework's own providers likewise stay alive because the OTel logger/meter
+    globals are set-once. See :class:`_CloudTelemetry` for the ownership model;
+    final shutdown happens once at process exit.
     """
-    # Detach the OTLP LoggingHandler from the root logger — belt to the
-    # suspenders of the parallel shutdown below.
-    root = logging.getLogger()
-    for h in list(root.handlers):
-        if isinstance(h, LoggingHandler):
-            root.removeHandler(h)
-
-    providers: list[Any] = []
-    if isinstance(lp := get_logger_provider(), LoggerProvider):
-        providers.append(lp)
-    if isinstance(tp := tracer._tracer_provider, trace_sdk.TracerProvider):
-        providers.append(tp)
-    if isinstance(mp := metrics_api.get_meter_provider(), SdkMeterProvider):
-        providers.append(mp)
-
-    def _shutdown_one(provider: Any) -> None:
-        try:
-            provider.shutdown()
-        except Exception:
-            logger.exception("failed to shut down telemetry provider")
-
-    threads = [
-        threading.Thread(
-            target=_shutdown_one,
-            args=(p,),
-            name=f"livekit-telemetry-shutdown-{type(p).__name__}",
-            daemon=True,
-        )
-        for p in providers
-    ]
-    for t in threads:
-        t.start()
-
-    deadline = time.monotonic() + timeout
-    for t in threads:
-        t.join(max(0.0, deadline - time.monotonic()))
-
-    if any(t.is_alive() for t in threads):
-        logger.warning("telemetry shutdown exceeded %.1fs; continuing", timeout)
+    _cloud.release(timeout)

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -213,11 +213,11 @@ class _AuthRefreshingSession(requests.Session):
 
 @dataclass(frozen=True)
 class _JobTelemetry:
-    """Per-job telemetry state, built by ``_CloudTelemetry.configure`` and kept
-    on the ``JobContext``. Spans, logs, and metric measurements resolve their
-    attribution and upload gating from the originating job through this object —
-    THREAD-mode jobs run concurrently on shared providers, so nothing per-job
-    can live in process-wide state."""
+    """A job's cloud-telemetry registration, built by
+    ``_CloudTelemetry.configure`` and kept on the ``JobContext``. Spans, logs,
+    and metric measurements created by the job resolve their attribution and
+    upload gating through this object, which stays correct when jobs run
+    concurrently on the shared providers (THREAD executor)."""
 
     # the job's identity and session metadata, stamped on every span/log/metric
     attributes: dict[str, AttributeValue]
@@ -227,7 +227,12 @@ class _JobTelemetry:
 
 def _job_stamp_attributes() -> dict[str, AttributeValue] | None:
     """The attributes stamped on telemetry created by the job on this context,
-    or None outside any job context."""
+    or None outside any job context.
+
+    Stamping is pure attribution and applies regardless of the job's recording
+    options — every exporter on a shared provider (an integrator's included)
+    sees the same attributes. Whether LiveKit Cloud uploads a record is decided
+    separately, by the exportable-jobs registry (``_job_export_state``)."""
 
     from ..job import get_job_context  # local import: job.py imports this module
 
@@ -518,27 +523,33 @@ class _CloudTelemetry:
     ``configure()`` and ``release()`` run once per job (from
     ``JobContext.init_recording`` and ``JobContext._on_cleanup``), but worker
     processes outlive jobs: the THREAD executor runs every job of the worker in
-    one shared process, and an integrator's OTel providers (e.g. the Langfuse
-    setup in the tracing docs, Logfire, dd-trace) are configured once at process
-    start. Telemetry state is therefore split by lifetime:
+    one shared process — possibly several concurrently — and an integrator's
+    OTel providers (e.g. the Langfuse setup in the tracing docs, Logfire,
+    dd-trace) are configured once at process start. State is therefore split by
+    lifetime:
 
-    * **process-lifetime** — the OTLP exporters, the framework's batch and
-      metadata processors, any provider the framework itself creates, and the
+    * **process** — the OTLP exporters, the framework's batch and metadata
+      processors, any provider the framework itself creates, and the
       root-logger handler instance. Created lazily on first use and shut down
       exactly once, at process exit (bounded, via atexit). A provider supplied
       by the integrator is *adopted*: the framework attaches its own processors
-      to it and NEVER shuts it down.
-    * **per-job** — the metadata stamped on spans/logs, the export gates
-      (a job that disabled traces/logs must not upload them), and whether the
-      root-logger handler is attached. ``release()`` flushes the framework's
-      batch processors (bounded) so LiveKit Cloud receives the job's telemetry
-      at job end, then disables export until the next job.
+      to it and never shuts it down.
+    * **job** — attribution and upload policy, kept independent of each other.
+      Every span/log/metric is stamped with its originating job's attributes,
+      resolved through the job contextvar, regardless of the job's recording
+      options — every destination on a shared provider sees consistent
+      attribution. Whether LiveKit Cloud uploads a record is decided by the
+      exportable-jobs registry (``_export_jobs``): the gated exporters upload a
+      record only while its stamped job_id is registered with that signal
+      enabled. ``release()`` flushes the batch processors (bounded) while the
+      job is still registered, then unregisters it.
 
-    The ``Resource`` on a framework-created provider is built by the first
-    configuring job; per-job attribution (room_id/job_id) rides on the metadata
-    processors, which stamp every span/log. Concurrent jobs in THREAD mode share
-    the single metadata slot — last configured wins, matching the previous
-    behavior of stacking one metadata processor per job on a shared provider.
+    The ``Resource`` on a framework-created tracer/logger provider is built by
+    the first configuring job; the meter provider's resource carries only
+    process-stable identity, with per-job attribution on each measurement.
+    Telemetry emitted outside any job context is stamped from a fallback slot
+    holding the most recently configured job's attributes, cleared once no job
+    remains registered.
     """
 
     def __init__(self) -> None:
@@ -650,7 +661,7 @@ class _CloudTelemetry:
             # the meter provider outlives the job (the OTel metrics global is
             # set-once), so its resource carries only process-stable identity;
             # per-job room_id/job_id ride on each measurement instead
-            # (otel_metrics._job_identity_attrs)
+            # (otel_metrics._job_attrs)
             process_metadata = {
                 k: v for k, v in base_metadata.items() if k not in ("room_id", "job_id")
             }

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -8,7 +8,8 @@ import os
 import random
 import threading
 import time
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -210,30 +211,39 @@ class _AuthRefreshingSession(requests.Session):
         return resp
 
 
-# Internal marker stamped on spans/log records created by a job that disabled
-# their upload; the gated exporters drop marked items. THREAD-mode workers run
-# jobs concurrently on shared providers, so per-record marking — not a process
-# gate alone — is what keeps a recorded job from exporting a disabled job's data.
-_ATTR_EXPORT_SUPPRESSED = "lk.cloud.export_suppressed"
+@dataclass(frozen=True)
+class _JobTelemetry:
+    """Per-job telemetry state, built by ``_CloudTelemetry.configure`` and kept
+    on the ``JobContext``. Spans, logs, and metric measurements resolve their
+    attribution and upload gating from the originating job through this object —
+    THREAD-mode jobs run concurrently on shared providers, so nothing per-job
+    can live in process-wide state."""
+
+    # the job's identity and session metadata, stamped on every span/log/metric
+    attributes: dict[str, AttributeValue]
+    traces_enabled: bool
+    logs_enabled: bool
 
 
-def _job_telemetry_state() -> tuple[dict[str, AttributeValue] | None, bool, bool] | None:
-    """(span/log metadata, traces_enabled, logs_enabled) of the job on this
-    context, or None when outside a job or before its recording was initialized."""
+def _job_stamp_attributes() -> dict[str, AttributeValue] | None:
+    """The attributes stamped on telemetry created by the job on this context,
+    or None outside any job context."""
+
     from ..job import get_job_context  # local import: job.py imports this module
 
     ctx = get_job_context(required=False)
-    if ctx is None or not ctx._recording_initialized:
+    if ctx is None:
         return None
-    return ctx._otel_session_metadata, ctx._otel_traces_enabled, ctx._otel_logs_enabled
+    if (state := ctx._telemetry_state) is not None:
+        return state.attributes
+    # recording not (or not yet) initialized: still attribute the telemetry
+    return {"room_id": ctx.job.room.sid, "job_id": ctx.job.id}
 
 
 class _MetadataSpanProcessor(SpanProcessor):
     """Stamps per-job metadata on every span, resolved from the originating
-    job's context — THREAD-mode jobs run concurrently on one shared provider, so
-    a single metadata slot would stamp another job's identity. The process-wide
-    slot remains as a fallback for spans created outside a job context. Spans of
-    a job that disabled trace upload are marked for the gated exporter to drop."""
+    job's context. The process-wide slot remains as a fallback for spans created
+    outside a job context (worker-level telemetry) while a job is running."""
 
     def __init__(self, metadata: dict[str, AttributeValue] | None = None) -> None:
         self._metadata = dict(metadata) if metadata else {}
@@ -246,13 +256,8 @@ class _MetadataSpanProcessor(SpanProcessor):
         self._metadata = {}
 
     def on_start(self, span: Span, parent_context: otel_context.Context | None = None) -> None:
-        if (state := _job_telemetry_state()) is not None:
-            metadata, traces_enabled, _ = state
-            if not traces_enabled:
-                span.set_attribute(_ATTR_EXPORT_SUPPRESSED, True)
-                return
-            if metadata:
-                span.set_attributes(metadata)
+        if (attributes := _job_stamp_attributes()) is not None:
+            span.set_attributes(attributes)
             return
         if self._metadata:
             span.set_attributes(self._metadata)
@@ -273,21 +278,19 @@ class _MetadataLogProcessor(LogRecordProcessor):
 
     def on_emit(self, log_data: ReadWriteLogRecord) -> None:
         stamped: dict[str, AttributeValue]
-        if (state := _job_telemetry_state()) is not None:
-            metadata, _, logs_enabled = state
-            if not logs_enabled:
-                stamped = {_ATTR_EXPORT_SUPPRESSED: True}
-            else:
-                stamped = dict(metadata) if metadata else {}
+        if (attributes := _job_stamp_attributes()) is not None:
+            stamped = dict(attributes)
         else:
             stamped = dict(self._metadata)
 
         if log_data.log_record.attributes:
             log_data.log_record.attributes.update(stamped)  # type: ignore
-        else:
+        elif stamped:
             log_data.log_record.attributes = stamped
 
         if log_data.instrumentation_scope:
+            if log_data.log_record.attributes is None:
+                log_data.log_record.attributes = {}
             log_data.log_record.attributes.update(  # type: ignore
                 {"logger.name": log_data.instrumentation_scope.name}
             )
@@ -299,20 +302,40 @@ class _MetadataLogProcessor(LogRecordProcessor):
         return True
 
 
-class _GatedSpanExporter(SpanExporter):
-    """Wraps the OTLP span exporter so per-job recording options can turn export
-    off without shutting anything down: the exporter and its batch processor have
-    process lifetime, but a job that disabled traces (or the gap between two jobs)
-    must not upload spans."""
+def _job_export_state(
+    export_jobs: Mapping[str, _JobTelemetry], attributes: Mapping[str, Any] | None
+) -> _JobTelemetry | None:
+    """Look up a record's originating job in the exportable-jobs registry.
 
-    def __init__(self, inner: SpanExporter) -> None:
+    Upload to LiveKit Cloud is explicit policy, decoupled from attribution: a
+    record is uploaded only while its stamped job_id (globally unique) is
+    registered — jobs register in ``configure()`` and are removed after their
+    final flush in ``release()`` — and only for the signals that job enabled.
+    Records of a job that disabled recording, and records emitted between jobs,
+    keep their attributes on every destination but never reach Cloud."""
+    if not attributes:
+        return None
+    job_id = attributes.get("job_id")
+    if not isinstance(job_id, str):
+        return None
+    return export_jobs.get(job_id)
+
+
+class _GatedSpanExporter(SpanExporter):
+    """Wraps the OTLP span exporter so only spans of registered, trace-enabled
+    jobs are uploaded (see ``_job_export_state``)."""
+
+    def __init__(self, inner: SpanExporter, export_jobs: Mapping[str, _JobTelemetry]) -> None:
         self._inner = inner
-        self.enabled = False
+        self._export_jobs = export_jobs
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
-        if not self.enabled:
-            return SpanExportResult.SUCCESS
-        exportable = [s for s in spans if not (s.attributes or {}).get(_ATTR_EXPORT_SUPPRESSED)]
+        exportable = [
+            s
+            for s in spans
+            if (state := _job_export_state(self._export_jobs, s.attributes)) is not None
+            and state.traces_enabled
+        ]
         if not exportable:
             return SpanExportResult.SUCCESS
         return self._inner.export(exportable)
@@ -327,15 +350,16 @@ class _GatedSpanExporter(SpanExporter):
 class _GatedLogExporter(LogRecordExporter):
     """Log counterpart of :class:`_GatedSpanExporter`."""
 
-    def __init__(self, inner: LogRecordExporter) -> None:
+    def __init__(self, inner: LogRecordExporter, export_jobs: Mapping[str, _JobTelemetry]) -> None:
         self._inner = inner
-        self.enabled = False
+        self._export_jobs = export_jobs
 
     def export(self, batch: Sequence[ReadableLogRecord]) -> LogRecordExportResult:
-        if not self.enabled:
-            return LogRecordExportResult.SUCCESS
         exportable = [
-            r for r in batch if not (r.log_record.attributes or {}).get(_ATTR_EXPORT_SUPPRESSED)
+            r
+            for r in batch
+            if (state := _job_export_state(self._export_jobs, r.log_record.attributes)) is not None
+            and state.logs_enabled
         ]
         if not exportable:
             return LogRecordExportResult.SUCCESS
@@ -519,23 +543,29 @@ class _CloudTelemetry:
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._active_jobs = 0
+        # the exportable-jobs registry: job_id (globally unique) -> the job's
+        # telemetry state, registered by configure() and removed after the final
+        # flush in release(). The gated exporters hold a reference to this exact
+        # dict, so it is mutated in place, never rebound.
+        self._export_jobs: dict[str, _JobTelemetry] = {}
         self._atexit_registered = False
         self._session: _AuthRefreshingSession | None = None
         self._observability_url: str | None = None
 
+        # everything the framework created, shut down once at process exit:
+        # providers it built (constructed with shutdown_on_exit=False) and every
+        # batch processor it attached — appended at each creation site. A
+        # provider supplied by the integrator is never in this list.
+        self._exit_targets: list[tuple[str, Callable[[], Any]]] = []
+
         # traces
         self._trace_provider_attached: trace_sdk.TracerProvider | None = None
-        self._owned_tracer_provider: trace_sdk.TracerProvider | None = None
         self._span_metadata_processor: _MetadataSpanProcessor | None = None
-        self._span_gate: _GatedSpanExporter | None = None
         self._span_batch_processor: BatchSpanProcessor | None = None
 
         # logs
         self._logger_provider: LoggerProvider | None = None
-        self._owned_logger_provider: LoggerProvider | None = None
         self._log_metadata_processor: _MetadataLogProcessor | None = None
-        self._log_gate: _GatedLogExporter | None = None
         self._log_batch_processor: BatchLogRecordProcessor | None = None
         self._log_handler: _TraceLevelLoggingHandler | None = None
 
@@ -563,10 +593,10 @@ class _CloudTelemetry:
         enable_traces: bool = True,
         enable_logs: bool = True,
         metadata: dict[str, AttributeValue] | None = None,
-    ) -> dict[str, AttributeValue]:
-        """Set up (or reuse) the pipelines for a job. Returns the session
-        metadata stamped on the job's spans and logs, for the caller to keep on
-        the JobContext (per-record stamping resolves it from there)."""
+    ) -> _JobTelemetry:
+        """Set up (or reuse) the pipelines for a job. Returns the job's
+        telemetry state, for the caller to keep on the JobContext — per-record
+        stamping and upload gating resolve it from there."""
         base_metadata: dict[str, AttributeValue] = {"room_id": room_id, "job_id": job_id}
         if agent_name:
             # identifies the agent for LiveKit Cloud agent insights (explicit dispatch
@@ -603,8 +633,6 @@ class _CloudTelemetry:
                 self._ensure_trace_pipeline(resource, url)
                 if self._span_metadata_processor is not None:
                     self._span_metadata_processor.set_metadata(session_metadata)
-                if self._span_gate is not None:
-                    self._span_gate.enabled = True
 
             # Always set up the logger provider — it's needed for session reports,
             # evaluations, and chat history, not just Python log export.
@@ -614,8 +642,6 @@ class _CloudTelemetry:
                 self._ensure_log_pipeline(url)
                 if self._log_metadata_processor is not None:
                     self._log_metadata_processor.set_metadata(session_metadata)
-                if self._log_gate is not None:
-                    self._log_gate.enabled = True
                 if self._log_handler is not None:
                     root = logging.getLogger()
                     if self._log_handler not in root.handlers:
@@ -635,9 +661,14 @@ class _CloudTelemetry:
                 self._atexit_registered = True
                 atexit.register(self.shutdown_at_exit)
 
-            self._active_jobs += 1
+            state = _JobTelemetry(
+                attributes=session_metadata,
+                traces_enabled=enable_traces,
+                logs_enabled=enable_logs,
+            )
+            self._export_jobs[job_id] = state
 
-        return session_metadata
+        return state
 
     def _ensure_trace_pipeline(self, resource: Resource, url: str) -> None:
         # Check if a tracer provider is not set and set one up
@@ -649,7 +680,9 @@ class _CloudTelemetry:
             (trace_api.ProxyTracerProvider, trace_api.NoOpTracerProvider),
         ):
             owned = trace_sdk.TracerProvider(resource=resource, shutdown_on_exit=False)
-            self._owned_tracer_provider = owned
+            # shutting the provider down also shuts down every processor attached
+            # to it (processor shutdown is idempotent, so overlap is harmless)
+            self._exit_targets.append(("TracerProvider", owned.shutdown))
             set_tracer_provider(owned)
             provider = owned
         else:
@@ -671,10 +704,10 @@ class _CloudTelemetry:
             if self._span_metadata_processor is not None:
                 self._span_metadata_processor.clear_metadata()
             if self._span_batch_processor is not None:
-                # shut the old pipeline down in the background: shutdown drains its
-                # queue through its still-enabled gate, exporting the prior jobs'
-                # remaining spans, then goes quiet. shutdown() is idempotent, so
-                # the owned provider shutting it down again at exit is harmless.
+                # shut the old pipeline down in the background: shutdown drains
+                # its queue, exporting the prior jobs' remaining stamped spans,
+                # then goes quiet. shutdown() is idempotent, so shutting it down
+                # again at process exit is harmless.
                 threading.Thread(
                     target=self._span_batch_processor.shutdown,
                     name="livekit-telemetry-retire-BatchSpanProcessor",
@@ -687,9 +720,11 @@ class _CloudTelemetry:
             compression=Compression.Gzip,
             session=self._session,
         )
-        self._span_gate = _GatedSpanExporter(span_exporter)
         self._span_metadata_processor = _MetadataSpanProcessor()
-        self._span_batch_processor = BatchSpanProcessor(self._span_gate)
+        self._span_batch_processor = BatchSpanProcessor(
+            _GatedSpanExporter(span_exporter, self._export_jobs)
+        )
+        self._exit_targets.append(("BatchSpanProcessor", self._span_batch_processor.shutdown))
         provider.add_span_processor(self._span_metadata_processor)
         provider.add_span_processor(self._span_batch_processor)
         self._trace_provider_attached = provider
@@ -703,8 +738,8 @@ class _CloudTelemetry:
             self._logger_provider = current
         else:
             owned = LoggerProvider(shutdown_on_exit=False)
+            self._exit_targets.append(("LoggerProvider", owned.shutdown))
             set_logger_provider(owned)
-            self._owned_logger_provider = owned
             self._logger_provider = owned
 
     def _ensure_log_pipeline(self, url: str) -> None:
@@ -716,9 +751,11 @@ class _CloudTelemetry:
             compression=Compression.Gzip,
             session=self._session,
         )
-        self._log_gate = _GatedLogExporter(log_exporter)
         self._log_metadata_processor = _MetadataLogProcessor()
-        self._log_batch_processor = BatchLogRecordProcessor(self._log_gate)
+        self._log_batch_processor = BatchLogRecordProcessor(
+            _GatedLogExporter(log_exporter, self._export_jobs)
+        )
+        self._exit_targets.append(("BatchLogRecordProcessor", self._log_batch_processor.shutdown))
         self._logger_provider.add_log_record_processor(self._log_metadata_processor)
         self._logger_provider.add_log_record_processor(self._log_batch_processor)
         self._log_handler = _TraceLevelLoggingHandler(
@@ -764,20 +801,22 @@ class _CloudTelemetry:
             ).start()
             self._metrics_unavailable = True
             return
+        self._exit_targets.append(("MeterProvider", provider.shutdown))
         self._owned_meter_provider = provider
 
-    def release(self, timeout: float = _TELEMETRY_SHUTDOWN_TIMEOUT) -> None:
-        """Per-job teardown: flush the framework's exporters (bounded), then —
-        when no other job is running — disable export and detach the log handler.
+    def release(self, job_id: str, timeout: float = _TELEMETRY_SHUTDOWN_TIMEOUT) -> None:
+        """Per-job teardown: flush the framework's exporters (bounded) while the
+        job is still registered, then remove it from the exportable-jobs
+        registry — records stamped with its id no longer upload. When no job
+        remains, the fallback stamp is cleared and the log handler detached.
 
         Nothing is shut down here: providers (ours or the integrator's) and the
         batch processors keep running for the next job in the process. Final
         shutdown happens once, at process exit (:meth:`shutdown_at_exit`).
         """
         with self._lock:
-            if self._active_jobs == 0:
-                return
-            self._active_jobs -= 1
+            if job_id not in self._export_jobs:
+                return  # never configured, or already released
 
             flush_targets: list[tuple[str, Callable[[], Any]]] = []
             if self._span_batch_processor is not None:
@@ -787,17 +826,14 @@ class _CloudTelemetry:
             if self._owned_meter_provider is not None:
                 flush_targets.append(("metrics", self._owned_meter_provider.force_flush))
 
-        # flush before gating off, so the job's remaining telemetry is exported
+        # flush before unregistering, so the job's remaining telemetry is exported
         _run_bounded("flush", flush_targets, timeout)
 
         with self._lock:
-            if self._active_jobs > 0:
+            self._export_jobs.pop(job_id, None)
+            if self._export_jobs:
                 # another job is still running in this process; keep exporting
                 return
-            if self._span_gate is not None:
-                self._span_gate.enabled = False
-            if self._log_gate is not None:
-                self._log_gate.enabled = False
             if self._span_metadata_processor is not None:
                 self._span_metadata_processor.clear_metadata()
             if self._log_metadata_processor is not None:
@@ -812,32 +848,15 @@ class _CloudTelemetry:
     def shutdown_at_exit(self, timeout: float = _TELEMETRY_SHUTDOWN_TIMEOUT) -> None:
         """Shut down what the framework created — once, at process exit, bounded.
 
-        Providers the framework created are shut down in full (they were built
-        with ``shutdown_on_exit=False``, so this is the only shutdown they get).
-        For an adopted provider, only the batch processors the framework attached
-        to it are shut down; the integrator's own pipeline is never touched.
+        ``_exit_targets`` is appended at each creation site: providers the
+        framework created (built with ``shutdown_on_exit=False``, so this is the
+        only shutdown they get) and every batch processor the framework attached.
+        Processor shutdown is idempotent, so a processor also covered by its
+        owned provider is harmless — and a provider the integrator supplied is
+        never in the list.
         """
         with self._lock:
-            targets: list[tuple[str, Callable[[], Any]]] = []
-            if self._owned_tracer_provider is not None:
-                # shutting the provider down also shuts down every processor
-                # attached to it
-                targets.append(("TracerProvider", self._owned_tracer_provider.shutdown))
-            if self._span_batch_processor is not None and (
-                self._trace_provider_attached is not self._owned_tracer_provider
-            ):
-                # the current pipeline is attached to a provider we do not own
-                # (adopted from the integrator, possibly after a mid-process swap
-                # away from our own provider) — its shutdown is on us
-                targets.append(("BatchSpanProcessor", self._span_batch_processor.shutdown))
-            if self._owned_logger_provider is not None:
-                targets.append(("LoggerProvider", self._owned_logger_provider.shutdown))
-            if self._log_batch_processor is not None and (
-                self._logger_provider is not self._owned_logger_provider
-            ):
-                targets.append(("BatchLogRecordProcessor", self._log_batch_processor.shutdown))
-            if self._owned_meter_provider is not None:
-                targets.append(("MeterProvider", self._owned_meter_provider.shutdown))
+            targets = list(self._exit_targets)
             handler = self._log_handler
 
         if handler is not None:
@@ -863,7 +882,7 @@ def _setup_cloud_tracer(
     enable_traces: bool = True,
     enable_logs: bool = True,
     metadata: dict[str, AttributeValue] | None = None,
-) -> dict[str, AttributeValue]:
+) -> _JobTelemetry:
     _upload_gate.reset()
     return _cloud.configure(
         room_id=room_id,
@@ -1199,16 +1218,17 @@ async def _upload_session_report(
     logger.debug("finished uploading")
 
 
-def _shutdown_telemetry(timeout: float = _TELEMETRY_SHUTDOWN_TIMEOUT) -> None:
+def _shutdown_telemetry(job_id: str, timeout: float = _TELEMETRY_SHUTDOWN_TIMEOUT) -> None:
     """Per-job telemetry teardown, with a hard wall-clock bound.
 
     This flushes the exporters the framework attached, so LiveKit Cloud receives
-    the job's telemetry at job end — it does NOT shut providers down. Worker
-    processes are reused across jobs (the THREAD executor runs every job in one
-    shared process), and a provider configured by the integrator at process
-    start (Langfuse, Logfire, dd-trace) must keep running for later jobs; the
-    framework's own providers likewise stay alive because the OTel logger/meter
-    globals are set-once. See :class:`_CloudTelemetry` for the ownership model;
-    final shutdown happens once at process exit.
+    the job's telemetry at job end, and unregisters the job from the export
+    registry — it does NOT shut providers down. Worker processes are reused
+    across jobs (the THREAD executor runs every job in one shared process), and
+    a provider configured by the integrator at process start (Langfuse, Logfire,
+    dd-trace) must keep running for later jobs; the framework's own providers
+    likewise stay alive because the OTel logger/meter globals are set-once. See
+    :class:`_CloudTelemetry` for the ownership model; final shutdown happens
+    once at process exit.
     """
-    _cloud.release(timeout)
+    _cloud.release(job_id, timeout)

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -955,7 +955,7 @@ def test_shutdown_telemetry_keeps_integrator_providers_alive() -> None:
         integrator_tracer.add_span_processor.assert_called()
         integrator_logger.add_log_record_processor.assert_called()
 
-        _shutdown_telemetry()
+        _shutdown_telemetry("job-1")
 
         # per-job teardown flushes the framework's own exporters...
         stubs.span_batch.return_value.force_flush.assert_called_once()
@@ -990,12 +990,12 @@ def test_framework_created_providers_live_for_the_process() -> None:
         assert isinstance(created, SdkTracerProvider)
 
         with patch.object(created, "shutdown") as mock_tracer_shutdown:
-            _shutdown_telemetry()
+            _shutdown_telemetry("job-1")
 
             # job 2 in the same process: everything is reused, nothing rebuilt
             _setup_cloud_tracer_for_job(job_id="job-2")
             assert traces_mod.tracer._tracer_provider is created
-            _shutdown_telemetry()
+            _shutdown_telemetry("job-2")
 
             stubs.span_exporter.assert_called_once()
             stubs.log_exporter.assert_called_once()
@@ -1009,58 +1009,78 @@ def test_framework_created_providers_live_for_the_process() -> None:
             assert stubs.span_batch.return_value.force_flush.call_count == 2
             assert stubs.meter_provider_cls.return_value.force_flush.call_count == 2
 
-            # process exit shuts down everything the framework created, once
+        # process exit shuts down everything the framework created, exactly once
+        with patch(f"{_TRACES_MOD}._run_bounded") as mock_run_bounded:
             traces_mod._cloud.shutdown_at_exit()
-            mock_tracer_shutdown.assert_called_once()
-            stubs.meter_provider_cls.return_value.shutdown.assert_called_once()
+        target_fns = [fn for _, fn in mock_run_bounded.call_args.args[1]]
+        assert created.shutdown in target_fns
+        assert stubs.meter_provider_cls.return_value.shutdown in target_fns
+        assert target_fns.count(created.shutdown) == 1
 
 
-def test_export_gates_follow_job_lifecycle() -> None:
-    """Export is enabled only while a job that asked for it is running: a job
-    with traces/logs disabled — and the gap between jobs — must not upload."""
+def test_slot_metadata_follows_job_lifecycle() -> None:
+    """The fallback stamp for out-of-job-context telemetry is set while a job is
+    running and cleared when the last job releases — unstamped records between
+    jobs are then dropped by the stamp-gated exporters."""
     from livekit.agents.telemetry import traces as traces_mod
     from livekit.agents.telemetry.traces import _shutdown_telemetry
 
     with _stub_cloud_tracer_deps():
         _setup_cloud_tracer_for_job(job_id="job-1")
         cloud = traces_mod._cloud
-        assert cloud._span_gate is not None and cloud._span_gate.enabled
-        assert cloud._log_gate is not None and cloud._log_gate.enabled
+        assert cloud._span_metadata_processor is not None
+        assert cloud._span_metadata_processor._metadata["job_id"] == "job-1"
+        assert cloud._log_metadata_processor is not None
+        assert cloud._log_metadata_processor._metadata["job_id"] == "job-1"
 
-        _shutdown_telemetry()
-        assert not cloud._span_gate.enabled
-        assert not cloud._log_gate.enabled
-
-        # a later job that disabled traces must not re-open the span gate
-        _setup_cloud_tracer_for_job(job_id="job-2", enable_traces=False)
-        assert not cloud._span_gate.enabled
-        assert cloud._log_gate.enabled
-        _shutdown_telemetry()
+        _shutdown_telemetry("job-1")
+        assert cloud._span_metadata_processor._metadata == {}
+        assert cloud._log_metadata_processor._metadata == {}
 
 
-def test_gated_exporters_drop_data_while_disabled() -> None:
+def test_exporters_only_upload_records_of_registered_jobs() -> None:
+    """Cloud export is registry-gated: a record uploads only while its stamped
+    job_id is in the exportable-jobs registry, and only for the signals that
+    job enabled. Attribution is never stripped from any record — upload policy
+    and attributes are independent."""
     from opentelemetry.sdk._logs.export import LogRecordExportResult
     from opentelemetry.sdk.trace.export import SpanExportResult
 
-    from livekit.agents.telemetry.traces import _GatedLogExporter, _GatedSpanExporter
+    from livekit.agents.telemetry.traces import (
+        _GatedLogExporter,
+        _GatedSpanExporter,
+        _JobTelemetry,
+    )
 
-    span = SimpleNamespace(attributes={"room_id": "room-1"})
-    inner = MagicMock()
-    gate = _GatedSpanExporter(inner)
-    assert gate.export([span]) is SpanExportResult.SUCCESS
-    inner.export.assert_not_called()
-    gate.enabled = True
-    gate.export([span])
-    inner.export.assert_called_once()
+    export_jobs = {
+        "job-on": _JobTelemetry(attributes={}, traces_enabled=True, logs_enabled=True),
+        "job-off": _JobTelemetry(attributes={}, traces_enabled=False, logs_enabled=False),
+    }
 
-    record = SimpleNamespace(log_record=SimpleNamespace(attributes={"room_id": "room-1"}))
+    recorded = SimpleNamespace(attributes={"room_id": "room-1", "job_id": "job-on"})
+    disabled = SimpleNamespace(attributes={"room_id": "room-2", "job_id": "job-off"})
+    released = SimpleNamespace(attributes={"room_id": "room-3", "job_id": "job-gone"})
+    unstamped = SimpleNamespace(attributes={"some": "attr"})
+
     inner = MagicMock()
-    log_gate = _GatedLogExporter(inner)
-    assert log_gate.export([record]) is LogRecordExportResult.SUCCESS
+    gate = _GatedSpanExporter(inner, export_jobs)
+    assert gate.export([disabled, released, unstamped]) is SpanExportResult.SUCCESS
     inner.export.assert_not_called()
-    log_gate.enabled = True
-    log_gate.export([record])
-    inner.export.assert_called_once()
+    gate.export([disabled, recorded, released, unstamped])
+    inner.export.assert_called_once_with([recorded])
+
+    def _rec(attrs: dict[str, Any] | None) -> SimpleNamespace:
+        return SimpleNamespace(log_record=SimpleNamespace(attributes=attrs))
+
+    inner = MagicMock()
+    log_gate = _GatedLogExporter(inner, export_jobs)
+    assert (
+        log_gate.export([_rec({"job_id": "job-off"}), _rec(None)]) is LogRecordExportResult.SUCCESS
+    )
+    inner.export.assert_not_called()
+    recorded_rec = _rec({"room_id": "room-1", "job_id": "job-on"})
+    log_gate.export([_rec({"job_id": "job-gone"}), recorded_rec])
+    inner.export.assert_called_once_with([recorded_rec])
 
 
 def test_shutdown_telemetry_is_idempotent_and_safe_without_setup() -> None:
@@ -1069,11 +1089,11 @@ def test_shutdown_telemetry_is_idempotent_and_safe_without_setup() -> None:
     from livekit.agents.telemetry.traces import _shutdown_telemetry
 
     with _stub_cloud_tracer_deps() as stubs:
-        _shutdown_telemetry()  # no configure ran — must be a no-op
+        _shutdown_telemetry("job-1")  # no configure ran — must be a no-op
 
         _setup_cloud_tracer_for_job()
-        _shutdown_telemetry()
-        _shutdown_telemetry()
+        _shutdown_telemetry("job-1")
+        _shutdown_telemetry("job-1")
         assert stubs.span_batch.return_value.force_flush.call_count == 1
 
 
@@ -1090,12 +1110,13 @@ def test_concurrent_jobs_keep_exporting_until_the_last_release() -> None:
         cloud = traces_mod._cloud
         root = logging.getLogger()
 
-        _shutdown_telemetry()  # job A ends; job B is still running
-        assert cloud._span_gate is not None and cloud._span_gate.enabled
+        _shutdown_telemetry("job-a")  # job A ends; job B is still running
+        assert cloud._span_metadata_processor is not None
+        assert cloud._span_metadata_processor._metadata  # slot still stamped
         assert cloud.log_handler is not None and cloud.log_handler in root.handlers
 
-        _shutdown_telemetry()  # job B ends
-        assert not cloud._span_gate.enabled
+        _shutdown_telemetry("job-b")  # job B ends
+        assert cloud._span_metadata_processor._metadata == {}
         assert cloud.log_handler not in root.handlers
 
 
@@ -1115,7 +1136,7 @@ def test_shutdown_telemetry_leaves_foreign_log_handlers_attached() -> None:
             ours = traces_mod._cloud.log_handler
             assert ours is not None and ours in root.handlers
 
-            _shutdown_telemetry()
+            _shutdown_telemetry("job-1")
             assert ours not in root.handlers
         assert foreign_handler in root.handlers
     finally:
@@ -1187,16 +1208,17 @@ def test_metric_measurements_carry_job_identity() -> None:
     from livekit.agents.job import _JobContextVar
     from livekit.agents.metrics.base import LLMMetrics
     from livekit.agents.telemetry import otel_metrics
+    from livekit.agents.telemetry.traces import _JobTelemetry
 
     mock_ctx = MagicMock()
     mock_ctx.job.id = "job-42"
     mock_ctx.job.room.sid = "room-42"
     # what init_recording() stashes: identity + session metadata
-    mock_ctx._otel_measurement_attrs = {
-        "room_id": "room-42",
-        "job_id": "job-42",
-        "lk.simulation.enabled": True,
-    }
+    mock_ctx._telemetry_state = _JobTelemetry(
+        attributes={"room_id": "room-42", "job_id": "job-42", "lk.simulation.enabled": True},
+        traces_enabled=True,
+        logs_enabled=True,
+    )
 
     ev = MagicMock(spec=LLMMetrics)
     ev.metadata = None
@@ -1217,7 +1239,7 @@ def test_metric_measurements_carry_job_identity() -> None:
     assert attrs["lk.simulation.enabled"] is True
 
     # recording never initialized (disabled / crash path): identity still stamped
-    mock_ctx._otel_measurement_attrs = None
+    mock_ctx._telemetry_state = None
     with patch.object(otel_metrics, "_llm_input_tokens") as mock_counter:
         token = _JobContextVar.set(mock_ctx)
         try:
@@ -1254,9 +1276,9 @@ def test_provider_swap_still_shuts_down_current_span_pipeline_at_exit() -> None:
         # job 1: no integrator provider — the framework creates its own
         set_tracer_provider(NoOpTracerProvider())
         _setup_cloud_tracer_for_job(job_id="job-1")
-        owned = traces_mod._cloud._owned_tracer_provider
-        assert owned is not None and len(batch_instances) == 1
-        _shutdown_telemetry()
+        owned = traces_mod.tracer._tracer_provider
+        assert isinstance(owned, SdkTracerProvider) and len(batch_instances) == 1
+        _shutdown_telemetry("job-1")
 
         # the integrator replaces the provider mid-process
         integrator = MagicMock(spec=SdkTracerProvider)
@@ -1273,14 +1295,16 @@ def test_provider_swap_still_shuts_down_current_span_pipeline_at_exit() -> None:
                 break
             time.sleep(0.02)
         old_batch.shutdown.assert_called_once()
-        _shutdown_telemetry()
+        _shutdown_telemetry("job-2")
 
-        with patch.object(owned, "shutdown") as mock_owned_shutdown:
+        # the exit targets cover the owned provider AND the current pipeline on
+        # the integrator's provider — never the integrator's provider itself
+        with patch(f"{_TRACES_MOD}._run_bounded") as mock_run_bounded:
             traces_mod._cloud.shutdown_at_exit()
-
-        mock_owned_shutdown.assert_called_once()
-        new_batch.shutdown.assert_called_once()
-        integrator.shutdown.assert_not_called()
+        target_fns = [fn for _, fn in mock_run_bounded.call_args.args[1]]
+        assert owned.shutdown in target_fns
+        assert new_batch.shutdown in target_fns
+        assert integrator.shutdown not in target_fns
 
 
 def _make_telemetry_job_ctx(
@@ -1294,14 +1318,19 @@ def _make_telemetry_job_ctx(
 ) -> MagicMock:
     """A JobContext stand-in carrying the per-record telemetry state that
     init_recording() stashes."""
+    from livekit.agents.telemetry.traces import _JobTelemetry
+
     ctx = MagicMock()
     ctx.job.id = job_id
     ctx.job.room.sid = room_id
-    ctx._recording_initialized = initialized
-    ctx._otel_traces_enabled = traces
-    ctx._otel_logs_enabled = logs
-    ctx._otel_session_metadata = (
-        {"room_id": room_id, "job_id": job_id, **(metadata or {})} if initialized else None
+    ctx._telemetry_state = (
+        _JobTelemetry(
+            attributes={"room_id": room_id, "job_id": job_id, **(metadata or {})},
+            traces_enabled=traces,
+            logs_enabled=logs,
+        )
+        if initialized
+        else None
     )
     return ctx
 
@@ -1323,12 +1352,18 @@ def test_unconfigured_job_cleanup_does_not_release_telemetry() -> None:
     release a concurrent recorded job's registration — in THREAD mode that would
     turn export off underneath it."""
     from livekit.agents.job import JobContext
+    from livekit.agents.telemetry.traces import _JobTelemetry
 
     def _make_ctx(configured: bool) -> JobContext:
         ctx = object.__new__(JobContext)
+        ctx._info = SimpleNamespace(job=SimpleNamespace(id="job-x"))
         ctx._early_log_handler = None
         ctx._recording_initialized = True
-        ctx._telemetry_configured = configured
+        ctx._telemetry_state = (
+            _JobTelemetry(attributes={}, traces_enabled=True, logs_enabled=True)
+            if configured
+            else None
+        )
         ctx._tempdir = MagicMock()
         ctx._handlers_with_filter = []
         ctx._log_filter = MagicMock()
@@ -1340,17 +1375,18 @@ def test_unconfigured_job_cleanup_does_not_release_telemetry() -> None:
 
     with patch("livekit.agents.job._shutdown_telemetry") as mock_shutdown:
         _make_ctx(configured=True)._on_cleanup()
-    mock_shutdown.assert_called_once()
+    mock_shutdown.assert_called_once_with("job-x")
 
 
 def test_spans_of_a_job_that_disabled_traces_are_not_uploaded() -> None:
-    """Concurrent THREAD-mode jobs share the provider and the export gates: a
-    recorded job holding the gate open must not cause a disabled job's spans to
-    upload. Spans are marked from their originating job context and dropped by
-    the gated exporter."""
+    """Concurrent THREAD-mode jobs share the provider and the exporter: a
+    recorded job must not cause a disabled job's spans to upload. The disabled
+    job's spans keep their full attribution for the integrator's exporters on
+    the same provider — Cloud upload is denied by the exportable-jobs registry,
+    not by stripping attributes."""
     from livekit.agents.telemetry.traces import (
-        _ATTR_EXPORT_SUPPRESSED,
         _GatedSpanExporter,
+        _JobTelemetry,
         _MetadataSpanProcessor,
     )
 
@@ -1359,21 +1395,24 @@ def test_spans_of_a_job_that_disabled_traces_are_not_uploaded() -> None:
     span = MagicMock()
     with _job_ctx_active(disabled_ctx):
         processor.on_start(span)
-    span.set_attribute.assert_called_once_with(_ATTR_EXPORT_SUPPRESSED, True)
-    span.set_attributes.assert_not_called()
+    # attribution is unconditional — the integrator's copy keeps room/job ids
+    span.set_attributes.assert_called_once_with({"room_id": "room-b", "job_id": "job-b"})
 
+    export_jobs = {
+        "job-a": _JobTelemetry(attributes={}, traces_enabled=True, logs_enabled=True),
+        "job-b": _JobTelemetry(attributes={}, traces_enabled=False, logs_enabled=True),
+    }
     inner = MagicMock()
-    gate = _GatedSpanExporter(inner)
-    gate.enabled = True  # held open by the concurrent recorded job
+    gate = _GatedSpanExporter(inner, export_jobs)
 
-    suppressed = SimpleNamespace(attributes={_ATTR_EXPORT_SUPPRESSED: True})
-    recorded = SimpleNamespace(attributes={"room_id": "room-a"})
+    disabled_span = SimpleNamespace(attributes={"room_id": "room-b", "job_id": "job-b"})
+    recorded_span = SimpleNamespace(attributes={"room_id": "room-a", "job_id": "job-a"})
 
-    gate.export([suppressed])
+    gate.export([disabled_span])
     inner.export.assert_not_called()
 
-    gate.export([suppressed, recorded])
-    inner.export.assert_called_once_with([recorded])
+    gate.export([disabled_span, recorded_span])
+    inner.export.assert_called_once_with([recorded_span])
 
 
 def test_concurrent_jobs_stamp_their_own_identity_on_spans() -> None:
@@ -1403,11 +1442,11 @@ def test_concurrent_jobs_stamp_their_own_identity_on_spans() -> None:
 
 
 def test_logs_of_a_job_that_disabled_logs_are_not_uploaded() -> None:
-    """Log counterpart: records are stamped/marked from their originating job
-    context and marked ones are dropped by the gated log exporter."""
+    """Log counterpart: records keep their full attribution for every
+    destination; Cloud upload is denied by the exportable-jobs registry."""
     from livekit.agents.telemetry.traces import (
-        _ATTR_EXPORT_SUPPRESSED,
         _GatedLogExporter,
+        _JobTelemetry,
         _MetadataLogProcessor,
     )
 
@@ -1421,25 +1460,25 @@ def test_logs_of_a_job_that_disabled_logs_are_not_uploaded() -> None:
             processor.on_emit(log_data)
         return log_data.log_record.attributes
 
-    enabled_ctx = _make_telemetry_job_ctx(room_id="room-a", job_id="job-a")
-    attrs = _emit(enabled_ctx)
-    assert attrs["room_id"] == "room-a" and attrs["job_id"] == "job-a"
-    assert _ATTR_EXPORT_SUPPRESSED not in attrs
-
+    # attribution is unconditional, recording options notwithstanding
     disabled_ctx = _make_telemetry_job_ctx(room_id="room-b", job_id="job-b", logs=False)
     attrs = _emit(disabled_ctx)
-    assert attrs.get(_ATTR_EXPORT_SUPPRESSED) is True
-    assert "room_id" not in attrs
+    assert attrs["room_id"] == "room-b" and attrs["job_id"] == "job-b"
 
+    export_jobs = {
+        "job-a": _JobTelemetry(attributes={}, traces_enabled=True, logs_enabled=True),
+        "job-b": _JobTelemetry(attributes={}, traces_enabled=True, logs_enabled=False),
+    }
     inner = MagicMock()
-    gate = _GatedLogExporter(inner)
-    gate.enabled = True
-    suppressed = SimpleNamespace(log_record=SimpleNamespace(attributes=attrs))
-    recorded = SimpleNamespace(log_record=SimpleNamespace(attributes={"room_id": "room-a"}))
+    gate = _GatedLogExporter(inner, export_jobs)
+    disabled = SimpleNamespace(log_record=SimpleNamespace(attributes=attrs))
+    recorded = SimpleNamespace(
+        log_record=SimpleNamespace(attributes={"room_id": "room-a", "job_id": "job-a"})
+    )
 
-    gate.export([suppressed])
+    gate.export([disabled])
     inner.export.assert_not_called()
-    gate.export([recorded, suppressed])
+    gate.export([recorded, disabled])
     inner.export.assert_called_once_with([recorded])
 
 

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -1044,20 +1044,22 @@ def test_gated_exporters_drop_data_while_disabled() -> None:
 
     from livekit.agents.telemetry.traces import _GatedLogExporter, _GatedSpanExporter
 
+    span = SimpleNamespace(attributes={"room_id": "room-1"})
     inner = MagicMock()
     gate = _GatedSpanExporter(inner)
-    assert gate.export([]) is SpanExportResult.SUCCESS
+    assert gate.export([span]) is SpanExportResult.SUCCESS
     inner.export.assert_not_called()
     gate.enabled = True
-    gate.export([])
+    gate.export([span])
     inner.export.assert_called_once()
 
+    record = SimpleNamespace(log_record=SimpleNamespace(attributes={"room_id": "room-1"}))
     inner = MagicMock()
     log_gate = _GatedLogExporter(inner)
-    assert log_gate.export([]) is LogRecordExportResult.SUCCESS
+    assert log_gate.export([record]) is LogRecordExportResult.SUCCESS
     inner.export.assert_not_called()
     log_gate.enabled = True
-    log_gate.export([])
+    log_gate.export([record])
     inner.export.assert_called_once()
 
 
@@ -1279,6 +1281,166 @@ def test_provider_swap_still_shuts_down_current_span_pipeline_at_exit() -> None:
         mock_owned_shutdown.assert_called_once()
         new_batch.shutdown.assert_called_once()
         integrator.shutdown.assert_not_called()
+
+
+def _make_telemetry_job_ctx(
+    *,
+    room_id: str,
+    job_id: str,
+    initialized: bool = True,
+    traces: bool = True,
+    logs: bool = True,
+    metadata: dict[str, Any] | None = None,
+) -> MagicMock:
+    """A JobContext stand-in carrying the per-record telemetry state that
+    init_recording() stashes."""
+    ctx = MagicMock()
+    ctx.job.id = job_id
+    ctx.job.room.sid = room_id
+    ctx._recording_initialized = initialized
+    ctx._otel_traces_enabled = traces
+    ctx._otel_logs_enabled = logs
+    ctx._otel_session_metadata = (
+        {"room_id": room_id, "job_id": job_id, **(metadata or {})} if initialized else None
+    )
+    return ctx
+
+
+@contextlib.contextmanager
+def _job_ctx_active(ctx: MagicMock) -> Iterator[None]:
+    from livekit.agents.job import _JobContextVar
+
+    token = _JobContextVar.set(ctx)
+    try:
+        yield
+    finally:
+        _JobContextVar.reset(token)
+
+
+def test_unconfigured_job_cleanup_does_not_release_telemetry() -> None:
+    """_on_cleanup runs for every job, including ones that never configured
+    telemetry (recording disabled, no observability URL). Such a job must not
+    release a concurrent recorded job's registration — in THREAD mode that would
+    turn export off underneath it."""
+    from livekit.agents.job import JobContext
+
+    def _make_ctx(configured: bool) -> JobContext:
+        ctx = object.__new__(JobContext)
+        ctx._early_log_handler = None
+        ctx._recording_initialized = True
+        ctx._telemetry_configured = configured
+        ctx._tempdir = MagicMock()
+        ctx._handlers_with_filter = []
+        ctx._log_filter = MagicMock()
+        return ctx
+
+    with patch("livekit.agents.job._shutdown_telemetry") as mock_shutdown:
+        _make_ctx(configured=False)._on_cleanup()
+    mock_shutdown.assert_not_called()
+
+    with patch("livekit.agents.job._shutdown_telemetry") as mock_shutdown:
+        _make_ctx(configured=True)._on_cleanup()
+    mock_shutdown.assert_called_once()
+
+
+def test_spans_of_a_job_that_disabled_traces_are_not_uploaded() -> None:
+    """Concurrent THREAD-mode jobs share the provider and the export gates: a
+    recorded job holding the gate open must not cause a disabled job's spans to
+    upload. Spans are marked from their originating job context and dropped by
+    the gated exporter."""
+    from livekit.agents.telemetry.traces import (
+        _ATTR_EXPORT_SUPPRESSED,
+        _GatedSpanExporter,
+        _MetadataSpanProcessor,
+    )
+
+    processor = _MetadataSpanProcessor()
+    disabled_ctx = _make_telemetry_job_ctx(room_id="room-b", job_id="job-b", traces=False)
+    span = MagicMock()
+    with _job_ctx_active(disabled_ctx):
+        processor.on_start(span)
+    span.set_attribute.assert_called_once_with(_ATTR_EXPORT_SUPPRESSED, True)
+    span.set_attributes.assert_not_called()
+
+    inner = MagicMock()
+    gate = _GatedSpanExporter(inner)
+    gate.enabled = True  # held open by the concurrent recorded job
+
+    suppressed = SimpleNamespace(attributes={_ATTR_EXPORT_SUPPRESSED: True})
+    recorded = SimpleNamespace(attributes={"room_id": "room-a"})
+
+    gate.export([suppressed])
+    inner.export.assert_not_called()
+
+    gate.export([suppressed, recorded])
+    inner.export.assert_called_once_with([recorded])
+
+
+def test_concurrent_jobs_stamp_their_own_identity_on_spans() -> None:
+    """Span metadata resolves from the originating job's context, not from the
+    shared last-configured slot — concurrent jobs must not inherit each other's
+    room/job identity."""
+    from livekit.agents.telemetry.traces import _MetadataSpanProcessor
+
+    processor = _MetadataSpanProcessor()
+    # a second job configured after the first: the shared slot holds job B's data
+    processor.set_metadata({"room_id": "room-b", "job_id": "job-b"})
+
+    ctx_a = _make_telemetry_job_ctx(
+        room_id="room-a", job_id="job-a", metadata={"lk.simulation.enabled": True}
+    )
+    span = MagicMock()
+    with _job_ctx_active(ctx_a):
+        processor.on_start(span)
+    span.set_attributes.assert_called_once_with(
+        {"room_id": "room-a", "job_id": "job-a", "lk.simulation.enabled": True}
+    )
+
+    # outside any job context, the slot is still the fallback
+    span = MagicMock()
+    processor.on_start(span)
+    span.set_attributes.assert_called_once_with({"room_id": "room-b", "job_id": "job-b"})
+
+
+def test_logs_of_a_job_that_disabled_logs_are_not_uploaded() -> None:
+    """Log counterpart: records are stamped/marked from their originating job
+    context and marked ones are dropped by the gated log exporter."""
+    from livekit.agents.telemetry.traces import (
+        _ATTR_EXPORT_SUPPRESSED,
+        _GatedLogExporter,
+        _MetadataLogProcessor,
+    )
+
+    processor = _MetadataLogProcessor()
+
+    def _emit(ctx: MagicMock) -> dict[str, Any]:
+        log_data = MagicMock()
+        log_data.log_record.attributes = {}
+        log_data.instrumentation_scope = None
+        with _job_ctx_active(ctx):
+            processor.on_emit(log_data)
+        return log_data.log_record.attributes
+
+    enabled_ctx = _make_telemetry_job_ctx(room_id="room-a", job_id="job-a")
+    attrs = _emit(enabled_ctx)
+    assert attrs["room_id"] == "room-a" and attrs["job_id"] == "job-a"
+    assert _ATTR_EXPORT_SUPPRESSED not in attrs
+
+    disabled_ctx = _make_telemetry_job_ctx(room_id="room-b", job_id="job-b", logs=False)
+    attrs = _emit(disabled_ctx)
+    assert attrs.get(_ATTR_EXPORT_SUPPRESSED) is True
+    assert "room_id" not in attrs
+
+    inner = MagicMock()
+    gate = _GatedLogExporter(inner)
+    gate.enabled = True
+    suppressed = SimpleNamespace(log_record=SimpleNamespace(attributes=attrs))
+    recorded = SimpleNamespace(log_record=SimpleNamespace(attributes={"room_id": "room-a"}))
+
+    gate.export([suppressed])
+    inner.export.assert_not_called()
+    gate.export([recorded, suppressed])
+    inner.export.assert_called_once_with([recorded])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -5,6 +5,7 @@ import contextlib
 import inspect
 import logging
 import ssl
+import time
 from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
@@ -1161,6 +1162,123 @@ def test_meter_provider_skipped_when_integrator_set_a_custom_one() -> None:
 
     stubs.meter_provider_cls.assert_not_called()
     stubs.set_meter_provider.assert_not_called()
+
+
+def test_meter_provider_resource_carries_no_job_identity() -> None:
+    """The meter provider outlives the job (set-once global), so its resource
+    must not carry the first job's room_id/job_id — per-job identity rides on
+    each measurement instead (otel_metrics._job_identity_attrs)."""
+    with _stub_cloud_tracer_deps() as stubs:
+        _setup_cloud_tracer_for_job(agent_name="test-agent")
+
+    resource = stubs.meter_provider_cls.call_args.kwargs["resource"]
+    assert "room_id" not in resource.attributes
+    assert "job_id" not in resource.attributes
+    # process-stable identity is kept
+    assert resource.attributes["service.name"] == "livekit-agents"
+    assert resource.attributes["lk.agent_name"] == "test-agent"
+
+
+def test_metric_measurements_carry_job_identity() -> None:
+    """Usage metrics are stamped with the job's identity and session metadata —
+    the same per-job fields that ride on spans and logs."""
+    from livekit.agents.job import _JobContextVar
+    from livekit.agents.metrics.base import LLMMetrics
+    from livekit.agents.telemetry import otel_metrics
+
+    mock_ctx = MagicMock()
+    mock_ctx.job.id = "job-42"
+    mock_ctx.job.room.sid = "room-42"
+    # what init_recording() stashes: identity + session metadata
+    mock_ctx._otel_measurement_attrs = {
+        "room_id": "room-42",
+        "job_id": "job-42",
+        "lk.simulation.enabled": True,
+    }
+
+    ev = MagicMock(spec=LLMMetrics)
+    ev.metadata = None
+    ev.prompt_tokens = 5
+    ev.prompt_cached_tokens = 0
+    ev.completion_tokens = 0
+
+    with patch.object(otel_metrics, "_llm_input_tokens") as mock_counter:
+        token = _JobContextVar.set(mock_ctx)
+        try:
+            otel_metrics.collect_usage(ev)
+        finally:
+            _JobContextVar.reset(token)
+
+    attrs = mock_counter.add.call_args.kwargs["attributes"]
+    assert attrs["room_id"] == "room-42"
+    assert attrs["job_id"] == "job-42"
+    assert attrs["lk.simulation.enabled"] is True
+
+    # recording never initialized (disabled / crash path): identity still stamped
+    mock_ctx._otel_measurement_attrs = None
+    with patch.object(otel_metrics, "_llm_input_tokens") as mock_counter:
+        token = _JobContextVar.set(mock_ctx)
+        try:
+            otel_metrics.collect_usage(ev)
+        finally:
+            _JobContextVar.reset(token)
+    attrs = mock_counter.add.call_args.kwargs["attributes"]
+    assert attrs == {"room_id": "room-42", "job_id": "job-42"}
+
+    # outside a job context the attributes are simply absent, never wrong
+    with patch.object(otel_metrics, "_llm_input_tokens") as mock_counter:
+        otel_metrics.collect_usage(ev)
+    attrs = mock_counter.add.call_args.kwargs["attributes"]
+    assert "room_id" not in attrs and "job_id" not in attrs
+
+
+def test_provider_swap_still_shuts_down_current_span_pipeline_at_exit() -> None:
+    """If the integrator replaces a framework-created tracer provider
+    mid-process, process exit must shut down BOTH the old owned provider and the
+    batch processor attached to the integrator's provider, or its queued spans
+    are lost — and it must never shut down the integrator's provider itself."""
+    from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+    from opentelemetry.trace import NoOpTracerProvider
+
+    from livekit.agents.telemetry import traces as traces_mod
+    from livekit.agents.telemetry.traces import _shutdown_telemetry, set_tracer_provider
+
+    with _stub_cloud_tracer_deps() as stubs:
+        batch_instances: list[MagicMock] = []
+        stubs.span_batch.side_effect = lambda *a, **k: (
+            batch_instances.append(MagicMock()) or batch_instances[-1]
+        )
+
+        # job 1: no integrator provider — the framework creates its own
+        set_tracer_provider(NoOpTracerProvider())
+        _setup_cloud_tracer_for_job(job_id="job-1")
+        owned = traces_mod._cloud._owned_tracer_provider
+        assert owned is not None and len(batch_instances) == 1
+        _shutdown_telemetry()
+
+        # the integrator replaces the provider mid-process
+        integrator = MagicMock(spec=SdkTracerProvider)
+        set_tracer_provider(integrator)
+
+        # job 2: the pipeline re-attaches to the integrator's provider and the
+        # old one is retired (shut down on a background thread)
+        _setup_cloud_tracer_for_job(job_id="job-2")
+        assert len(batch_instances) == 2
+        old_batch, new_batch = batch_instances
+        integrator.add_span_processor.assert_any_call(new_batch)
+        for _ in range(50):  # retire happens on a daemon thread
+            if old_batch.shutdown.called:
+                break
+            time.sleep(0.02)
+        old_batch.shutdown.assert_called_once()
+        _shutdown_telemetry()
+
+        with patch.object(owned, "shutdown") as mock_owned_shutdown:
+            traces_mod._cloud.shutdown_at_exit()
+
+        mock_owned_shutdown.assert_called_once()
+        new_batch.shutdown.assert_called_once()
+        integrator.shutdown.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import inspect
+import logging
 import ssl
 from collections.abc import Iterator
 from pathlib import Path
@@ -145,6 +146,15 @@ def _observability_endpoint_arg(func: Any) -> dict[str, str]:
     return {"cloud_hostname": "test.livekit.cloud"}
 
 
+def _stub_access_token(mock_at: MagicMock) -> None:
+    """Make a patched api.AccessToken produce a fixed JWT."""
+    mock_token = MagicMock()
+    mock_token.with_observability_grants.return_value = mock_token
+    mock_token.with_ttl.return_value = mock_token
+    mock_token.to_jwt.return_value = "test-jwt"
+    mock_at.return_value = mock_token
+
+
 @contextlib.contextmanager
 def _patch_upload_deps() -> Iterator[MagicMock]:
     """Patch OTel logger provider and AccessToken. Yields the mock logger for assertions."""
@@ -156,12 +166,99 @@ def _patch_upload_deps() -> Iterator[MagicMock]:
         provider = mock_glp.return_value
         provider.get_logger.return_value = mock_logger
         mock_logger.provider = provider
-        mock_token = MagicMock()
-        mock_token.with_observability_grants.return_value = mock_token
-        mock_token.with_ttl.return_value = mock_token
-        mock_token.to_jwt.return_value = "test-jwt"
-        mock_at.return_value = mock_token
+        _stub_access_token(mock_at)
         yield mock_logger
+
+
+@contextlib.contextmanager
+def _fresh_telemetry_state() -> Iterator[None]:
+    """Swap in a fresh _CloudTelemetry and restore process-wide telemetry state.
+
+    _setup_cloud_tracer / _shutdown_telemetry mutate process-lifetime state (the
+    singleton, the _DynamicTracer provider slot, the root logger); tests must not
+    leak it into each other.
+    """
+    from livekit.agents.telemetry import traces as traces_mod
+
+    prev_cloud = traces_mod._cloud
+    prev_provider = traces_mod.tracer._tracer_provider
+    traces_mod._cloud = traces_mod._CloudTelemetry()
+    try:
+        yield
+    finally:
+        if (handler := traces_mod._cloud.log_handler) is not None:
+            logging.getLogger().removeHandler(handler)
+        traces_mod._cloud = prev_cloud
+        traces_mod.tracer.set_provider(prev_provider)
+
+
+@contextlib.contextmanager
+def _stub_cloud_tracer_deps() -> Iterator[SimpleNamespace]:
+    """Fresh telemetry state with auth, the OTLP exporters, the batch processors,
+    and the set-once OTel logger/meter globals stubbed out, so tests never touch
+    the network or the real process globals."""
+    from opentelemetry.metrics._internal import _ProxyMeterProvider
+
+    # stateful stand-ins for the set-once OTel globals; tests can pre-seed these
+    # with an "integrator" provider
+    meter_state: dict[str, Any] = {"provider": _ProxyMeterProvider()}
+    logger_state: dict[str, Any] = {"provider": MagicMock()}  # not an SDK LoggerProvider
+
+    with (
+        _fresh_telemetry_state(),
+        patch(f"{_TRACES_MOD}.api.AccessToken") as mock_at,
+        patch(f"{_TRACES_MOD}.OTLPSpanExporter") as mock_span_exporter,
+        patch(f"{_TRACES_MOD}.OTLPLogExporter") as mock_log_exporter,
+        patch(f"{_TRACES_MOD}.OTLPMetricExporter") as mock_metric_exporter,
+        patch(f"{_TRACES_MOD}.BatchSpanProcessor") as mock_span_batch,
+        patch(f"{_TRACES_MOD}.BatchLogRecordProcessor") as mock_log_batch,
+        patch(f"{_TRACES_MOD}.PeriodicExportingMetricReader"),
+        patch(f"{_TRACES_MOD}.SdkMeterProvider") as mock_meter_provider_cls,
+        patch(
+            f"{_TRACES_MOD}.get_logger_provider",
+            side_effect=lambda: logger_state["provider"],
+        ),
+        patch(
+            f"{_TRACES_MOD}.set_logger_provider",
+            side_effect=lambda p: logger_state.__setitem__("provider", p),
+        ) as mock_set_logger_provider,
+        patch(
+            f"{_TRACES_MOD}.metrics_api.get_meter_provider",
+            side_effect=lambda: meter_state["provider"],
+        ),
+        patch(
+            f"{_TRACES_MOD}.metrics_api.set_meter_provider",
+            side_effect=lambda p: meter_state.__setitem__("provider", p),
+        ) as mock_set_meter_provider,
+        patch(f"{_TRACES_MOD}.atexit"),
+    ):
+        _stub_access_token(mock_at)
+        yield SimpleNamespace(
+            span_exporter=mock_span_exporter,
+            log_exporter=mock_log_exporter,
+            metric_exporter=mock_metric_exporter,
+            span_batch=mock_span_batch,
+            log_batch=mock_log_batch,
+            meter_provider_cls=mock_meter_provider_cls,
+            set_logger_provider=mock_set_logger_provider,
+            set_meter_provider=mock_set_meter_provider,
+            meter_state=meter_state,
+            logger_state=logger_state,
+        )
+
+
+def _setup_cloud_tracer_for_job(job_id: str = "job-1", **kwargs: Any) -> None:
+    from livekit.agents.telemetry.traces import _setup_cloud_tracer
+
+    params: dict[str, Any] = {
+        "room_id": "room-1",
+        "job_id": job_id,
+        **_observability_endpoint_arg(_setup_cloud_tracer),
+        "enable_traces": True,
+        "enable_logs": True,
+    }
+    params.update(kwargs)
+    _setup_cloud_tracer(**params)
 
 
 async def _call_upload(
@@ -755,69 +852,38 @@ async def test_upload_session_report_omits_simulation_metadata_for_normal_sessio
 
 def test_setup_cloud_tracer_logger_provider_always_created() -> None:
     """LoggerProvider should be set up even when enable_logs=False."""
-    from livekit.agents.telemetry.traces import _setup_cloud_tracer
-
     with (
-        patch(f"{_TRACES_MOD}.api.AccessToken") as mock_at,
-        patch(f"{_TRACES_MOD}.get_logger_provider") as mock_glp,
-        patch(f"{_TRACES_MOD}.set_logger_provider") as mock_slp,
-        patch(f"{_TRACES_MOD}.OTLPLogExporter") as mock_exporter,
-        patch(f"{_TRACES_MOD}.BatchLogRecordProcessor") as mock_blrp,
+        _stub_cloud_tracer_deps() as stubs,
         patch(f"{_TRACES_MOD}.Resource.create") as mock_resource_create,
-        patch(f"{_TRACES_MOD}.logging"),
     ):
-        mock_token = MagicMock()
-        mock_token.with_observability_grants.return_value = mock_token
-        mock_token.with_ttl.return_value = mock_token
-        mock_token.to_jwt.return_value = "test-jwt"
-        mock_at.return_value = mock_token
-        # Return a non-LoggerProvider so the code creates a new one
-        mock_glp.return_value = MagicMock()
-
-        _setup_cloud_tracer(
-            room_id="room-1",
-            job_id="job-1",
-            **_observability_endpoint_arg(_setup_cloud_tracer),
+        _setup_cloud_tracer_for_job(
             enable_traces=False,
             enable_logs=False,
             metadata={"lk.simulation.enabled": True},
         )
 
-    mock_slp.assert_called_once()
-    assert not any(k.startswith("lk.simulation.") for k in mock_resource_create.call_args.args[0])
+    stubs.set_logger_provider.assert_called_once()
+    service_resource_calls = [
+        call.args[0]
+        for call in mock_resource_create.call_args_list
+        if "service.name" in call.args[0]
+    ]
+    assert service_resource_calls
+    assert not any(k.startswith("lk.simulation.") for k in service_resource_calls[0])
     # OTLP exporter should NOT be created when enable_logs=False
-    mock_exporter.assert_not_called()
-    mock_blrp.assert_not_called()
+    stubs.log_exporter.assert_not_called()
+    stubs.log_batch.assert_not_called()
 
 
 def _resource_attrs_for_env(env: dict[str, str]) -> dict[str, Any]:
     """Run _setup_cloud_tracer under the given os.environ and return the dict
     passed to Resource.create."""
-    from livekit.agents.telemetry.traces import _setup_cloud_tracer
-
     with (
         patch.dict("os.environ", env, clear=True),
-        patch(f"{_TRACES_MOD}.api.AccessToken") as mock_at,
-        patch(f"{_TRACES_MOD}.get_logger_provider", return_value=MagicMock()),
-        patch(f"{_TRACES_MOD}.set_logger_provider"),
-        patch(f"{_TRACES_MOD}.OTLPLogExporter"),
-        patch(f"{_TRACES_MOD}.BatchLogRecordProcessor"),
+        _stub_cloud_tracer_deps(),
         patch(f"{_TRACES_MOD}.Resource.create") as mock_resource_create,
-        patch(f"{_TRACES_MOD}.logging"),
     ):
-        mock_token = MagicMock()
-        mock_token.with_observability_grants.return_value = mock_token
-        mock_token.with_ttl.return_value = mock_token
-        mock_token.to_jwt.return_value = "test-jwt"
-        mock_at.return_value = mock_token
-
-        _setup_cloud_tracer(
-            room_id="room-1",
-            job_id="job-1",
-            **_observability_endpoint_arg(_setup_cloud_tracer),
-            enable_traces=False,
-            enable_logs=False,
-        )
+        _setup_cloud_tracer_for_job(enable_traces=False, enable_logs=False)
     # Resource.create is also called internally by LoggerProvider() with an
     # empty dict, so select the call that built the tracing resource (the one
     # carrying service.name) rather than relying on call ordering.
@@ -852,6 +918,249 @@ def test_setup_cloud_tracer_omits_empty_deployment() -> None:
     )
     assert attrs["lk.cloud_agent_id"] == "CA_test123"
     assert "lk.deployment_id" not in attrs
+
+
+# ---------------------------------------------------------------------------
+# Group 3.5: telemetry ownership & process reuse (_CloudTelemetry)
+# ---------------------------------------------------------------------------
+
+
+def test_shutdown_telemetry_keeps_integrator_providers_alive() -> None:
+    """Providers the integrator configured at process start (Langfuse per the
+    tracing docs, Logfire, dd-trace) must survive per-job teardown: worker
+    processes are reused across jobs, so shutting them down would kill the
+    integrator's export for every later job."""
+    from opentelemetry.sdk._logs import LoggerProvider
+    from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+    from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+
+    from livekit.agents.telemetry import traces as traces_mod
+    from livekit.agents.telemetry.traces import _shutdown_telemetry, set_tracer_provider
+
+    integrator_tracer = MagicMock(spec=SdkTracerProvider)
+    integrator_logger = MagicMock(spec=LoggerProvider)
+    integrator_meter = MagicMock(spec=SdkMeterProvider)
+
+    with _stub_cloud_tracer_deps() as stubs:
+        set_tracer_provider(integrator_tracer)
+        stubs.logger_state["provider"] = integrator_logger
+        stubs.meter_state["provider"] = integrator_meter
+
+        _setup_cloud_tracer_for_job()
+
+        # sanity: the framework adopted the integrator's providers and attached
+        # its own processors to them
+        assert traces_mod.tracer._tracer_provider is integrator_tracer
+        integrator_tracer.add_span_processor.assert_called()
+        integrator_logger.add_log_record_processor.assert_called()
+
+        _shutdown_telemetry()
+
+        # per-job teardown flushes the framework's own exporters...
+        stubs.span_batch.return_value.force_flush.assert_called_once()
+        stubs.log_batch.return_value.force_flush.assert_called_once()
+
+    # ...but never shuts down anything the integrator owns
+    integrator_tracer.shutdown.assert_not_called()
+    integrator_logger.shutdown.assert_not_called()
+    integrator_meter.shutdown.assert_not_called()
+    # the framework did not build a competing meter provider either (there is no
+    # API to attach a reader to the integrator's)
+    stubs.meter_provider_cls.assert_not_called()
+
+
+def test_framework_created_providers_live_for_the_process() -> None:
+    """Providers the framework creates are reused by the next job in the process
+    (the OTel logger/meter globals are set-once) and shut down only at process
+    exit — not per job, which previously left job 2+ on dead providers."""
+    from opentelemetry.trace import NoOpTracerProvider
+
+    from livekit.agents.telemetry import traces as traces_mod
+    from livekit.agents.telemetry.traces import _shutdown_telemetry, set_tracer_provider
+
+    with _stub_cloud_tracer_deps() as stubs:
+        set_tracer_provider(NoOpTracerProvider())
+
+        # job 1
+        _setup_cloud_tracer_for_job(job_id="job-1")
+        created = traces_mod.tracer._tracer_provider
+        from opentelemetry.sdk.trace import TracerProvider as SdkTracerProvider
+
+        assert isinstance(created, SdkTracerProvider)
+
+        with patch.object(created, "shutdown") as mock_tracer_shutdown:
+            _shutdown_telemetry()
+
+            # job 2 in the same process: everything is reused, nothing rebuilt
+            _setup_cloud_tracer_for_job(job_id="job-2")
+            assert traces_mod.tracer._tracer_provider is created
+            _shutdown_telemetry()
+
+            stubs.span_exporter.assert_called_once()
+            stubs.log_exporter.assert_called_once()
+            stubs.set_logger_provider.assert_called_once()
+            stubs.set_meter_provider.assert_called_once()
+
+            # per-job teardown never shut anything down...
+            mock_tracer_shutdown.assert_not_called()
+            stubs.meter_provider_cls.return_value.shutdown.assert_not_called()
+            # ...but flushed the exporters at the end of each job
+            assert stubs.span_batch.return_value.force_flush.call_count == 2
+            assert stubs.meter_provider_cls.return_value.force_flush.call_count == 2
+
+            # process exit shuts down everything the framework created, once
+            traces_mod._cloud.shutdown_at_exit()
+            mock_tracer_shutdown.assert_called_once()
+            stubs.meter_provider_cls.return_value.shutdown.assert_called_once()
+
+
+def test_export_gates_follow_job_lifecycle() -> None:
+    """Export is enabled only while a job that asked for it is running: a job
+    with traces/logs disabled — and the gap between jobs — must not upload."""
+    from livekit.agents.telemetry import traces as traces_mod
+    from livekit.agents.telemetry.traces import _shutdown_telemetry
+
+    with _stub_cloud_tracer_deps():
+        _setup_cloud_tracer_for_job(job_id="job-1")
+        cloud = traces_mod._cloud
+        assert cloud._span_gate is not None and cloud._span_gate.enabled
+        assert cloud._log_gate is not None and cloud._log_gate.enabled
+
+        _shutdown_telemetry()
+        assert not cloud._span_gate.enabled
+        assert not cloud._log_gate.enabled
+
+        # a later job that disabled traces must not re-open the span gate
+        _setup_cloud_tracer_for_job(job_id="job-2", enable_traces=False)
+        assert not cloud._span_gate.enabled
+        assert cloud._log_gate.enabled
+        _shutdown_telemetry()
+
+
+def test_gated_exporters_drop_data_while_disabled() -> None:
+    from opentelemetry.sdk._logs.export import LogRecordExportResult
+    from opentelemetry.sdk.trace.export import SpanExportResult
+
+    from livekit.agents.telemetry.traces import _GatedLogExporter, _GatedSpanExporter
+
+    inner = MagicMock()
+    gate = _GatedSpanExporter(inner)
+    assert gate.export([]) is SpanExportResult.SUCCESS
+    inner.export.assert_not_called()
+    gate.enabled = True
+    gate.export([])
+    inner.export.assert_called_once()
+
+    inner = MagicMock()
+    log_gate = _GatedLogExporter(inner)
+    assert log_gate.export([]) is LogRecordExportResult.SUCCESS
+    inner.export.assert_not_called()
+    log_gate.enabled = True
+    log_gate.export([])
+    inner.export.assert_called_once()
+
+
+def test_shutdown_telemetry_is_idempotent_and_safe_without_setup() -> None:
+    """_on_cleanup runs for every job, including ones that never initialized
+    recording; and a second teardown must not double-flush."""
+    from livekit.agents.telemetry.traces import _shutdown_telemetry
+
+    with _stub_cloud_tracer_deps() as stubs:
+        _shutdown_telemetry()  # no configure ran — must be a no-op
+
+        _setup_cloud_tracer_for_job()
+        _shutdown_telemetry()
+        _shutdown_telemetry()
+        assert stubs.span_batch.return_value.force_flush.call_count == 1
+
+
+def test_concurrent_jobs_keep_exporting_until_the_last_release() -> None:
+    """THREAD-mode workers run multiple jobs in one process: the first job's
+    cleanup must not turn off export or detach the log handler while another
+    job is still running."""
+    from livekit.agents.telemetry import traces as traces_mod
+    from livekit.agents.telemetry.traces import _shutdown_telemetry
+
+    with _stub_cloud_tracer_deps():
+        _setup_cloud_tracer_for_job(job_id="job-a")
+        _setup_cloud_tracer_for_job(job_id="job-b")
+        cloud = traces_mod._cloud
+        root = logging.getLogger()
+
+        _shutdown_telemetry()  # job A ends; job B is still running
+        assert cloud._span_gate is not None and cloud._span_gate.enabled
+        assert cloud.log_handler is not None and cloud.log_handler in root.handlers
+
+        _shutdown_telemetry()  # job B ends
+        assert not cloud._span_gate.enabled
+        assert cloud.log_handler not in root.handlers
+
+
+def test_shutdown_telemetry_leaves_foreign_log_handlers_attached() -> None:
+    """Only the framework's own OTLP handler is detached from the root logger."""
+    from opentelemetry.sdk._logs import LoggingHandler
+
+    from livekit.agents.telemetry import traces as traces_mod
+    from livekit.agents.telemetry.traces import _shutdown_telemetry
+
+    foreign_handler = LoggingHandler(logger_provider=MagicMock())
+    root = logging.getLogger()
+    root.addHandler(foreign_handler)
+    try:
+        with _stub_cloud_tracer_deps():
+            _setup_cloud_tracer_for_job()
+            ours = traces_mod._cloud.log_handler
+            assert ours is not None and ours in root.handlers
+
+            _shutdown_telemetry()
+            assert ours not in root.handlers
+        assert foreign_handler in root.handlers
+    finally:
+        root.removeHandler(foreign_handler)
+
+
+def test_flush_early_log_buffer_replays_into_framework_handler() -> None:
+    """Buffered crash logs replay into the framework's own OTLP handler — not
+    into an integrator's LoggingHandler that was installed on root first."""
+    from opentelemetry.sdk._logs import LoggingHandler
+
+    from livekit.agents.job import JobContext
+    from livekit.agents.telemetry.traces import _BufferingHandler
+
+    ctx = object.__new__(JobContext)
+    buffering = _BufferingHandler()
+    record = logging.LogRecord("test", logging.INFO, __file__, 1, "boom", None, None)
+    buffering.buffer.append(record)
+    ctx._early_log_handler = buffering
+
+    foreign_handler = MagicMock(spec=LoggingHandler)
+    framework_handler = MagicMock()
+    root = logging.getLogger()
+    root.addHandler(foreign_handler)  # like an integrator handler, installed first
+    root.addHandler(buffering)
+    root.addHandler(framework_handler)
+    try:
+        with patch("livekit.agents.job._cloud_log_handler", return_value=framework_handler):
+            ctx._flush_early_log_buffer(replay=True)
+    finally:
+        root.removeHandler(foreign_handler)
+        root.removeHandler(framework_handler)
+
+    framework_handler.emit.assert_called_once_with(record)
+    foreign_handler.emit.assert_not_called()
+    assert buffering not in root.handlers
+
+
+def test_meter_provider_skipped_when_integrator_set_a_custom_one() -> None:
+    """A non-SDK meter provider set by the integrator is left alone, and no
+    orphan reader is built (set_meter_provider would silently refuse ours)."""
+    with _stub_cloud_tracer_deps() as stubs:
+        stubs.meter_state["provider"] = MagicMock()  # custom, not Proxy/NoOp/SDK
+
+        _setup_cloud_tracer_for_job()
+
+    stubs.meter_provider_cls.assert_not_called()
+    stubs.set_meter_provider.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -973,7 +973,8 @@ def test_shutdown_telemetry_keeps_integrator_providers_alive() -> None:
 def test_framework_created_providers_live_for_the_process() -> None:
     """Providers the framework creates are reused by the next job in the process
     (the OTel logger/meter globals are set-once) and shut down only at process
-    exit — not per job, which previously left job 2+ on dead providers."""
+    exit — never per job: the set-once OTel globals cannot be replaced, so a
+    per-job shutdown would leave every later job on dead providers."""
     from opentelemetry.trace import NoOpTracerProvider
 
     from livekit.agents.telemetry import traces as traces_mod


### PR DESCRIPTION
otel registry is per process, so when threaded job handlers are used, we'd accidentally remove third-party otel providers when cloud tracers shut down.

this PR moves it to a per job tracer attachment.