### PR TITLE
fix(google): don't let closing the TTS input generator mask the real error

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/tts.py
@@ -468,7 +468,12 @@ class SynthesizeStream(tts.SynthesizeStream):
         except GoogleAPICallError as e:
             raise APIStatusError(e.message, status_code=e.code or -1, body=f"{e.details}") from e
         finally:
-            await input_gen.aclose()
+            # the transport may still be parked inside input_gen; closing it then raises
+            # RuntimeError and would mask the real error
+            try:
+                await input_gen.aclose()
+            except Exception:
+                pass
 
 
 def _gender_from_str(gender: str) -> SsmlVoiceGender:

--- a/tests/test_plugin_google_tts_stream_close.py
+++ b/tests/test_plugin_google_tts_stream_close.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from google.api_core.exceptions import DeadlineExceeded
+from google.cloud import texttospeech
+
+from livekit.agents import APITimeoutError, tokenize
+from livekit.plugins.google.tts import TTS
+
+pytestmark = pytest.mark.plugin("google")
+
+
+@pytest.mark.asyncio
+async def test_input_gen_close_does_not_mask_api_error() -> None:
+    """gRPC drives input_gen from its own task, so closing it must not replace the real error."""
+    tts = TTS(credentials_info={"type": "service_account"})
+
+    parked = asyncio.Event()
+    consumer: asyncio.Task[None] | None = None
+
+    async def fake_streaming_synthesize(input_gen, timeout=None):  # noqa: ANN001
+        nonlocal consumer
+
+        async def consume() -> None:
+            async for _ in input_gen:
+                parked.set()
+
+        consumer = asyncio.create_task(consume())
+        await parked.wait()  # first request yielded; generator now awaits the next sentence
+        await asyncio.sleep(0)
+        raise DeadlineExceeded("deadline exceeded")
+
+    client = MagicMock()
+    client.streaming_synthesize = fake_streaming_synthesize
+    tts._client = client
+
+    stream = tts.stream()
+    input_stream = tokenize.basic.SentenceTokenizer().stream()
+    try:
+        with pytest.raises(APITimeoutError):
+            await stream._run_stream(
+                input_stream,
+                MagicMock(),
+                texttospeech.StreamingSynthesizeConfig(),
+            )
+    finally:
+        if consumer is not None:
+            consumer.cancel()
+        await stream.aclose()


### PR DESCRIPTION
`SynthesizeStream._run_stream` hands `input_gen` to the grpc client, which drives it from its own task. when the call fails, that task is usually still parked inside the generator waiting for the next sentence, so the `await input_gen.aclose()` in the `finally` raises

```
RuntimeError: aclose(): asynchronous generator is already running
```

and that replaces the `APITimeoutError` / `APIStatusError` the caller was meant to see. it shows up on interrupted turns and on deadline exceeded, so it reads as intermittent.

same race and same fix as #4766, which guarded the `aclose()` calls in `utils/aio/itertools.py`.

added `tests/test_plugin_google_tts_stream_close.py`: a fake client consumes `input_gen` from a background task, then raises `DeadlineExceeded`. it fails on main with the RuntimeError and passes with the guard.
