### PR TITLE
fix: correctly handle SIGTERM/SIGINT even when sync functions block

### DIFF
--- a/livekit-agents/livekit/agents/cli/_legacy.py
+++ b/livekit-agents/livekit/agents/cli/_legacy.py
@@ -75,7 +75,10 @@ class _ToggleMode(Exception):
     pass
 
 
-class _ExitCli(BaseException):
+class _ExitCli(SystemExit):
+    # SystemExit rather than BaseException, mirroring cli.py: if the raise from
+    # the signal handler ever lands inside an asyncio task or callback, only
+    # SystemExit/KeyboardInterrupt are re-raised out of the event loop (#5856).
     pass
 
 

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -25,8 +25,20 @@ HANDLED_SIGNALS = (
     signal.SIGTERM,
 )
 
+# how long the exit scheduled on the event loop may go unserved before the
+# watchdog concludes the loop is blocked by synchronous code and preempts it
+# with a raise (see _run_worker._handle_exit). Kept well under the ~30s
+# SIGTERM→SIGKILL budget of common orchestrators so the drain still gets time.
+_EXIT_ESCALATION_TIMEOUT = 3.0
 
-class _ExitCli(BaseException):
+
+class _ExitCli(SystemExit):
+    # SystemExit rather than BaseException: a raise from the signal path can land
+    # at an arbitrary bytecode boundary of the main thread, i.e. inside whatever
+    # asyncio task or callback the loop happened to be executing. Task.__step and
+    # Handle._run re-raise only SystemExit/KeyboardInterrupt out of the event
+    # loop; any other BaseException is stored on the task / reported to the loop
+    # exception handler, silently swallowing the exit (#5856, #6724).
     pass
 
 
@@ -294,24 +306,82 @@ def _run_worker(server: AgentServer, args: proto.CliArgs) -> None:
     devmode = args.dev
     colored_logs = devmode or args.log_format == "colored"
 
-    exit_raised = False
-
-    def _handle_exit(sig: int, frame: FrameType | None) -> None:
-        nonlocal exit_raised
-        if exit_raised:
-            os._exit(1)
-        exit_raised = True
-        raise _ExitCli()
-
-    for sig in HANDLED_SIGNALS:
-        signal.signal(sig, _handle_exit)
-
     setup_logging(args.log_level, devmode=colored_logs, console=False, compact=args.simulation)
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
     loop.slow_callback_duration = 0.1  # 100ms
+
+    # exit signalling. A plain `signal.signal` handler runs on the main thread at
+    # an arbitrary bytecode boundary — raising from it can land inside whatever
+    # asyncio task or callback the loop is executing, killing an unrelated task
+    # (bad mid-drain) or never reaching run_until_complete at all (#5856, #6724).
+    # So the first signal only *schedules* the exit on the loop. If the scheduled
+    # callback doesn't run within _EXIT_ESCALATION_TIMEOUT, the loop is blocked by
+    # synchronous code (e.g. a request_fnc doing blocking I/O) and a raise is the
+    # only thing that can interrupt it: the watchdog re-signals with the handler
+    # switched to raise mode, so the raise lands in the frame that is actually
+    # blocking the loop.
+    exit_fut: asyncio.Future[None] = loop.create_future()
+    exit_raised = False
+    escalating = False
+    escalation_watchdog: threading.Timer | None = None
+
+    def _trigger_exit() -> None:
+        # runs on the event loop: the loop is healthy, no preemption needed
+        if escalation_watchdog is not None:
+            escalation_watchdog.cancel()
+        if not exit_fut.done():
+            exit_fut.set_result(None)
+
+    def _escalate_blocked_loop() -> None:
+        # watchdog thread: _trigger_exit never ran within the timeout
+        nonlocal escalating
+        escalating = True
+        main_thread_id = threading.main_thread().ident
+        if hasattr(signal, "pthread_kill") and main_thread_id is not None:
+            # deliver to the main thread at the OS level, so its blocking call
+            # (e.g. time.sleep) is interrupted and the handler runs right away
+            signal.pthread_kill(main_thread_id, signal.SIGTERM)
+        else:
+            # Windows: raise_signal targets this thread, so the handler only runs
+            # at the main thread's next bytecode boundary — best effort
+            signal.raise_signal(signal.SIGTERM)
+
+    def _handle_exit(sig: int, frame: FrameType | None) -> None:
+        nonlocal exit_raised, escalating, escalation_watchdog
+        if escalating:
+            escalating = False
+            # raise only while the scheduled exit is still unserved (the loop is
+            # provably blocked): the raise then lands inside the blocking frame,
+            # and _ExitCli (a SystemExit) is re-raised out of whatever task or
+            # callback that is, so run_until_complete sees it. If exit_fut is
+            # already resolved, the loop resumed and won the race with the
+            # watchdog — raising here could land after run_until_complete
+            # returned and skip the drain, so the stray re-signal is dropped.
+            if not exit_fut.done():
+                raise _ExitCli()
+            return
+        if exit_raised:
+            os._exit(1)
+        exit_raised = True
+        loop.call_soon_threadsafe(_trigger_exit)
+        escalation_watchdog = threading.Timer(_EXIT_ESCALATION_TIMEOUT, _escalate_blocked_loop)
+        escalation_watchdog.daemon = True
+        escalation_watchdog.start()
+
+    for sig in HANDLED_SIGNALS:
+        signal.signal(sig, _handle_exit)
+
+    def _loop_exception_handler(loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+        if isinstance(context.get("exception"), _ExitCli):
+            # a task preempted by the exit escalation; the shutdown path is
+            # already running, don't log it as an unretrieved task exception
+            return
+        loop.default_exception_handler(context)
+
+    loop.set_exception_handler(_loop_exception_handler)
 
     async def _worker_run(worker: AgentServer) -> None:
         try:
@@ -328,13 +398,28 @@ def _run_worker(server: AgentServer, args: proto.CliArgs) -> None:
 
     try:
         main_task = loop.create_task(_worker_run(server), name="worker_main_task_cli")
+
+        async def _wait_for_exit_or_main() -> None:
+            # the worker keeps running during drain: an exit must end this wait
+            # without cancelling main_task
+            await asyncio.wait({main_task, exit_fut}, return_when=asyncio.FIRST_COMPLETED)
+
         try:
-            loop.run_until_complete(main_task)
+            loop.run_until_complete(_wait_for_exit_or_main())
         except _ExitCli:
-            pass
+            pass  # the escalation raise, surfaced through the event loop
+
+        if escalation_watchdog is not None:
+            escalation_watchdog.cancel()
 
         # Second Ctrl+C force-exits.
         def _force_exit(sig: int, frame: FrameType | None) -> None:
+            nonlocal escalating
+            if escalating:
+                # a stray watchdog re-signal that lost the race with the loop
+                # resuming — not the operator asking for a force exit
+                escalating = False
+                return
             logger.warning("exiting forcefully", extra={"signal": sig})
             os._exit(1)
 

--- a/livekit-agents/livekit/agents/cli/cli.py
+++ b/livekit-agents/livekit/agents/cli/cli.py
@@ -345,9 +345,12 @@ def _run_worker(server: AgentServer, args: proto.CliArgs) -> None:
             # (e.g. time.sleep) is interrupted and the handler runs right away
             signal.pthread_kill(main_thread_id, signal.SIGTERM)
         else:
-            # Windows: raise_signal targets this thread, so the handler only runs
-            # at the main thread's next bytecode boundary — best effort
-            signal.raise_signal(signal.SIGTERM)
+            # Windows has no pthread_kill; re-raise SIGINT rather than SIGTERM:
+            # CPython's C-level handler sets the SIGINT event that time.sleep()
+            # and other sigint-aware waits block on, so those are interrupted
+            # immediately. Other blocking calls only observe the handler at the
+            # main thread's next bytecode boundary — best effort there.
+            signal.raise_signal(signal.SIGINT)
 
     def _handle_exit(sig: int, frame: FrameType | None) -> None:
         nonlocal exit_raised, escalating, escalation_watchdog

--- a/tests/test_cli_exit.py
+++ b/tests/test_cli_exit.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import signal
-import sys
 import threading
 import time
 from collections.abc import Iterator
@@ -39,7 +38,8 @@ pytestmark = [pytest.mark.unit, pytest.mark.no_concurrent]
 
 
 # ---------------------------------------------------------------------------
-# _ExitCli propagation through asyncio (the #6624 base-class fix)
+# _ExitCli propagation through asyncio — the SystemExit base class, adopted
+# from PR #6624, covering the #5856 (callback) and #6724 (task) landing cases
 # ---------------------------------------------------------------------------
 
 
@@ -85,13 +85,21 @@ def test_exit_cli_escapes_a_task() -> None:
             await asyncio.sleep(30)  # the worker's main task, still running
 
         main_task = loop.create_task(_main())
-        loop.call_soon(lambda: loop.create_task(_job_request_task()))
+        request_tasks: list[asyncio.Task[None]] = []
+        loop.call_soon(lambda: request_tasks.append(loop.create_task(_job_request_task())))
         loop.call_later(0.5, loop.stop)  # safety stop for the broken case
 
         with pytest.raises(_ExitCli):
             loop.run_until_complete(main_task)
     finally:
+        # drain the cancellation and retrieve the request task's exception so
+        # closing the loop doesn't emit destroyed-pending / never-retrieved noise
         main_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, _ExitCli):
+            loop.run_until_complete(main_task)
+        for task in request_tasks:
+            if task.done() and not task.cancelled():
+                task.exception()
         loop.close()
 
 
@@ -164,7 +172,7 @@ def _sigterm_main_thread_after(delay: float) -> threading.Timer:
     return timer
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal delivery")
+@pytest.mark.skipif(not hasattr(signal, "pthread_kill"), reason="needs signal.pthread_kill (POSIX)")
 def test_sigterm_triggers_graceful_shutdown() -> None:
     """One SIGTERM on a healthy loop: drain + aclose run and _run_worker returns."""
     server = _StubServer()
@@ -186,7 +194,7 @@ def test_sigterm_triggers_graceful_shutdown() -> None:
     assert elapsed < 5.0, f"shutdown took {elapsed:.1f}s — the exit signal was lost"
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal delivery")
+@pytest.mark.skipif(not hasattr(signal, "pthread_kill"), reason="needs signal.pthread_kill (POSIX)")
 def test_sigterm_with_blocked_event_loop_escalates() -> None:
     """The #6724 repro: SIGTERM arrives while a job-request task blocks the event
     loop with synchronous work. The watchdog must preempt the blocking frame so

--- a/tests/test_cli_exit.py
+++ b/tests/test_cli_exit.py
@@ -1,0 +1,217 @@
+"""Regression tests for #5856 / #6724: SIGTERM must reliably shut the worker down.
+
+``signal.signal`` handlers run on the main thread at an arbitrary bytecode
+boundary. The old handler raised ``_ExitCli`` directly, so the raise could land
+inside whatever asyncio task or callback the loop happened to be executing —
+asyncio stores any non-SystemExit/KeyboardInterrupt exception on the task
+("Task exception was never retrieved") and the loop keeps running, so the
+worker never drains and keeps accepting jobs.
+
+The fix has three parts, each covered here:
+  * ``_ExitCli`` derives from ``SystemExit``, the only class (besides
+    KeyboardInterrupt) that ``Task.__step`` / ``Handle._run`` re-raise out of
+    the event loop;
+  * the first signal only *schedules* the exit on the loop instead of raising,
+    so a healthy loop shuts down without any task being preempted;
+  * a watchdog escalates when the loop is blocked by synchronous code (the
+    #6724 repro: a ``request_fnc`` calling ``time.sleep``): it re-signals the
+    main thread so the raise lands in the frame that is blocking the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import signal
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from livekit.agents.cli import _legacy, proto
+from livekit.agents.cli.cli import _ExitCli, _run_worker
+
+pytestmark = [pytest.mark.unit, pytest.mark.no_concurrent]
+
+
+# ---------------------------------------------------------------------------
+# _ExitCli propagation through asyncio (the #6624 base-class fix)
+# ---------------------------------------------------------------------------
+
+
+def test_exit_cli_is_systemexit() -> None:
+    # Task.__step / Handle._run re-raise only SystemExit and KeyboardInterrupt;
+    # anything else is swallowed by the loop when the raise lands inside a task
+    # or callback
+    assert issubclass(_ExitCli, SystemExit)
+    assert issubclass(_legacy._ExitCli, SystemExit)
+
+
+def test_exit_cli_escapes_a_loop_callback() -> None:
+    # 5856: the raise lands inside Handle._run (a loop callback)
+    loop = asyncio.new_event_loop()
+    try:
+
+        def _raise_exit() -> None:
+            raise _ExitCli()
+
+        swallowed: list[dict[str, Any]] = []
+        loop.set_exception_handler(lambda _loop, ctx: swallowed.append(ctx))
+        loop.call_soon(_raise_exit)
+        loop.call_later(0.5, loop.stop)  # safety stop for the broken case
+
+        with pytest.raises(_ExitCli):
+            loop.run_forever()
+
+        assert not swallowed, "exit was reported to the exception handler instead of raised"
+    finally:
+        loop.close()
+
+
+def test_exit_cli_escapes_a_task() -> None:
+    # 6724: the raise lands inside a coroutine (e.g. _job_request_task while a
+    # request_fnc blocks); Task.__step must re-raise it out of the loop
+    loop = asyncio.new_event_loop()
+    try:
+
+        async def _job_request_task() -> None:
+            raise _ExitCli()
+
+        async def _main() -> None:
+            await asyncio.sleep(30)  # the worker's main task, still running
+
+        main_task = loop.create_task(_main())
+        loop.call_soon(lambda: loop.create_task(_job_request_task()))
+        loop.call_later(0.5, loop.stop)  # safety stop for the broken case
+
+        with pytest.raises(_ExitCli):
+            loop.run_until_complete(main_task)
+    finally:
+        main_task.cancel()
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# _run_worker end-to-end signal handling (stub server, real signals)
+# ---------------------------------------------------------------------------
+
+
+class _StubServer:
+    """Stands in for AgentServer: run() until aclose(), with an optional task
+    that blocks the event loop the way a synchronous request_fnc does."""
+
+    def __init__(self, *, block_loop_for: float = 0.0) -> None:
+        self._block_loop_for = block_loop_for
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._stopped: asyncio.Event | None = None
+        self.calls: list[str] = []
+        self.run_active_during_drain = False
+
+    async def run(self, *, devmode: bool, unregistered: bool) -> None:
+        self._loop = asyncio.get_running_loop()
+        self._stopped = asyncio.Event()
+        if self._block_loop_for > 0:
+
+            async def _blocking_job_request() -> None:
+                time.sleep(self._block_loop_for)  # noqa: ASYNC251
+
+            self._loop.create_task(_blocking_job_request())
+        await self._stopped.wait()
+
+    async def drain(self) -> None:
+        self.calls.append("drain")
+        # drain must run while run() is still active: jobs are joined by drain,
+        # and aclose() is what ends run()
+        self.run_active_during_drain = self._stopped is not None and not self._stopped.is_set()
+
+    async def aclose(self) -> None:
+        self.calls.append("aclose")
+        if self._stopped is not None:
+            self._stopped.set()
+
+    def force_finish_threadsafe(self) -> None:
+        """Test safety net: end run() so a regression fails by timing instead of
+        hanging pytest forever."""
+        if self._loop is not None and self._stopped is not None:
+            with contextlib.suppress(RuntimeError):
+                self._loop.call_soon_threadsafe(self._stopped.set)
+
+
+@contextlib.contextmanager
+def _run_worker_test_env() -> Iterator[None]:
+    """_run_worker installs signal handlers (and leaves force-exit ones behind on
+    purpose); restore the pytest process state afterwards."""
+    saved = {sig: signal.getsignal(sig) for sig in (signal.SIGINT, signal.SIGTERM)}
+    try:
+        with patch("livekit.agents.cli.cli.setup_logging"):
+            yield
+    finally:
+        for sig, handler in saved.items():
+            signal.signal(sig, handler)
+        asyncio.set_event_loop(None)
+
+
+def _sigterm_main_thread_after(delay: float) -> threading.Timer:
+    main_id = threading.main_thread().ident
+    assert main_id is not None
+    timer = threading.Timer(delay, lambda: signal.pthread_kill(main_id, signal.SIGTERM))
+    timer.daemon = True
+    timer.start()
+    return timer
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal delivery")
+def test_sigterm_triggers_graceful_shutdown() -> None:
+    """One SIGTERM on a healthy loop: drain + aclose run and _run_worker returns."""
+    server = _StubServer()
+    args = proto.CliArgs(log_level="DEBUG", dev=False)
+
+    with _run_worker_test_env():
+        _sigterm_main_thread_after(0.2)
+        safety = threading.Timer(8.0, server.force_finish_threadsafe)
+        safety.daemon = True
+        safety.start()
+
+        start = time.monotonic()
+        _run_worker(server, args)  # type: ignore[arg-type]
+        elapsed = time.monotonic() - start
+        safety.cancel()
+
+    assert server.calls == ["drain", "aclose"]
+    assert server.run_active_during_drain
+    assert elapsed < 5.0, f"shutdown took {elapsed:.1f}s — the exit signal was lost"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal delivery")
+def test_sigterm_with_blocked_event_loop_escalates() -> None:
+    """The #6724 repro: SIGTERM arrives while a job-request task blocks the event
+    loop with synchronous work. The watchdog must preempt the blocking frame so
+    drain starts long before the blocking call would have finished."""
+    block_for = 30.0
+    server = _StubServer(block_loop_for=block_for)
+    args = proto.CliArgs(log_level="DEBUG", dev=False)
+
+    with (
+        _run_worker_test_env(),
+        patch("livekit.agents.cli.cli._EXIT_ESCALATION_TIMEOUT", 0.25),
+    ):
+        # deliver while time.sleep() holds the loop; the handler must not lose it
+        _sigterm_main_thread_after(0.3)
+        safety = threading.Timer(8.0, server.force_finish_threadsafe)
+        safety.daemon = True
+        safety.start()
+
+        start = time.monotonic()
+        _run_worker(server, args)  # type: ignore[arg-type]
+        elapsed = time.monotonic() - start
+        safety.cancel()
+
+    assert server.calls == ["drain", "aclose"]
+    assert server.run_active_during_drain
+    assert elapsed < block_for / 2, (
+        f"shutdown took {elapsed:.1f}s — the blocked loop was never preempted"
+    )


### PR DESCRIPTION
fixes #6724