### PR TITLE
fix(mistralai): support assistant-ending chat contexts

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
@@ -15,7 +15,7 @@ class MistralFormatData:
 
 
 def to_conversations_ctx(
-    chat_ctx: llm.ChatContext,
+    chat_ctx: llm.ChatContext, *, inject_dummy_user_message: bool = True
 ) -> tuple[list[dict], MistralFormatData]:
     """Convert ChatContext to Mistral Conversations API entry format.
 
@@ -64,6 +64,9 @@ def to_conversations_ctx(
                     "result": tool_output.output,
                 }
             )
+
+    if inject_dummy_user_message and entries and entries[-1].get("role") == "assistant":
+        entries.append({"type": "message.input", "role": "user", "content": "(empty)"})
 
     return entries, MistralFormatData(instructions=instructions)
 

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -711,7 +711,7 @@ class ChatContext:
 
     @overload
     def to_provider_format(
-        self, format: Literal["mistralai"]
+        self, format: Literal["mistralai"], *, inject_dummy_user_message: bool = True
     ) -> tuple[list[dict], _provider_format.mistralai.MistralFormatData]: ...
 
     @overload
@@ -746,7 +746,9 @@ class ChatContext:
         elif format == "anthropic":
             return _provider_format.anthropic.to_chat_ctx(self, **kwargs)
         elif format == "mistralai":
-            return _provider_format.mistralai.to_conversations_ctx(self)
+            return _provider_format.mistralai.to_conversations_ctx(
+                self, inject_dummy_user_message=inject_dummy_user_message
+            )
         else:
             raise ValueError(f"Unsupported provider format: {format}")
 

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -140,6 +140,33 @@ def test_chat_ctx_can_be_serialized_and_deserialized_with_defaults():
     assert chat_ctx.is_equivalent(ChatContext.from_dict(chat_ctx.to_dict()))
 
 
+def test_mistralai_format_injects_trailing_user_message_after_assistant():
+    from livekit.agents import ChatContext
+
+    chat_ctx = ChatContext.empty()
+    chat_ctx.add_message(role="user", content="Hello")
+    chat_ctx.add_message(role="assistant", content="Hi there")
+
+    messages, _ = chat_ctx.to_provider_format(format="mistralai")
+
+    assert messages[-1] == {
+        "type": "message.input",
+        "role": "user",
+        "content": "(empty)",
+    }
+
+
+def test_mistralai_format_can_skip_trailing_user_message_injection():
+    from livekit.agents import ChatContext
+
+    chat_ctx = ChatContext.empty()
+    chat_ctx.add_message(role="assistant", content="Hi there")
+
+    messages, _ = chat_ctx.to_provider_format(format="mistralai", inject_dummy_user_message=False)
+
+    assert messages == [{"type": "message.output", "role": "assistant", "content": "Hi there"}]
+
+
 @skip_if_no_credentials()
 async def test_summarize():
     from livekit.agents import ChatContext


### PR DESCRIPTION
## Summary

The Mistral Conversations API requires a user or tool entry after an assistant output when starting a new response. LiveKit can legitimately call `generate_reply()` with an assistant message at the end of the chat context, including after a filler message, but the Mistral formatter previously forwarded that context unchanged.

This change wires the existing dummy-user-message option through the Mistral provider formatter and appends an `(empty)` user input only when the formatted context ends with an assistant entry. The option can still be disabled explicitly.

## Tests

- `uv run --frozen pytest tests/test_chat_ctx.py --unit`: 59 passed, 1 skipped because LiveKit credentials are not configured.
- `uv run --frozen ruff check ...`: passed.
- `uv run --frozen ruff format --check ...`: passed after formatting.
- `git diff --check`: passed.

The repository-wide type-check script was started but did not produce output after approximately two minutes on the local Windows environment and was stopped; it was not reported as passing.
