### PR TITLE
fix(mistral): inject dummy user when last turn is assistant

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
@@ -16,8 +16,14 @@ class MistralFormatData:
 
 def to_conversations_ctx(
     chat_ctx: llm.ChatContext,
+    *,
+    inject_dummy_user_message: bool = True,
 ) -> tuple[list[dict], MistralFormatData]:
     """Convert ChatContext to Mistral Conversations API entry format.
+
+    Mistral requires the last serving turn to be User or Tool (HTTP 400 /
+    code 3230 otherwise). When ``inject_dummy_user_message`` is True, append
+    a dummy user turn if the context ends on an assistant message.
 
     Returns:
         A tuple of (entries, instructions) where instructions is the extracted
@@ -65,7 +71,20 @@ def to_conversations_ctx(
                 }
             )
 
+    if inject_dummy_user_message and not _last_serving_role_ok(entries):
+        entries.append({"type": "message.input", "role": "user", "content": "."})
+
     return entries, MistralFormatData(instructions=instructions)
+
+
+def _last_serving_role_ok(entries: list[dict[str, Any]]) -> bool:
+    """True when the last entry is a user message or a tool result."""
+    if not entries:
+        return False
+    last = entries[-1]
+    if last.get("type") == "function.result":
+        return True
+    return last.get("type") == "message.input" or last.get("role") == "user"
 
 
 def _to_entry(item: llm.ChatItem) -> dict[str, Any] | None:

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -711,7 +711,7 @@ class ChatContext:
 
     @overload
     def to_provider_format(
-        self, format: Literal["mistralai"]
+        self, format: Literal["mistralai"], *, inject_dummy_user_message: bool = True
     ) -> tuple[list[dict], _provider_format.mistralai.MistralFormatData]: ...
 
     @overload
@@ -746,7 +746,7 @@ class ChatContext:
         elif format == "anthropic":
             return _provider_format.anthropic.to_chat_ctx(self, **kwargs)
         elif format == "mistralai":
-            return _provider_format.mistralai.to_conversations_ctx(self)
+            return _provider_format.mistralai.to_conversations_ctx(self, **kwargs)
         else:
             raise ValueError(f"Unsupported provider format: {format}")
 

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -875,3 +875,53 @@ def test_to_provider_format_non_object_tool_arguments(fmt: str, arguments: str):
 
     messages, _ = ctx.to_provider_format(format=fmt)
     assert _tool_call_input(fmt, messages) == {}
+
+
+def test_mistralai_injects_dummy_user_when_last_message_is_assistant():
+    """Mistral serving requires last role User or Tool; a trailing assistant 400s."""
+    ctx = ChatContext.empty()
+    ctx.add_message(role="user", content="Hello")
+    ctx.add_message(role="assistant", content="One moment...")
+
+    entries, _ = ctx.to_provider_format(format="mistralai")
+
+    assert entries[-1] == {"type": "message.input", "role": "user", "content": "."}
+    assert entries[-2] == {
+        "type": "message.output",
+        "role": "assistant",
+        "content": "One moment...",
+    }
+
+
+def test_mistralai_does_not_inject_when_last_is_user():
+    ctx = ChatContext.empty()
+    ctx.add_message(role="user", content="Hello")
+
+    entries, _ = ctx.to_provider_format(format="mistralai")
+
+    assert entries == [{"type": "message.input", "role": "user", "content": "Hello"}]
+
+
+def test_mistralai_does_not_inject_when_last_is_tool_result():
+    ctx = ChatContext.empty()
+    ctx.add_message(role="user", content="lookup")
+    ctx.insert(FunctionCall(call_id="c1", name="lookup", arguments="{}"))
+    ctx.insert(FunctionCallOutput(call_id="c1", name="lookup", output="ok", is_error=False))
+
+    entries, _ = ctx.to_provider_format(format="mistralai")
+
+    assert entries[-1] == {
+        "type": "function.result",
+        "tool_call_id": "c1",
+        "result": "ok",
+    }
+
+
+def test_mistralai_can_disable_dummy_user_injection():
+    ctx = ChatContext.empty()
+    ctx.add_message(role="user", content="Hello")
+    ctx.add_message(role="assistant", content="Hi")
+
+    entries, _ = ctx.to_provider_format(format="mistralai", inject_dummy_user_message=False)
+
+    assert entries[-1] == {"type": "message.output", "role": "assistant", "content": "Hi"}


### PR DESCRIPTION
Mistral's Conversations API returns 400 / code 3230 when the last turn is an assistant message. That's a valid LiveKit context after `with_filler()` or `generate_reply()` with no `user_input`.

The other formatters already inject a dummy user turn for this. Mistral's path never took `inject_dummy_user_message`, so the request went up as-is.

Fixes #7030

## Test plan
- [x] `uv run pytest tests/test_chat_ctx.py --unit` (61 passed, 1 skipped)
- [x] `ruff check` / `ruff format` on the touched files