### PR TITLE
feat(inference): add Cartesia Sonic 3.6 TTS types

### DIFF
--- a/livekit-agents/livekit/agents/inference/tts.py
+++ b/livekit-agents/livekit/agents/inference/tts.py
@@ -106,6 +106,7 @@ CartesiaLocale = (
         "en-NZ",
         "en-SG",
         "en-AU",
+        "hi-IN",
         "es-ES",
         "es-MX",
         "es-US",
@@ -165,6 +166,15 @@ TTSModels = (
     | XaiModels
     | FishAudioModels
 )
+
+
+def _validate_cartesia_options(
+    model: str,
+    language: NotGivenOr[str],
+    extra_kwargs: dict[str, Any],
+) -> None:
+    if model.split("/")[0] == "cartesia" and is_given(language) and "locale" in extra_kwargs:
+        raise ValueError("Cartesia TTS accepts either language or locale, not both")
 
 
 def _parse_model_string(model: str) -> tuple[str, str | None]:
@@ -539,6 +549,7 @@ class TTS(tts.TTS):
                 voice = parsed_voice
 
         resolved_extra_kwargs = dict(extra_kwargs) if is_given(extra_kwargs) else {}
+        _validate_cartesia_options(model, language, resolved_extra_kwargs)
         super().__init__(
             capabilities=tts.TTSCapabilities(
                 streaming=True,
@@ -726,14 +737,19 @@ class TTS(tts.TTS):
             language (str, optional): Language code for the TTS model.
             extra_kwargs (dict, optional): Extra kwargs to pass to the TTS model.
         """
-        if is_given(model):
-            self._opts.model = model
+        updated_model = model if is_given(model) else self._opts.model
+        updated_language = LanguageCode(language) if is_given(language) else self._opts.language
+        updated_extra_kwargs = self._opts.extra_kwargs.copy()
+        if is_given(extra_kwargs):
+            updated_extra_kwargs.update(extra_kwargs)
+
+        _validate_cartesia_options(updated_model, updated_language, updated_extra_kwargs)
+
+        self._opts.model = updated_model
+        self._opts.language = updated_language
+        self._opts.extra_kwargs = updated_extra_kwargs
         if is_given(voice):
             self._opts.voice = voice
-        if is_given(language):
-            self._opts.language = LanguageCode(language)
-        if is_given(extra_kwargs):
-            self._opts.extra_kwargs.update(extra_kwargs)
 
         self._capabilities.aligned_transcript = _has_aligned_transcript(
             self._opts.model, self._opts.extra_kwargs

--- a/livekit-agents/livekit/agents/inference/tts.py
+++ b/livekit-agents/livekit/agents/inference/tts.py
@@ -40,6 +40,7 @@ from ._utils import (
 
 CartesiaModels = Literal[
     "cartesia",
+    "cartesia/sonic-3.6",
     "cartesia/sonic-3.5",
     "cartesia/sonic-3",
     "cartesia/sonic-2",
@@ -48,6 +49,75 @@ CartesiaModels = Literal[
     "cartesia/sonic-3-latest",
     "cartesia/sonic-latest",
 ]
+CartesiaLanguage = Literal[
+    "en",
+    "de",
+    "es",
+    "fr",
+    "ja",
+    "pt",
+    "zh",
+    "hi",
+    "ko",
+    "it",
+    "nl",
+    "pl",
+    "ru",
+    "sv",
+    "tr",
+    "tl",
+    "bg",
+    "ro",
+    "ar",
+    "cs",
+    "el",
+    "fi",
+    "hr",
+    "ms",
+    "sk",
+    "da",
+    "ta",
+    "uk",
+    "hu",
+    "no",
+    "vi",
+    "bn",
+    "th",
+    "he",
+    "ka",
+    "id",
+    "te",
+    "gu",
+    "kn",
+    "ml",
+    "mr",
+    "pa",
+    "or",
+    "ur",
+]
+CartesiaLocale = (
+    CartesiaLanguage
+    | Literal[
+        "en-GB",
+        "en-US",
+        "en-IN",
+        "en-IE",
+        "en-ZA",
+        "en-NZ",
+        "en-SG",
+        "en-AU",
+        "es-ES",
+        "es-MX",
+        "es-US",
+        "fr-FR",
+        "fr-CA",
+        "nl-NL",
+        "nl-BE",
+        "pt-PT",
+        "pt-BR",
+    ]
+)
+CartesiaNormalization = Literal["auto", "off"] | CartesiaLocale
 DeepgramModels = Literal[
     "deepgram",
     "deepgram/aura",
@@ -160,6 +230,8 @@ def _normalize_fallback(
 
 
 class CartesiaOptions(TypedDict, total=False):
+    locale: CartesiaLocale  # sonic-3.6+; mutually exclusive with language
+    normalization: CartesiaNormalization  # sonic-3.6+
     emotion: str
     speed: Literal["slow", "normal", "fast"] | float
     volume: float
@@ -269,7 +341,7 @@ class TTS(tts.TTS):
         model: CartesiaModels,
         *,
         voice: NotGivenOr[str] = NOT_GIVEN,
-        language: NotGivenOr[str] = NOT_GIVEN,
+        language: NotGivenOr[CartesiaLanguage] = NOT_GIVEN,
         encoding: NotGivenOr[TTSEncoding] = NOT_GIVEN,
         sample_rate: NotGivenOr[int] = NOT_GIVEN,
         base_url: NotGivenOr[str] = NOT_GIVEN,

--- a/tests/test_inference_tts_alignment.py
+++ b/tests/test_inference_tts_alignment.py
@@ -12,7 +12,7 @@ import pytest
 import livekit.agents.inference.tts as inference_tts
 from livekit.agents import APIConnectOptions
 from livekit.agents.inference._utils import HEADER_SESSION_ID
-from livekit.agents.inference.tts import TTS, CartesiaLanguage
+from livekit.agents.inference.tts import TTS, CartesiaLanguage, CartesiaLocale
 from livekit.agents.types import USERDATA_TIMED_TRANSCRIPT
 
 pytestmark = pytest.mark.unit
@@ -20,9 +20,46 @@ pytestmark = pytest.mark.unit
 
 def test_cartesia_sonic_36_languages() -> None:
     languages = set(get_args(CartesiaLanguage))
+    locales = set(get_args(get_args(CartesiaLocale)[1]))
 
     assert len(languages) == 44
     assert {"or", "ur"} <= languages
+    assert "hi-IN" in locales
+
+
+def test_cartesia_language_and_locale_are_mutually_exclusive() -> None:
+    with pytest.raises(ValueError, match="either language or locale"):
+        TTS(
+            model="cartesia/sonic-3.6",
+            language="hi",
+            api_key="test-key",
+            api_secret="test-secret",
+            extra_kwargs={"locale": "hi-IN"},
+        )
+
+
+def test_cartesia_update_options_rejects_language_and_locale_atomically() -> None:
+    language_tts = TTS(
+        model="cartesia/sonic-3.6",
+        language="hi",
+        api_key="test-key",
+        api_secret="test-secret",
+    )
+    with pytest.raises(ValueError, match="either language or locale"):
+        language_tts.update_options(extra_kwargs={"locale": "hi-IN"})
+
+    assert "locale" not in language_tts._opts.extra_kwargs
+
+    locale_tts = TTS(
+        model="cartesia/sonic-3.6",
+        api_key="test-key",
+        api_secret="test-secret",
+        extra_kwargs={"locale": "hi-IN"},
+    )
+    with pytest.raises(ValueError, match="either language or locale"):
+        locale_tts.update_options(language="hi")
+
+    assert not isinstance(locale_tts._opts.language, str)
 
 
 class _FakeWebSocket:

--- a/tests/test_inference_tts_alignment.py
+++ b/tests/test_inference_tts_alignment.py
@@ -4,7 +4,7 @@ import base64
 import json
 from collections import deque
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, get_args
 
 import aiohttp
 import pytest
@@ -12,10 +12,17 @@ import pytest
 import livekit.agents.inference.tts as inference_tts
 from livekit.agents import APIConnectOptions
 from livekit.agents.inference._utils import HEADER_SESSION_ID
-from livekit.agents.inference.tts import TTS
+from livekit.agents.inference.tts import TTS, CartesiaLanguage
 from livekit.agents.types import USERDATA_TIMED_TRANSCRIPT
 
 pytestmark = pytest.mark.unit
+
+
+def test_cartesia_sonic_36_languages() -> None:
+    languages = set(get_args(CartesiaLanguage))
+
+    assert len(languages) == 44
+    assert {"or", "ur"} <= languages
 
 
 class _FakeWebSocket:
@@ -133,3 +140,36 @@ async def test_connection_retains_header_session_id(monkeypatch: pytest.MonkeyPa
     assert http_session.headers[HEADER_SESSION_ID] == "inference_connection"
     assert connection.session_id == "inference_connection"
     assert connection.ws is websocket
+
+
+async def test_cartesia_sonic_36_session_configuration() -> None:
+    websocket = _FakeWebSocket([{"type": "session.created", "session_id": "session-1"}])
+
+    class _FakeHTTPSession:
+        async def ws_connect(self, url: str, *, headers: dict[str, str]) -> _FakeWebSocket:
+            assert url.endswith("/tts?model=cartesia/sonic-3.6")
+            return websocket
+
+    tts = TTS(
+        model="cartesia/sonic-3.6",
+        voice="voice-id",
+        api_key="test-key",
+        api_secret="test-secret",
+        base_url="https://example.livekit.cloud",
+        http_session=_FakeHTTPSession(),  # type: ignore[arg-type]
+        extra_kwargs={"locale": "en-GB", "normalization": "en-GB"},
+    )
+
+    await tts._connect_ws(timeout=1.0)
+
+    assert websocket.sent == [
+        {
+            "type": "session.create",
+            "sample_rate": "24000",
+            "encoding": "pcm_s16le",
+            "extra": {"locale": "en-GB", "normalization": "en-GB"},
+            "voice": "voice-id",
+            "model": "cartesia/sonic-3.6",
+            "connection": {"timeout": 10.0, "retries": 3},
+        }
+    ]


### PR DESCRIPTION
## Summary

- add the explicit cartesia/sonic-3.6 model identifier to LiveKit Inference TTS
- type all 44 Sonic 3.6 languages, including the new Odia and Urdu codes
- add the Sonic 3.6 locale and locale-aware normalization options
- cover the model and options in the inference session payload test

Cartesia release documentation: https://docs.cartesia.ai/build-with-cartesia/tts-models/latest

A corresponding model allowlist update is required in the LiveKit Inference gateway before the explicit model identifier is available at runtime.

## Testing

- uv run pytest tests/test_inference_tts_alignment.py
- uv run ruff format livekit-agents/livekit/agents/inference/tts.py tests/test_inference_tts_alignment.py
- uv run ruff check livekit-agents/livekit/agents/inference/tts.py tests/test_inference_tts_alignment.py
- uv run --group typing mypy --platform linux -p livekit.agents