### PR TITLE
fix: unblock avatar audio after lost stream trailer

### DIFF
--- a/livekit-agents/livekit/agents/voice/avatar/_datastream_io.py
+++ b/livekit-agents/livekit/agents/voice/avatar/_datastream_io.py
@@ -420,7 +420,9 @@ class DataStreamAudioReceiver(AudioReceiver):
 
         # A new stream means the previous segment has ended. Close a reader whose
         # trailer was lost so its receive loop can advance to the new segment.
-        if self._current_reader is not None:
+        if self._stream_readers:
+            self._stream_readers[-1].close()
+        elif self._current_reader is not None:
             self._current_reader.close()
 
         self._stream_readers.append(reader)

--- a/livekit-agents/livekit/agents/voice/avatar/_datastream_io.py
+++ b/livekit-agents/livekit/agents/voice/avatar/_datastream_io.py
@@ -402,24 +402,29 @@ class DataStreamAudioReceiver(AudioReceiver):
             self.emit("clear_buffer")
             return "ok"
 
-        def _handle_stream_received(
-            reader: rtc.ByteStreamReader, remote_participant_id: str
-        ) -> None:
-            if (
-                not self._remote_participant
-                or remote_participant_id != self._remote_participant.identity
-            ):
-                return
-
-            self._stream_readers.append(reader)
-            self._stream_reader_changed.set()
-
         self._register_clear_buffer_rpc(
             self._room,
             caller_identity=self._remote_participant.identity,
             handler=_handle_clear_buffer,
         )
-        self._room.register_byte_stream_handler(AUDIO_STREAM_TOPIC, _handle_stream_received)
+        self._room.register_byte_stream_handler(AUDIO_STREAM_TOPIC, self._handle_stream_received)
+
+    def _handle_stream_received(
+        self, reader: rtc.ByteStreamReader, remote_participant_id: str
+    ) -> None:
+        if (
+            not self._remote_participant
+            or remote_participant_id != self._remote_participant.identity
+        ):
+            return
+
+        # A new stream means the previous segment has ended. Close a reader whose
+        # trailer was lost so its receive loop can advance to the new segment.
+        if self._current_reader is not None:
+            self._current_reader.close()
+
+        self._stream_readers.append(reader)
+        self._stream_reader_changed.set()
 
     def notify_playback_finished(self, playback_position: float, interrupted: bool) -> None:
         self._rpc_send_ch.send_nowait(

--- a/tests/test_datastream_io.py
+++ b/tests/test_datastream_io.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from livekit.agents.voice.avatar._datastream_io import DataStreamAudioReceiver
+
+
+class _Reader:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.unit
+def test_new_audio_stream_closes_reader_with_lost_trailer() -> None:
+    receiver = DataStreamAudioReceiver(SimpleNamespace(), sender_identity="sender")
+    receiver._remote_participant = SimpleNamespace(identity="sender")
+    current = _Reader()
+    next_reader = _Reader()
+    receiver._current_reader = current
+
+    receiver._handle_stream_received(next_reader, "sender")
+
+    assert current.closed
+    assert receiver._stream_readers == [next_reader]
+    assert receiver._stream_reader_changed.is_set()

--- a/tests/test_datastream_io.py
+++ b/tests/test_datastream_io.py
@@ -28,3 +28,21 @@ def test_new_audio_stream_closes_reader_with_lost_trailer() -> None:
     assert current.closed
     assert receiver._stream_readers == [next_reader]
     assert receiver._stream_reader_changed.is_set()
+
+
+@pytest.mark.unit
+def test_new_audio_stream_closes_last_queued_reader_with_lost_trailer() -> None:
+    receiver = DataStreamAudioReceiver(SimpleNamespace(), sender_identity="sender")
+    receiver._remote_participant = SimpleNamespace(identity="sender")
+    current = _Reader()
+    queued = _Reader()
+    next_reader = _Reader()
+    receiver._current_reader = current
+    receiver._stream_readers.append(queued)
+
+    receiver._handle_stream_received(next_reader, "sender")
+
+    assert not current.closed
+    assert queued.closed
+    assert receiver._stream_readers == [queued, next_reader]
+    assert receiver._stream_reader_changed.is_set()


### PR DESCRIPTION
## Summary

When an avatar audio stream loses its trailer, `DataStreamAudioReceiver` can remain blocked on that reader forever even after later audio streams arrive. This change closes the stale reader when a subsequent stream is received, allowing the receiver to emit the pending segment end and process queued audio.

## Testing

- `uv run --package livekit-agents --with pytest python -m pytest tests/test_datastream_io.py -q`
- `uv run --package livekit-agents ruff check livekit-agents/livekit/agents/voice/avatar/_datastream_io.py tests/test_datastream_io.py`
- `git diff --check`
