### PR TITLE
fix(telemetry): prevent blocking shutdown offline

### DIFF
--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -344,12 +344,18 @@ def _setup_cloud_tracer(
         # Check if a tracer provider is not set and set one up
         # below shows how the ProxyTracerProvider is returned when none have been setup
         # https://github.com/open-telemetry/opentelemetry-python/blob/0018c0030bac9bdce4487fe5fcb3ec6a542ec904/opentelemetry-api/src/opentelemetry/trace/__init__.py#L555
+        #
+        # shutdown_on_exit=False: the SDK registers atexit handlers that call
+        # provider.shutdown() → worker_thread.join(30s).  When the OTLP endpoint
+        # is unreachable (offline / no network), the worker threads may be stuck
+        # exporting and the join blocks process exit.  We manage shutdown
+        # explicitly via _shutdown_telemetry() with a bounded wall-clock timeout.
         tracer_provider: trace_api.TracerProvider
         if isinstance(
             tracer._tracer_provider,
             (trace_api.ProxyTracerProvider, trace_api.NoOpTracerProvider),
         ):
-            tracer_provider = trace_sdk.TracerProvider(resource=resource)
+            tracer_provider = trace_sdk.TracerProvider(resource=resource, shutdown_on_exit=False)
             set_tracer_provider(tracer_provider)
         else:
             # attach the processor to the existing tracer provider
@@ -371,7 +377,7 @@ def _setup_cloud_tracer(
     # evaluations, and chat history, not just Python log export.
     logger_provider = get_logger_provider()
     if not isinstance(logger_provider, LoggerProvider):
-        logger_provider = LoggerProvider()
+        logger_provider = LoggerProvider(shutdown_on_exit=False)
         set_logger_provider(logger_provider)
 
     if enable_logs:
@@ -405,7 +411,9 @@ def _setup_cloud_tracer(
             },
         )
         reader = PeriodicExportingMetricReader(metric_exporter, export_interval_millis=30000)
-        meter_provider = SdkMeterProvider(resource=resource, metric_readers=[reader])
+        meter_provider = SdkMeterProvider(
+            resource=resource, metric_readers=[reader], shutdown_on_exit=False
+        )
         metrics_api.set_meter_provider(meter_provider)
 
 

--- a/tests/test_telemetry_shutdown.py
+++ b/tests/test_telemetry_shutdown.py
@@ -1,0 +1,118 @@
+"""Regression tests for issue #7029.
+
+``_setup_cloud_tracer`` must create OTel SDK providers with
+``shutdown_on_exit=False``.  The SDK default is ``True``, which registers
+``atexit`` handlers calling ``provider.shutdown() → worker_thread.join()``.
+When the OTLP endpoint is unreachable the worker threads may be stuck
+exporting, blocking process exit indefinitely.
+
+LiveKit manages shutdown explicitly via ``_shutdown_telemetry()`` with a
+bounded wall-clock timeout, so the SDK atexit handlers are redundant and
+dangerous.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+from opentelemetry import metrics as metrics_api
+from opentelemetry._logs import get_logger_provider
+from opentelemetry.sdk import trace as trace_sdk
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk.metrics import MeterProvider as SdkMeterProvider
+
+from livekit.agents.telemetry.traces import tracer
+
+pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
+
+
+_ENV = {**os.environ, "LIVEKIT_API_KEY": "dummy", "LIVEKIT_API_SECRET": "dummy"}
+
+
+def _setup() -> None:
+    """Call _setup_cloud_tracer with an unreachable endpoint."""
+    from livekit.agents.telemetry.traces import _setup_cloud_tracer
+
+    _setup_cloud_tracer(
+        room_id="room",
+        job_id="job",
+        agent_name="agent",
+        observability_url="http://127.0.0.1:1",
+        enable_traces=True,
+        enable_logs=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test A: providers must be created with shutdown_on_exit=False
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.no_concurrent
+def test_providers_created_without_atexit() -> None:
+    """All three OTel providers created by _setup_cloud_tracer must have
+    shutdown_on_exit=False so they don't register blocking atexit handlers."""
+    # save originals
+    orig_tp = tracer._tracer_provider
+    orig_lp = get_logger_provider()
+    orig_mp = metrics_api.get_meter_provider()
+    try:
+        _setup()
+
+        if isinstance(tracer._tracer_provider, trace_sdk.TracerProvider):
+            tp = tracer._tracer_provider
+            assert tp._atexit_handler is None, "TracerProvider must not register atexit handler"
+
+        lp = get_logger_provider()
+        if isinstance(lp, LoggerProvider):
+            assert lp._at_exit_handler is None, "LoggerProvider must not register atexit handler"
+
+        mp = metrics_api.get_meter_provider()
+        if isinstance(mp, SdkMeterProvider):
+            assert mp._atexit_handler is None, "MeterProvider must not register atexit handler"
+    finally:
+        from opentelemetry._logs import set_logger_provider
+
+        from livekit.agents.telemetry import set_tracer_provider
+
+        set_tracer_provider(orig_tp)  # type: ignore[arg-type]
+        set_logger_provider(orig_lp)  # type: ignore[arg-type]
+        metrics_api.set_meter_provider(orig_mp)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Test B: process with unreachable endpoint must exit promptly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.no_concurrent
+def test_offline_exit_no_hang() -> None:
+    """A process that sets up telemetry with an unreachable endpoint and
+    exits without calling _shutdown_telemetry must not hang on atexit."""
+    code = (
+        "from livekit.agents.telemetry.traces import _setup_cloud_tracer\n"
+        "_setup_cloud_tracer(\n"
+        "    room_id='r', job_id='j', agent_name='a',\n"
+        "    observability_url='http://127.0.0.1:1',\n"
+        "    enable_traces=True, enable_logs=True,\n"
+        ")\n"
+    )
+    start = time.monotonic()
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env=_ENV,
+    )
+    elapsed = time.monotonic() - start
+    assert result.returncode == 0, (
+        f"subprocess failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert elapsed < 5.0, (
+        f"Process took {elapsed:.1f}s to exit — likely deadlocked on atexit handler"
+    )

--- a/tests/test_telemetry_shutdown.py
+++ b/tests/test_telemetry_shutdown.py
@@ -2,7 +2,7 @@
 
 ``_setup_cloud_tracer`` must create OTel SDK providers with
 ``shutdown_on_exit=False``.  The SDK default is ``True``, which registers
-``atexit`` handlers calling ``provider.shutdown() → worker_thread.join()``.
+``atexit`` handlers calling ``provider.shutdown() -> worker_thread.join()``.
 When the OTLP endpoint is unreachable the worker threads may be stuck
 exporting, blocking process exit indefinitely.
 
@@ -17,6 +17,7 @@ import os
 import subprocess
 import sys
 import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 from opentelemetry import metrics as metrics_api
@@ -30,21 +31,30 @@ from livekit.agents.telemetry.traces import tracer
 pytestmark = [pytest.mark.unit, pytest.mark.concurrent]
 
 
-_ENV = {**os.environ, "LIVEKIT_API_KEY": "dummy", "LIVEKIT_API_SECRET": "dummy"}
+# Subprocess env: supply dummy credentials so AccessToken validation passes.
+# These are never sent anywhere — the endpoint is unreachable (127.0.0.1:1).
+_SUBPROCESS_ENV = {
+    **os.environ,
+    "LIVEKIT_API_KEY": "test-api-key",
+    "LIVEKIT_API_SECRET": "test-api-secret",
+}
 
 
-def _setup() -> None:
-    """Call _setup_cloud_tracer with an unreachable endpoint."""
+def _mocked_setup() -> None:
+    """Call _setup_cloud_tracer with a mocked AccessToken (no credentials needed)."""
     from livekit.agents.telemetry.traces import _setup_cloud_tracer
 
-    _setup_cloud_tracer(
-        room_id="room",
-        job_id="job",
-        agent_name="agent",
-        observability_url="http://127.0.0.1:1",
-        enable_traces=True,
-        enable_logs=True,
-    )
+    mock_token = MagicMock()
+    mock_token.to_jwt.return_value = "dummy.jwt.token"
+    with patch("livekit.api.AccessToken", return_value=mock_token):
+        _setup_cloud_tracer(
+            room_id="room",
+            job_id="job",
+            agent_name="agent",
+            observability_url="http://127.0.0.1:1",
+            enable_traces=True,
+            enable_logs=True,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -61,7 +71,7 @@ def test_providers_created_without_atexit() -> None:
     orig_lp = get_logger_provider()
     orig_mp = metrics_api.get_meter_provider()
     try:
-        _setup()
+        _mocked_setup()
 
         if isinstance(tracer._tracer_provider, trace_sdk.TracerProvider):
             tp = tracer._tracer_provider
@@ -107,7 +117,7 @@ def test_offline_exit_no_hang() -> None:
         capture_output=True,
         text=True,
         timeout=15,
-        env=_ENV,
+        env=_SUBPROCESS_ENV,
     )
     elapsed = time.monotonic() - start
     assert result.returncode == 0, (


### PR DESCRIPTION
## Summary

Fixes #7029.

OpenTelemetry providers register automatic `atexit` shutdown handlers by default.

When the OTLP endpoint is unavailable, those handlers can block process exit while waiting for exporter worker threads. LiveKit already has its own bounded telemetry shutdown path, so the SDK-owned `atexit` handlers are unnecessary.

This change disables automatic shutdown handlers for the tracer, logger, and meter providers created by LiveKit.

## Changes

- set `shutdown_on_exit=False` for `TracerProvider`
- set `shutdown_on_exit=False` for `LoggerProvider`
- set `shutdown_on_exit=False` for `MeterProvider`
- add regression coverage for:
  - providers not registering SDK-owned `atexit` handlers
  - offline process exiting without hanging

## Testing

- `tests/test_telemetry_shutdown.py`: 2 passed
- existing telemetry tests: 18 passed
- Ruff lint: passed
- Ruff format: passed
- `git diff --check`: passed

Normal telemetry exporting behavior is unchanged. The change only disables the SDK's automatic process-exit shutdown path.