### PR TITLE
fix(openai): add "fast" to the responses ServiceTier literal

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -47,7 +47,7 @@ from ..log import logger
 from ..models import _supports_reasoning_effort
 from ..tools import OpenAITool
 
-ServiceTier = Literal["auto", "default", "flex", "scale", "priority"]
+ServiceTier = Literal["auto", "default", "flex", "scale", "priority", "fast"]
 Verbosity = Literal["low", "medium", "high"]
 
 OPENAI_RESPONSES_WS_URL = "wss://api.openai.com/v1/responses"


### PR DESCRIPTION
OpenAI renamed "Priority processing" to "Fast mode" on 2026-07-30 and changed the accepted `service_tier` values ([docs](https://developers.openai.com/api/docs/guides/priority-processing), [FAQ](https://help.openai.com/en/articles/11647665-priority-processing-faq)). `fast` and `priority` are aliases for the same tier: a request with `service_tier="fast"` succeeds, and the response still reports `service_tier="priority"`.

The `ServiceTier` literal in the responses LLM predates the rename, so passing `service_tier="fast"` needs a `cast` today. This PR adds `"fast"` to the literal, in the same member order as the openai SDK's own type (checked on openai 2.53.0: `Literal["auto", "default", "flex", "scale", "priority", "fast"]`).

Note that the API no longer accepts `"scale"`. Requesting it on chat completions fails (verified against the live API on 2026-08-30):

```
Error code: 400 - {'error': {'message': "Invalid value: 'scale'. Supported values are: 'auto', 'default', 'fast', 'flex', and 'priority'.", 'type': 'invalid_request_error', 'param': 'service_tier', 'code': 'invalid_value'}}
```

So the API currently accepts `auto`, `default`, `fast`, `flex`, `priority`. I kept `"scale"` in the literal so existing type-checked callers don't break; whether to deprecate or remove it is up to you.

For awareness, two related spots left untouched: the chat-completions path types `service_tier` as plain `str`, and `livekit-agents/livekit/agents/inference/llm.py` has the same pre-rename literal for the LiveKit inference gateway, which defines its own accepted set.
