### PR TITLE
fix(mistralai): handle trailing assistant messages

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
@@ -16,8 +16,17 @@ class MistralFormatData:
 
 def to_conversations_ctx(
     chat_ctx: llm.ChatContext,
+    *,
+    inject_dummy_user_message: bool = True,
 ) -> tuple[list[dict], MistralFormatData]:
     """Convert ChatContext to Mistral Conversations API entry format.
+
+    Args:
+        chat_ctx: The chat context to convert.
+        inject_dummy_user_message: If ``True`` (the default), a dummy user message
+            (``"."``) is appended when the last entry is an assistant message.
+            The Mistral Conversations API requires the inputs list to end with a
+            ``message.input`` (user) or ``function.result`` (tool) entry.
 
     Returns:
         A tuple of (entries, instructions) where instructions is the extracted
@@ -64,6 +73,15 @@ def to_conversations_ctx(
                     "result": tool_output.output,
                 }
             )
+
+    # Mistral Conversations API requires the last entry to be a user message
+    # (message.input) or tool result (function.result), not an assistant message.
+    if (
+        inject_dummy_user_message
+        and entries
+        and entries[-1]["type"] == "message.output"
+    ):
+        entries.append({"type": "message.input", "role": "user", "content": "."})
 
     return entries, MistralFormatData(instructions=instructions)
 

--- a/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/mistralai.py
@@ -76,11 +76,7 @@ def to_conversations_ctx(
 
     # Mistral Conversations API requires the last entry to be a user message
     # (message.input) or tool result (function.result), not an assistant message.
-    if (
-        inject_dummy_user_message
-        and entries
-        and entries[-1]["type"] == "message.output"
-    ):
+    if inject_dummy_user_message and entries and entries[-1]["type"] == "message.output":
         entries.append({"type": "message.input", "role": "user", "content": "."})
 
     return entries, MistralFormatData(instructions=instructions)

--- a/livekit-agents/livekit/agents/llm/chat_context.py
+++ b/livekit-agents/livekit/agents/llm/chat_context.py
@@ -711,7 +711,10 @@ class ChatContext:
 
     @overload
     def to_provider_format(
-        self, format: Literal["mistralai"]
+        self,
+        format: Literal["mistralai"],
+        *,
+        inject_dummy_user_message: bool = True,
     ) -> tuple[list[dict], _provider_format.mistralai.MistralFormatData]: ...
 
     @overload
@@ -746,7 +749,7 @@ class ChatContext:
         elif format == "anthropic":
             return _provider_format.anthropic.to_chat_ctx(self, **kwargs)
         elif format == "mistralai":
-            return _provider_format.mistralai.to_conversations_ctx(self)
+            return _provider_format.mistralai.to_conversations_ctx(self, **kwargs)
         else:
             raise ValueError(f"Unsupported provider format: {format}")
 

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -875,3 +875,62 @@ def test_to_provider_format_non_object_tool_arguments(fmt: str, arguments: str):
 
     messages, _ = ctx.to_provider_format(format=fmt)
     assert _tool_call_input(fmt, messages) == {}
+
+
+# ── Mistral trailing-assistant regression (issue #7030) ───────────────────────
+
+
+def test_mistral_formatter_trailing_assistant_injects_dummy_user():
+    """When ChatContext ends with an assistant message, the Mistral formatter must
+    append a dummy user message so the last entry is not message.output.
+
+    The Mistral Conversations API requires the inputs list to end with a user
+    (message.input) or tool-result (function.result) entry.  Sending a trailing
+    message.output causes the API to reject the request.
+    """
+    ctx = ChatContext.empty()
+    ctx.insert(ChatMessage(role="user", content=["Hello"]))
+    ctx.insert(ChatMessage(role="assistant", content=["Hi there!"]))
+
+    entries, _ = ctx.to_provider_format(format="mistralai")
+
+    # The last entry must NOT be a message.output (assistant)
+    assert entries[-1]["role"] != "assistant", (
+        f"Last entry is {entries[-1]['type']} / {entries[-1]['role']}, "
+        "but Mistral requires a user or tool entry at the end"
+    )
+    # The dummy user message should be present
+    assert entries[-1]["type"] == "message.input"
+    assert entries[-1]["role"] == "user"
+
+
+def test_mistral_formatter_trailing_tool_output_no_injection():
+    """When ChatContext ends with tool/function output, no dummy message is needed."""
+    ctx = ChatContext.empty()
+    ctx.insert(ChatMessage(role="user", content=["What's the weather?"]))
+    ctx.insert(FunctionCall(call_id="c1", name="get_weather", arguments="{}"))
+    ctx.insert(FunctionCallOutput(call_id="c1", name="get_weather", output="sunny", is_error=False))
+
+    entries, _ = ctx.to_provider_format(format="mistralai")
+
+    # Last entry is already a function.result – no dummy needed
+    assert entries[-1]["type"] == "function.result"
+
+
+def test_mistral_formatter_trailing_user_no_injection():
+    """When ChatContext ends with a user message, no dummy message is needed."""
+    ctx = ChatContext.empty()
+    ctx.insert(ChatMessage(role="user", content=["Hello"]))
+
+    entries, _ = ctx.to_provider_format(format="mistralai")
+
+    assert len(entries) == 1
+    assert entries[0]["type"] == "message.input"
+    assert entries[0]["role"] == "user"
+
+
+def test_mistral_formatter_empty_context():
+    """An empty ChatContext should produce no entries."""
+    ctx = ChatContext.empty()
+    entries, _ = ctx.to_provider_format(format="mistralai")
+    assert entries == []


### PR DESCRIPTION
## Summary

Fixes #7030.

Mistral's Conversations API requires the conversation input to end with a user message or a tool result.

When a LiveKit `ChatContext` ended with an assistant message, the Mistral formatter produced a trailing `message.output`, causing Mistral to reject the request.

This change appends a minimal user input when the formatted Mistral conversation would otherwise end with an assistant message.

## Changes

- handle assistant-ending contexts in the Mistral provider formatter
- support `inject_dummy_user_message` for the Mistral provider format
- preserve existing behavior for user-ending and tool-result-ending contexts
- add regression tests covering:
  - trailing assistant message
  - trailing user message
  - trailing tool result
  - empty context

## Testing

- Mistral regression tests: **4 passed**
- `tests/test_chat_ctx.py`: **61 passed, 1 skipped**
- Ruff: **all checks passed**
- `git diff --check`: **passed**

The skipped test requires LiveKit API credentials and is unrelated to this change.