### PR TITLE
fix: handle google/gemini-3.5-flash thought token leak in inference

### DIFF
--- a/livekit/agents/inference/llm.py
+++ b/livekit/agents/inference/llm.py
@@ -1,0 +1,606 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+import httpx
+import openai
+from openai.types.chat import (
+    ChatCompletionChunk,
+    ChatCompletionMessageParam,
+    ChatCompletionPredictionContentParam,
+    ChatCompletionToolChoiceOptionParam,
+    ChatCompletionToolParam,
+    completion_create_params,
+)
+from openai.types.chat.chat_completion_chunk import Choice
+from openai.types.shared.reasoning_effort import ReasoningEffort
+from openai.types.shared_params import Metadata
+from typing_extensions import TypedDict
+
+from .. import llm
+from .._exceptions import APIConnectionError, APIStatusError, APITimeoutError
+from ..llm import ToolChoice, utils as llm_utils
+from ..llm.chat_context import ChatContext
+from ..llm.tool_context import Tool
+from ..log import logger
+from ..types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, APIConnectOptions, NotGivenOr
+from ..utils import is_given
+from ._utils import (
+    HEADER_INFERENCE_PROVIDER,
+    create_access_token,
+    extract_quota_usage,
+    get_default_inference_url,
+    get_inference_headers,
+)
+
+lk_oai_debug = int(os.getenv("LK_OPENAI_DEBUG", 0))
+
+# Reasoning models don't support sampling parameters.
+# See: https://platform.openai.com/docs/guides/reasoning
+_REASONING_UNSUPPORTED_PARAMS: set[str] = {
+    "temperature",
+    "top_p",
+    "presence_penalty",
+    "frequency_penalty",
+    "logit_bias",
+    "logprobs",
+    "top_logprobs",
+    "n",
+}
+
+# xAI reasoning models only restrict presence_penalty, frequency_penalty, stop.
+# They still support temperature and top_p.
+_XAI_REASONING_UNSUPPORTED_PARAMS: set[str] = {
+    "presence_penalty",
+    "frequency_penalty",
+    "stop",
+}
+
+# Model prefix -> set of param names that should be dropped
+_UNSUPPORTED_PARAMS: dict[str, set[str]] = {
+    "o1": _REASONING_UNSUPPORTED_PARAMS,
+    "o3": _REASONING_UNSUPPORTED_PARAMS,
+    "o4": _REASONING_UNSUPPORTED_PARAMS,
+    "gpt-5": _REASONING_UNSUPPORTED_PARAMS,
+    "grok-4-1-fast-reasoning": _XAI_REASONING_UNSUPPORTED_PARAMS,
+    "grok-4.20-0309-reasoning": _XAI_REASONING_UNSUPPORTED_PARAMS,
+    "grok-4.20-multi-agent": _XAI_REASONING_UNSUPPORTED_PARAMS,
+}
+
+# models that don't support reasoning_effort when function tools are present
+_REASONING_EFFORT_TOOL_INCOMPATIBLE_PREFIXES: set[str] = {"gpt-5.2", "gpt-5.4"}
+
+_MODEL_THINK_TAGS = {
+    "google/gemma-4-31b-it": ("<|channel>thought", "<channel|>"),
+        "google/gemini-3.5-flash": ("thought", ""),
+}
+
+
+def drop_unsupported_params(
+    model: str, params: dict[str, Any], tools: list[Any] | None = None
+) -> dict[str, Any]:
+    """Remove parameters that are not supported by the given model.
+
+    Strips any provider prefix (e.g. ``openai/o3-pro`` -> ``o3-pro``) before
+    matching against known model prefixes.
+    """
+    model_name = model.split("/")[-1] if "/" in model else model
+    for prefix, unsupported in _UNSUPPORTED_PARAMS.items():
+        if model_name.startswith(prefix):
+            params = {k: v for k, v in params.items() if k not in unsupported}
+            break
+    if tools and any(
+        model_name.startswith(p) for p in _REASONING_EFFORT_TOOL_INCOMPATIBLE_PREFIXES
+    ):
+        params = {k: v for k, v in params.items() if k != "reasoning_effort"}
+    return params
+
+
+# lowest supported reasoning effort per model; "none" requires gpt-5.1+
+_MIN_REASONING_EFFORT: dict[str, ReasoningEffort] = {
+    "gpt-5.1": "none",
+    "gpt-5.2": "none",
+    "gpt-5.4": "none",
+    "gpt-5.4-mini": "none",
+    "gpt-5": "minimal",
+    "gpt-5-mini": "minimal",
+    "gpt-5-nano": "minimal",
+}
+
+
+def min_reasoning_effort(model: str) -> ReasoningEffort | None:
+    """Lowest reasoning effort the model supports, or None if the model has no
+    reasoning-effort control.
+
+    Strips any provider prefix (e.g. ``openai/gpt-5`` -> ``gpt-5``) before matching.
+    """
+    return _MIN_REASONING_EFFORT.get(model.split("/")[-1])
+
+
+OpenAIModels = Literal[
+    "openai/gpt-4o",
+    "openai/gpt-4o-mini",
+    "openai/gpt-4.1",
+    "openai/gpt-4.1-mini",
+    "openai/gpt-4.1-nano",
+    "openai/gpt-5",
+    "openai/gpt-5-mini",
+    "openai/gpt-5-nano",
+    "openai/gpt-5.1",
+    "openai/gpt-5.1-chat-latest",
+    "openai/gpt-5.2",
+    "openai/gpt-5.2-chat-latest",
+    "openai/gpt-5.3-chat-latest",
+    "openai/gpt-5.4",
+    "openai/gpt-5.4-mini",
+    "openai/gpt-5.4-nano",
+    "openai/gpt-5.5",
+    "openai/chat-latest",
+    "openai/gpt-oss-120b",
+]
+
+GoogleModels = Literal[
+    "google/gemini-3.1-pro",
+    "google/gemini-3-flash",
+    "google/gemini-3.1-flash-lite",
+    "google/gemini-3.5-flash",
+    "google/gemini-2.5-pro",
+    "google/gemini-2.5-flash",
+    "google/gemini-2.5-flash-lite",
+]
+
+KimiModels = Literal[
+    "moonshotai/kimi-k2.5",
+    "moonshotai/kimi-k2.6",
+]
+
+DeepSeekModels = Literal[
+    "deepseek-ai/deepseek-v3",
+    "deepseek-ai/deepseek-v3.2",
+]
+
+ZAIModels = Literal["zai/glm-5.1"]
+
+XAIModels = Literal[
+    "xai/grok-4-1-fast-non-reasoning",
+    "xai/grok-4-1-fast-reasoning",
+    "xai/grok-4.20-0309-non-reasoning",
+    "xai/grok-4.20-0309-reasoning",
+    "xai/grok-4.20-multi-agent-0309",
+    "xai/grok-4.3",
+    "xai/grok-4.5",
+]
+
+LLMModels = OpenAIModels | GoogleModels | KimiModels | DeepSeekModels | ZAIModels | XAIModels
+
+InferenceClass = Literal["priority", "standard", "low"]
+"""Scheduling class for a request. ``low`` yields to voice traffic, so it is only
+appropriate for work no caller is waiting on."""
+
+
+class ChatCompletionOptions(TypedDict, total=False):
+    frequency_penalty: float | None
+    logit_bias: dict[str, int] | None
+    logprobs: bool | None
+    max_completion_tokens: int | None
+    max_tokens: int | None
+    metadata: Metadata | None
+    modalities: list[Literal["text", "audio"]] | None
+    n: int | None
+    parallel_tool_calls: bool
+    prediction: ChatCompletionPredictionContentParam | None
+    presence_penalty: float | None
+    prompt_cache_key: str
+    prompt_cache_retention: Literal["in_memory", "24h"] | None
+    reasoning_effort: ReasoningEffort | None
+    safety_identifier: str
+    seed: int | None
+    service_tier: Literal["auto", "default", "flex", "scale", "priority"] | None
+    stop: str | None | list[str] | None
+    store: bool | None
+    temperature: float | None
+    top_logprobs: int | None
+    top_p: float | None
+    user: str
+    verbosity: Literal["low", "medium", "high"] | None
+    web_search_options: completion_create_params.WebSearchOptions
+
+    # livekit-typed arguments
+    tool_choice: ToolChoice
+    # TODO(theomonnomn): support repsonse format
+    # response_format: completion_create_params.ResponseFormat
+
+
+@dataclass
+class _LLMOptions:
+    model: LLMModels | str
+    provider: str | None
+    base_url: str
+    api_key: str
+    api_secret: str
+    inference_class: InferenceClass | None
+    extra_kwargs: ChatCompletionOptions | dict[str, Any]
+
+
+class LLM(llm.LLM):
+    def __init__(
+        self,
+        model: LLMModels | str,
+        *,
+        provider: str | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        api_secret: str | None = None,
+        inference_class: InferenceClass | None = None,
+        extra_kwargs: ChatCompletionOptions | dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__()
+
+        lk_base_url = base_url if base_url else get_default_inference_url()
+
+        lk_api_key = (
+            api_key
+            if api_key
+            else os.getenv("LIVEKIT_INFERENCE_API_KEY", os.getenv("LIVEKIT_API_KEY", ""))
+        )
+        if not lk_api_key:
+            raise ValueError(
+                "api_key is required, either as argument or set LIVEKIT_API_KEY environmental variable"
+            )
+
+        lk_api_secret = (
+            api_secret
+            if api_secret
+            else os.getenv("LIVEKIT_INFERENCE_API_SECRET", os.getenv("LIVEKIT_API_SECRET", ""))
+        )
+        if not lk_api_secret:
+            raise ValueError(
+                "api_secret is required, either as argument or set LIVEKIT_API_SECRET environmental variable"
+            )
+
+        self._opts = _LLMOptions(
+            model=model,
+            provider=provider,
+            base_url=lk_base_url,
+            api_key=lk_api_key,
+            api_secret=lk_api_secret,
+            inference_class=inference_class,
+            extra_kwargs=extra_kwargs or {},
+        )
+        self._client = openai.AsyncClient(
+            api_key=create_access_token(self._opts.api_key, self._opts.api_secret),
+            base_url=self._opts.base_url,
+            max_retries=0,
+            http_client=httpx.AsyncClient(
+                timeout=httpx.Timeout(connect=15.0, read=5.0, write=5.0, pool=5.0),
+                follow_redirects=True,
+                limits=httpx.Limits(
+                    max_connections=50, max_keepalive_connections=50, keepalive_expiry=120
+                ),
+            ),
+        )
+
+    async def _prewarm_impl(self) -> None:
+        await self._client.models.list()
+
+    async def aclose(self) -> None:
+        await super().aclose()
+        await self._client.close()
+
+    @classmethod
+    def from_model_string(cls, model: str) -> LLM:
+        """Create a LLM instance from a model string"""
+        return cls(model)
+
+    def update_options(
+        self,
+        *,
+        model: NotGivenOr[LLMModels | str] = NOT_GIVEN,
+        extra_kwargs: NotGivenOr[ChatCompletionOptions | dict[str, Any]] = NOT_GIVEN,
+    ) -> None:
+        """Update LLM configuration options.
+
+        Each option is read on the next ``chat()`` call, so a swap
+        takes effect on the agent's next turn without recreating the
+        LLM. ``extra_kwargs`` *replaces* the persistent kwargs dict
+        rather than merging — pass ``{}`` to clear it.
+        """
+        if is_given(model):
+            self._opts.model = model
+        if is_given(extra_kwargs):
+            self._opts.extra_kwargs = dict(extra_kwargs)
+
+    @property
+    def model(self) -> str:
+        """Get the model name for this LLM instance."""
+        return self._opts.model
+
+    @property
+    def provider(self) -> str:
+        return "livekit"
+
+    def chat(
+        self,
+        *,
+        chat_ctx: ChatContext,
+        tools: list[Tool] | None = None,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+        parallel_tool_calls: NotGivenOr[bool] = NOT_GIVEN,
+        tool_choice: NotGivenOr[ToolChoice] = NOT_GIVEN,
+        response_format: NotGivenOr[
+            completion_create_params.ResponseFormat | type[llm_utils.ResponseFormatT]
+        ] = NOT_GIVEN,
+        inference_class: NotGivenOr[InferenceClass] = NOT_GIVEN,
+        extra_kwargs: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
+    ) -> LLMStream:
+        extra = {}
+        if is_given(extra_kwargs):
+            extra.update(extra_kwargs)
+
+        parallel_tool_calls = (
+            parallel_tool_calls
+            if is_given(parallel_tool_calls)
+            else self._opts.extra_kwargs.get("parallel_tool_calls", NOT_GIVEN)
+        )
+        if is_given(parallel_tool_calls):
+            extra["parallel_tool_calls"] = parallel_tool_calls
+
+        extra_tool_choice = self._opts.extra_kwargs.get("tool_choice", NOT_GIVEN)
+        tool_choice = tool_choice if is_given(tool_choice) else extra_tool_choice
+        if is_given(tool_choice):
+            oai_tool_choice: ChatCompletionToolChoiceOptionParam
+            if isinstance(tool_choice, dict):
+                oai_tool_choice = {
+                    "type": "function",
+                    "function": {"name": tool_choice["function"]["name"]},
+                }
+                extra["tool_choice"] = oai_tool_choice
+            elif tool_choice in ("auto", "required", "none"):
+                oai_tool_choice = tool_choice
+                extra["tool_choice"] = oai_tool_choice
+
+        if is_given(response_format):
+            extra["response_format"] = llm_utils.to_openai_response_format(response_format)  # type: ignore
+
+        extra.update(self._opts.extra_kwargs)
+
+        effective_inference_class = (
+            inference_class if is_given(inference_class) else self._opts.inference_class
+        )
+
+        self._client.api_key = create_access_token(self._opts.api_key, self._opts.api_secret)
+        return LLMStream(
+            self,
+            model=self._opts.model,
+            provider=self._opts.provider,
+            inference_class=effective_inference_class,
+            strict_tool_schema=True,
+            client=self._client,
+            chat_ctx=chat_ctx,
+            tools=tools or [],
+            conn_options=conn_options,
+            extra_kwargs=extra,
+        )
+
+
+class LLMStream(llm.LLMStream):
+    def __init__(
+        self,
+        llm_v: LLM | llm.LLM,
+        *,
+        model: LLMModels | str,
+        provider: str | None = None,
+        inference_class: InferenceClass | None = None,
+        strict_tool_schema: bool,
+        client: openai.AsyncClient,
+        chat_ctx: llm.ChatContext,
+        tools: list[Tool],
+        conn_options: APIConnectOptions,
+        extra_kwargs: dict[str, Any],
+        provider_fmt: str = "openai",  # used internally for chat_ctx format
+    ) -> None:
+        super().__init__(llm_v, chat_ctx=chat_ctx, tools=tools, conn_options=conn_options)
+        self._model = model
+        self._provider = provider
+        self._inference_class = inference_class
+        self._provider_fmt = provider_fmt
+        self._strict_tool_schema = strict_tool_schema
+        self._client = client
+        self._llm = llm_v
+        self._extra_kwargs = drop_unsupported_params(model, extra_kwargs, tools=tools)
+        self._tool_ctx = llm.ToolContext(tools)
+
+    async def _run(self) -> None:
+        # current function call that we're waiting for full completion (args are streamed)
+        # (defined inside the _run method to make sure the state is reset for each run/attempt)
+        self._oai_stream: openai.AsyncStream[ChatCompletionChunk] | None = None
+        self._tool_call_id: str | None = None
+        self._fnc_name: str | None = None
+        self._fnc_raw_arguments: str | None = None
+        self._tool_extra: dict[str, Any] | None = None
+        self._tool_index: int | None = None
+        retryable = True
+
+        try:
+            chat_ctx, _ = self._chat_ctx.to_provider_format(format=self._provider_fmt)
+            tool_schemas = cast(
+                list[ChatCompletionToolParam],
+                self._tool_ctx.parse_function_tools("openai", strict=self._strict_tool_schema),
+            )
+            if lk_oai_debug:
+                tool_choice = self._extra_kwargs.get("tool_choice", NOT_GIVEN)
+                logger.debug(
+                    "chat.completions.create",
+                    extra={
+                        "fnc_ctx": tool_schemas,
+                        "tool_choice": tool_choice,
+                        "lk.pii.chat_ctx": chat_ctx,
+                    },
+                )
+            if not self._tools:
+                # remove tool_choice from extra_kwargs if no tools are provided
+                self._extra_kwargs.pop("tool_choice", None)
+
+            extra_headers = self._extra_kwargs.setdefault("extra_headers", {})
+            extra_headers.update(get_inference_headers(inference_class=self._inference_class))
+            if self._provider:
+                extra_headers[HEADER_INFERENCE_PROVIDER] = self._provider
+
+            self._oai_stream = stream = await self._client.chat.completions.create(
+                messages=cast(list[ChatCompletionMessageParam], chat_ctx),
+                tools=tool_schemas or openai.omit,
+                model=self._model,
+                stream_options={"include_usage": True},
+                stream=True,
+                timeout=httpx.Timeout(self._conn_options.timeout),
+                **self._extra_kwargs,
+            )
+
+            thinking_filter = llm_utils.ThinkingTokenFilter(
+                *_MODEL_THINK_TAGS.get(
+                    self._model, (llm_utils.THINK_TAG_START, llm_utils.THINK_TAG_END)
+                )
+            )
+            async with stream:
+                async for chunk in stream:
+                    for choice in chunk.choices:
+                        chat_chunk = self._parse_choice(chunk.id, choice, thinking_filter)
+                        if chat_chunk is not None:
+                            if chat_chunk.has_response():
+                                retryable = False
+                            self._event_ch.send_nowait(chat_chunk)
+
+                    if chunk.usage is not None:
+                        tokens_details = chunk.usage.prompt_tokens_details
+                        cached_tokens = tokens_details.cached_tokens if tokens_details else 0
+                        usage_chunk = llm.ChatChunk(
+                            id=chunk.id,
+                            usage=llm.CompletionUsage(
+                                completion_tokens=chunk.usage.completion_tokens or 0,
+                                prompt_tokens=chunk.usage.prompt_tokens or 0,
+                                prompt_cached_tokens=cached_tokens or 0,
+                                total_tokens=chunk.usage.total_tokens or 0,
+                                service_tier=getattr(chunk, "service_tier", None),
+                            ),
+                        )
+                        self._event_ch.send_nowait(usage_chunk)
+
+        except openai.APITimeoutError:
+            raise APITimeoutError(retryable=retryable) from None
+        except httpx.TimeoutException as e:
+            # Only the request call runs inside the openai client's error mapping, so a
+            # timeout waiting on the stream body arrives as the raw httpx exception.
+            raise APITimeoutError(retryable=retryable) from e
+        except openai.APIStatusError as e:
+            if e.status_code == 429:
+                self._log_rate_limited(e)
+            raise APIStatusError(
+                e.message,
+                status_code=e.status_code,
+                request_id=e.request_id,
+                body=e.body,
+                retryable=retryable,
+            ) from None
+        except Exception as e:
+            raise APIConnectionError(retryable=retryable) from e
+
+    def _log_rate_limited(self, e: openai.APIStatusError) -> None:
+        """Log the gateway's quota snapshot when a request is rejected with 429.
+
+        The gateway stamps X-LiveKit-Inference-{RPM,TPM,Credits}-{Limit,Used}
+        on rejections so customers can see which limit they hit and by how much.
+        """
+        extra: dict[str, Any] = {"model": self._model, "request_id": e.request_id}
+        extra.update(extract_quota_usage(e.response.headers))
+        logger.warning("LLM request rate limited by inference gateway", extra=extra)
+
+    def _parse_choice(
+        self, id: str, choice: Choice, thinking_filter: llm_utils.ThinkingTokenFilter
+    ) -> llm.ChatChunk | None:
+        delta = choice.delta
+
+        # https://github.com/livekit/agents/issues/688
+        # the delta can be None when using Azure OpenAI (content filtering)
+        if delta is None:
+            return None
+
+        delta.content = llm_utils.strip_thinking_tokens(
+            delta.content, thinking_filter, final=choice.finish_reason is not None
+        )
+
+        if delta.tool_calls:
+            for tool in delta.tool_calls:
+                if not tool.function:
+                    continue
+
+                call_chunk = None
+                if self._tool_call_id and tool.id and tool.index != self._tool_index:
+                    call_chunk = llm.ChatChunk(
+                        id=id,
+                        delta=llm.ChoiceDelta(
+                            role="assistant",
+                            content=delta.content,
+                            tool_calls=[
+                                llm.FunctionToolCall(
+                                    arguments=self._fnc_raw_arguments or "",
+                                    name=self._fnc_name or "",
+                                    call_id=self._tool_call_id or "",
+                                    extra=self._tool_extra,
+                                )
+                            ],
+                        ),
+                    )
+                    self._tool_call_id = self._fnc_name = self._fnc_raw_arguments = None
+                    self._tool_extra = None
+
+                if tool.function.name:
+                    self._tool_index = tool.index
+                    self._tool_call_id = tool.id
+                    self._fnc_name = tool.function.name
+                    self._fnc_raw_arguments = tool.function.arguments or ""
+                    # Extract extra from tool call (e.g., Google thought signatures)
+                    self._tool_extra = getattr(tool, "extra_content", None)
+                elif tool.function.arguments:
+                    self._fnc_raw_arguments += tool.function.arguments  # type: ignore
+
+                if call_chunk is not None:
+                    return call_chunk
+
+        if choice.finish_reason in ("tool_calls", "stop") and self._tool_call_id:
+            finish_extra = getattr(delta, "extra_content", None)
+            call_chunk = llm.ChatChunk(
+                id=id,
+                delta=llm.ChoiceDelta(
+                    role="assistant",
+                    content=delta.content,
+                    extra=finish_extra,
+                    tool_calls=[
+                        llm.FunctionToolCall(
+                            arguments=self._fnc_raw_arguments or "",
+                            name=self._fnc_name or "",
+                            call_id=self._tool_call_id or "",
+                            extra=self._tool_extra,
+                        )
+                    ],
+                ),
+            )
+            self._tool_call_id = self._fnc_name = self._fnc_raw_arguments = None
+            self._tool_extra = None
+            return call_chunk
+
+        # Extract extra from delta (e.g., Google thought signatures on text parts)
+        delta_extra = getattr(delta, "extra_content", None)
+
+        if not delta.content and not delta_extra:
+            return None
+
+        return llm.ChatChunk(
+            id=id,
+            delta=llm.ChoiceDelta(
+                content=delta.content,
+                role="assistant",
+                extra=delta_extra,
+            ),
+        )

--- a/livekit/agents/llm/utils.py
+++ b/livekit/agents/llm/utils.py
@@ -1,0 +1,1060 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import copy
+import inspect
+import json
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    cast,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+import json_repair
+import pydantic
+from pydantic import BaseModel, TypeAdapter, create_model
+from pydantic.fields import Field, FieldInfo
+from pydantic_core import PydanticUndefined, from_json
+from typing_extensions import TypeVar
+
+from livekit import rtc
+
+from ..log import logger
+from ..utils import images
+from . import _strict
+from .chat_context import ChatContext, ImageContent
+from .tool_context import FunctionTool, RawFunctionTool, ToolError
+
+if TYPE_CHECKING:
+    from ..voice.events import RunContext
+    from .chat_context import FunctionCall, FunctionCallOutput
+    from .llm import FunctionToolCall
+    from .tool_context import ToolContext
+
+THINK_TAG_START = "<think>"
+THINK_TAG_END = "</think>"
+
+
+def _compute_lcs(old_ids: list[str], new_ids: list[str]) -> list[str]:
+    """
+    Standard dynamic-programming LCS to get the common subsequence
+    of IDs (in order) that appear in both old_ids and new_ids.
+    """
+    n, m = len(old_ids), len(new_ids)
+    dp = [[0] * (m + 1) for _ in range(n + 1)]
+
+    # Fill DP table
+    for i in range(1, n + 1):
+        for j in range(1, m + 1):
+            if old_ids[i - 1] == new_ids[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1] + 1
+            else:
+                dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+
+    # Backtrack to find the actual LCS sequence
+    lcs_ids = []
+    i, j = n, m
+    while i > 0 and j > 0:
+        if old_ids[i - 1] == new_ids[j - 1]:
+            lcs_ids.append(old_ids[i - 1])
+            i -= 1
+            j -= 1
+        elif dp[i - 1][j] > dp[i][j - 1]:
+            i -= 1
+        else:
+            j -= 1
+
+    return list(reversed(lcs_ids))
+
+
+@dataclass
+class DiffOps:
+    to_remove: list[str]
+    to_create: list[
+        tuple[str | None, str]
+    ]  # (previous_item_id, id), if previous_item_id is None, add to the root
+    to_update: list[
+        tuple[str | None, str]
+    ]  # (previous_item_id, id), the items with the same id but different content
+
+
+def compute_chat_ctx_diff(old_ctx: ChatContext, new_ctx: ChatContext) -> DiffOps:
+    """Computes the minimal list of create/remove operations to transform old_ctx into new_ctx."""
+    # TODO(theomonnom): Make ChatMessage hashable and also add update ops
+
+    old_ids = [m.id for m in old_ctx.items]
+    new_ids = [m.id for m in new_ctx.items]
+
+    lcs_ids = set(_compute_lcs(old_ids, new_ids))
+    old_ctx_by_id = {item.id: item for item in old_ctx.items}
+
+    to_remove = [msg.id for msg in old_ctx.items if msg.id not in lcs_ids]
+    to_create: list[tuple[str | None, str]] = []
+    to_update: list[tuple[str | None, str]] = []
+
+    prev_id: str | None = None  # None means root
+    for new_msg in new_ctx.items:
+        if new_msg.id not in lcs_ids:
+            to_create.append((prev_id, new_msg.id))
+        else:
+            # check if the content is different
+            old_msg = old_ctx_by_id[new_msg.id]
+            if new_msg.type == "message" and old_msg.type == "message":
+                if new_msg.raw_text_content != old_msg.raw_text_content:
+                    to_update.append((prev_id, new_msg.id))
+                # TODO: check other content types
+
+        prev_id = new_msg.id
+
+    return DiffOps(to_remove=to_remove, to_create=to_create, to_update=to_update)
+
+
+def is_context_type(ty: type, *, allow_subclasses: bool = False) -> bool:
+    from ..voice.events import RunContext
+
+    origin = get_origin(ty)
+
+    if not allow_subclasses:
+        return ty is RunContext or origin is RunContext
+
+    if origin is not None:
+        try:
+            return issubclass(origin, RunContext)
+        except TypeError:
+            return False
+
+    try:
+        return issubclass(ty, RunContext)
+    except TypeError:
+        return False
+
+
+@dataclass
+class SerializedImage:
+    inference_detail: str
+    mime_type: str | None
+    data_bytes: bytes | None = None
+    external_url: str | None = None
+
+
+def serialize_image(image: ImageContent, *, use_cache: bool = True) -> SerializedImage:
+    cache_key = "serialized_image"  # TODO(long): use hash of encoding options if available
+    if use_cache and cache_key in image._cache:
+        return cast(SerializedImage, image._cache[cache_key])
+
+    serialized_image: SerializedImage
+    if isinstance(image.image, str):
+        if image.image.startswith("data:"):
+            header, b64_data = image.image.split(",", 1)
+            encoded_data = base64.b64decode(b64_data)
+            header_mime = header.split(";")[0].split(":")[1]
+            if image.mime_type and image.mime_type != header_mime:
+                logger.warning(
+                    f"""Provided mime_type '{image.mime_type}' does not match data URL mime type
+                    '{header_mime}'. Using provided mime_type."""
+                )
+                mime_type = image.mime_type
+            else:
+                mime_type = header_mime
+            supported_types = {"image/jpeg", "image/png", "image/webp", "image/gif"}
+            if mime_type not in supported_types:
+                raise ValueError(
+                    f"Unsupported mime_type {mime_type}. Must be jpeg, png, webp, or gif"
+                )
+
+            serialized_image = SerializedImage(
+                data_bytes=encoded_data,
+                mime_type=mime_type,
+                inference_detail=image.inference_detail,
+            )
+        else:
+            serialized_image = SerializedImage(
+                mime_type=image.mime_type,
+                inference_detail=image.inference_detail,
+                external_url=image.image,
+            )
+
+    elif isinstance(image.image, rtc.VideoFrame):
+        opts = images.EncodeOptions()
+        if image.inference_width and image.inference_height:
+            opts.resize_options = images.ResizeOptions(
+                width=image.inference_width,
+                height=image.inference_height,
+                strategy="scale_aspect_fit",
+            )
+        encoded_data = images.encode(image.image, opts)
+
+        serialized_image = SerializedImage(
+            data_bytes=encoded_data,
+            mime_type="image/jpeg",
+            inference_detail=image.inference_detail,
+        )
+    else:
+        raise ValueError("Unsupported image type")
+
+    if use_cache:
+        image._cache[cache_key] = serialized_image
+    return serialized_image
+
+
+def build_legacy_openai_schema(
+    function_tool: FunctionTool, *, internally_tagged: bool = False
+) -> dict[str, Any]:
+    """non-strict mode tool description
+    see https://serde.rs/enum-representations.html for the internally tagged representation"""
+    model = function_arguments_to_pydantic_model(function_tool)
+    info = function_tool.info
+    schema = model.model_json_schema()
+
+    if internally_tagged:
+        return {
+            "name": info.name,
+            "description": info.description or "",
+            "parameters": schema,
+            "type": "function",
+        }
+    else:
+        return {
+            "type": "function",
+            "function": {
+                "name": info.name,
+                "description": info.description or "",
+                "parameters": schema,
+            },
+        }
+
+
+def build_strict_openai_schema(
+    function_tool: FunctionTool,
+) -> dict[str, Any]:
+    """strict mode tool description"""
+    model = function_arguments_to_pydantic_model(function_tool)
+    info = function_tool.info
+    schema = _strict.to_strict_json_schema(model, null_sentinel_for_defaults=True)
+
+    return {
+        "type": "function",
+        "function": {
+            "name": info.name,
+            "strict": True,
+            "description": info.description or "",
+            "parameters": schema,
+        },
+    }
+
+
+ResponseFormatT = TypeVar("ResponseFormatT", default=None)
+
+
+def is_typed_dict(cls: type | Any) -> bool:
+    return isinstance(cls, type) and issubclass(cls, dict) and hasattr(cls, "__annotations__")
+
+
+# mostly from https://github.com/openai/openai-python/blob/main/src/openai/lib/_parsing/_completions.py
+# and https://github.com/instructor-ai/instructor/blob/be7821e34fb10f7dabf658d684135297a2e40ef3/instructor/process_response.py#L812C1-L816C10
+
+
+def to_response_format_param(
+    response_format: type | dict[str, Any],
+) -> tuple[str, type[BaseModel] | TypeAdapter[Any]]:
+    if isinstance(response_format, dict):
+        # TODO(theomonnom): better type validation, copy TypedDict from OpenAI
+        if response_format.get("type", "") not in ("text", "json_schema", "json_object"):
+            raise TypeError("Unsupported response_format type")
+
+        # TODO(long): fix return value
+        raise TypeError("Unsupported response_format type")
+        return response_format
+
+    # add support for TypedDict
+    if is_typed_dict(response_format):
+        response_format = create_model(
+            response_format.__name__,
+            **{k: (v, ...) for k, v in response_format.__annotations__.items()},  # type: ignore
+        )
+    json_schema_type: type[BaseModel] | TypeAdapter[Any] | None = None
+    if inspect.isclass(response_format) and issubclass(response_format, BaseModel):
+        name = response_format.__name__
+        json_schema_type = response_format
+    elif inspect.isclass(response_format) and hasattr(
+        response_format, "__pydantic_config__"
+    ):  # @pydantic.dataclass
+        name = response_format.__name__
+        json_schema_type = TypeAdapter(response_format)
+    else:
+        raise TypeError(f"Unsupported response_format type - {response_format}")
+
+    return name, json_schema_type
+
+
+def to_openai_response_format(response_format: type | dict[str, Any]) -> dict[str, Any]:
+    name, json_schema_type = to_response_format_param(response_format)
+
+    # No null sentinel here: nothing resolves it on the decode side (users validate
+    # the raw payload themselves), so the schema must be exactly what validation
+    # accepts. Defaulted fields stay required; the model produces their values.
+    schema = _strict.to_strict_json_schema(json_schema_type)
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "schema": schema,
+            "name": name,
+            "strict": True,
+        },
+    }
+
+
+def _inject_schema_defaults(value: Any, *, schema: dict[str, Any], root: dict[str, Any]) -> Any:
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        resolved = _strict.resolve_ref(root=root, ref=ref)
+        if isinstance(resolved, dict):
+            schema = {**resolved, **schema}
+
+    if value is None:
+        if "default" in schema and not _json_schema_allows_null(schema, root=root):
+            return copy.deepcopy(schema["default"])
+        return None
+
+    all_of = schema.get("allOf")
+    if isinstance(all_of, list):
+        for variant in all_of:
+            if isinstance(variant, dict):
+                value = _inject_schema_defaults(value, schema=variant, root=root)
+
+    for union_key in ("anyOf", "oneOf"):
+        variants = schema.get(union_key)
+        if isinstance(variants, list):
+            for variant in variants:
+                if isinstance(variant, dict) and _json_schema_matches(value, variant, root=root):
+                    return _inject_schema_defaults(value, schema=variant, root=root)
+
+    if isinstance(value, dict):
+        properties = schema.get("properties")
+        additional = schema.get("additionalProperties")
+        if isinstance(properties, dict) or isinstance(additional, dict):
+            # additionalProperties only governs keys not declared in properties
+            def _inject_entry(key: str, item: Any) -> Any:
+                prop = properties.get(key) if isinstance(properties, dict) else None
+                if isinstance(prop, dict):
+                    return _inject_schema_defaults(item, schema=prop, root=root)
+                if isinstance(additional, dict):
+                    return _inject_schema_defaults(item, schema=additional, root=root)
+                return item
+
+            return {key: _inject_entry(key, item) for key, item in value.items()}
+
+    if isinstance(value, list):
+        prefix_items = schema.get("prefixItems")
+        items = schema.get("items")
+        if isinstance(prefix_items, list) or isinstance(items, dict):
+            # prefixItems covers positional slots (fixed tuples); items the rest
+            def _inject_item(i: int, item: Any) -> Any:
+                if (
+                    isinstance(prefix_items, list)
+                    and i < len(prefix_items)
+                    and isinstance(prefix_items[i], dict)
+                ):
+                    return _inject_schema_defaults(item, schema=prefix_items[i], root=root)
+                if isinstance(items, dict):
+                    return _inject_schema_defaults(item, schema=items, root=root)
+                return item
+
+            return [_inject_item(i, item) for i, item in enumerate(value)]
+
+    return value
+
+
+def _json_schema_allows_null(
+    schema: dict[str, Any], *, root: dict[str, Any], seen_refs: set[str] | None = None
+) -> bool:
+    """Whether ``null`` is a valid instance of ``schema``.
+
+    JSON schema keywords are conjunctive: null must satisfy every constraint
+    present (type, enum, const, allOf, unions, $ref), so any keyword that
+    rejects null makes the whole schema reject it.
+    """
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        if ref in (seen_refs or set()):
+            return False
+        resolved = _strict.resolve_ref(root=root, ref=ref)
+        if isinstance(resolved, dict) and not _json_schema_allows_null(
+            resolved, root=root, seen_refs={*(seen_refs or set()), ref}
+        ):
+            return False
+
+    typ = schema.get("type")
+    if isinstance(typ, str) and typ != "null":
+        return False
+    if isinstance(typ, list) and "null" not in typ:
+        return False
+
+    if "const" in schema and schema["const"] is not None:
+        return False
+    enum = schema.get("enum")
+    if isinstance(enum, list) and None not in enum:
+        return False
+
+    all_of = schema.get("allOf")
+    if isinstance(all_of, list) and not all(
+        _json_schema_allows_null(variant, root=root, seen_refs=seen_refs)
+        for variant in all_of
+        if isinstance(variant, dict)
+    ):
+        return False
+
+    for union_key in ("anyOf", "oneOf"):
+        variants = schema.get(union_key)
+        if isinstance(variants, list) and not any(
+            isinstance(variant, dict)
+            and _json_schema_allows_null(variant, root=root, seen_refs=seen_refs)
+            for variant in variants
+        ):
+            return False
+
+    return True
+
+
+def _json_schema_matches(value: Any, schema: dict[str, Any], *, root: dict[str, Any]) -> bool:
+    ref = schema.get("$ref")
+    if isinstance(ref, str):
+        resolved = _strict.resolve_ref(root=root, ref=ref)
+        if isinstance(resolved, dict):
+            schema = {**resolved, **schema}
+
+    if value is None and "default" in schema and not _json_schema_allows_null(schema, root=root):
+        return True
+
+    if "const" in schema and value != schema["const"]:
+        return False
+    enum = schema.get("enum")
+    if isinstance(enum, list) and value not in enum:
+        return False
+
+    typ = schema.get("type")
+    if isinstance(typ, list):
+        return any(_json_type_matches(value, item) for item in typ if isinstance(item, str))
+    if isinstance(typ, str) and not _json_type_matches(value, typ):
+        return False
+
+    if isinstance(value, dict):
+        required = schema.get("required")
+        if isinstance(required, list) and not all(key in value for key in required):
+            return False
+        properties = schema.get("properties")
+        if isinstance(properties, dict):
+            # the strict wire schema closes objects (additionalProperties: false),
+            # so a key outside the declared properties rules this variant out;
+            # otherwise a payload meant for a sibling union variant matches any
+            # variant that merely ignores the extra keys
+            if schema.get("additionalProperties") in (None, False) and any(
+                key not in properties for key in value
+            ):
+                return False
+            for key, item in value.items():
+                property_schema = properties.get(key)
+                if isinstance(property_schema, dict) and not _json_schema_matches(
+                    item, property_schema, root=root
+                ):
+                    return False
+
+    return True
+
+
+def _json_type_matches(value: Any, typ: str) -> bool:
+    if typ == "null":
+        return value is None
+    if typ == "object":
+        return isinstance(value, dict)
+    if typ == "array":
+        return isinstance(value, list)
+    if typ == "boolean":
+        return isinstance(value, bool)
+    if typ == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if typ == "number":
+        return isinstance(value, int | float) and not isinstance(value, bool)
+    if typ == "string":
+        return isinstance(value, str)
+    return True
+
+
+def function_arguments_to_pydantic_model(func: Callable[..., Any]) -> type[BaseModel]:
+    """Create a Pydantic model from a function's signature. (excluding context types)"""
+
+    from docstring_parser import parse_from_object
+
+    fnc_names = func.__name__.split("_")
+    fnc_name = "".join(x.capitalize() for x in fnc_names)
+    model_name = fnc_name + "Args"
+
+    docstring = parse_from_object(func)
+    param_docs = {p.arg_name: p.description for p in docstring.params}
+
+    signature = inspect.signature(func)
+    type_hints = get_type_hints(func, include_extras=True)
+
+    # field_name -> (type, FieldInfo or default)
+    fields: dict[str, Any] = {}
+
+    for param_name, param in signature.parameters.items():
+        type_hint = type_hints[param_name]
+
+        if is_context_type(type_hint, allow_subclasses=True):
+            continue
+
+        default_value = param.default if param.default is not param.empty else ...
+        field_info: FieldInfo | None = None
+        field_attrs: dict[str, Any] = {}
+
+        # Annotated[str, Field(description="...")]
+        if get_origin(type_hint) is Annotated:
+            annotated_args = get_args(type_hint)
+            type_hint = annotated_args[0]
+            annotated_field = next(
+                (x for x in annotated_args[1:] if isinstance(x, FieldInfo)), None
+            )
+            if annotated_field and hasattr(annotated_field, "asdict"):
+                # `asdict` is available after pydantic 2.12
+                field_dict = annotated_field.asdict()
+                field_attrs = field_dict["attributes"]
+                # Constraints (ge/le/gt/lt/multiple_of/min_length/pattern/...) live
+                # in `metadata`, not `attributes`. Re-attach them to the annotation
+                # so `Field(...)` constraints on a tool argument are preserved.
+                if field_dict["metadata"]:
+                    type_hint = Annotated[(type_hint, *field_dict["metadata"])]
+            elif annotated_field:
+                field_attrs["default"] = annotated_field.default
+                field_attrs["description"] = annotated_field.description
+                field_info = annotated_field
+
+        if (
+            default_value is not ...
+            and field_attrs.get("default", PydanticUndefined) is PydanticUndefined
+        ):
+            field_attrs["default"] = default_value
+
+        if field_attrs.get("description") is None:
+            field_attrs["description"] = param_docs.get(param_name, None)
+
+        if not field_info:
+            field_info = Field(**field_attrs)
+        else:
+            for k, v in field_attrs.items():
+                setattr(field_info, k, v)
+
+        fields[param_name] = (type_hint, field_info)
+
+    return create_model(model_name, **fields)
+
+
+# Patterns for chat-template tokens that sometimes leak into tool-call arguments
+# when the model fumbles its own special-token formatting. Ordered: well-formed
+# delimiters first (so we don't leave dangling halves), then stragglers.
+# Covers Qwen/ChatML-style (`<|im_start|>`, `<|tool_call|>`, the leaked `<|"|"`
+# we've seen from Gemma 4) and Gemma turn markers (`<start_of_turn>` /
+# `<end_of_turn>`).
+_TEMPLATE_TOKEN_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"<\|[^<>|]{0,40}\|>"),  # well-formed <|...|>
+    re.compile(r"<\|[^<>a-zA-Z0-9_]{0,10}"),  # dangling start <|"|" etc.
+    re.compile(r"[^<>a-zA-Z0-9_]{0,10}\|>"),  # dangling end
+    re.compile(r"<(?:start|end)_of_turn>"),  # Gemma turn markers
+)
+
+
+def _strip_template_tokens(value: Any) -> Any:
+    """Recursively remove leaked chat-template tokens from string values.
+
+    Only applied after a JSON repair pass — we don't want to silently rewrite
+    legitimate arguments that happen to contain `<|...|>` substrings.
+    """
+    if isinstance(value, str):
+        out = value
+        for pat in _TEMPLATE_TOKEN_PATTERNS:
+            out = pat.sub("", out)
+        return out.strip()
+    if isinstance(value, list):
+        cleaned = [_strip_template_tokens(v) for v in value]
+        # Drop empties that were left behind purely as separators between leaked
+        # tokens (e.g. `["<|", "X<|", ""]` -> `["X"]`).
+        return [v for v in cleaned if v not in ("", None)]
+    if isinstance(value, dict):
+        return {k: _strip_template_tokens(v) for k, v in value.items()}
+    return value
+
+
+def parse_function_arguments(json_arguments: str) -> dict[str, Any]:
+    """Parse a raw JSON tool-call arguments string into a dict.
+
+    First tries strict parsing; if the JSON is malformed (common with smaller /
+    open-weight models that fumble special tokens or escaping), falls back to
+    ``json_repair`` and then strips known chat-template token leaks.
+
+    Raises ``ValueError`` if the arguments can't be recovered or don't decode
+    to a dict-shaped value.
+    """
+    try:
+        args_dict: Any = from_json(json_arguments)
+    except ValueError as strict_err:
+        repaired = json_repair.loads(json_arguments)
+        if repaired == "":
+            # json_repair returns "" when it can't recover anything meaningful.
+            raise ValueError(
+                f"could not parse function arguments as JSON: {strict_err}: {json_arguments[:200]}"
+            ) from strict_err
+        # After a repair, also strip leaked chat-template tokens — many of
+        # the failures we see are caused by `<|...|>` markers bleeding into
+        # the model's structured output.
+        cleaned = _strip_template_tokens(repaired)
+        logger.warning(
+            "repaired malformed function-call JSON arguments",
+            extra={
+                "lk.pii.raw_arguments": json_arguments[:500],
+                "lk.pii.repaired": cleaned,
+                "lk.pii.error": str(strict_err),
+            },
+        )
+        args_dict = cleaned
+
+    # Some providers (e.g. Nova Sonic) double-encode tool arguments as nested
+    # JSON strings. Unwrap until we reach a non-string value.
+    while isinstance(args_dict, str):
+        try:
+            args_dict = from_json(args_dict)
+        except Exception:
+            raise ValueError(
+                f"function arguments decoded to a non-JSON string: {args_dict[:200]}"
+            ) from None
+
+    if args_dict is None:
+        return {}
+    if not isinstance(args_dict, dict):
+        raise ValueError(
+            f"expected dict from function arguments, "
+            f"got {type(args_dict).__name__}: {json_arguments[:200]}"
+        )
+    return args_dict
+
+
+def prepare_function_arguments(
+    *,
+    fnc: FunctionTool | RawFunctionTool,
+    json_arguments: str | dict[str, Any],
+    call_ctx: RunContext[Any] | None = None,
+    fnc_call: FunctionCall | None = None,
+) -> tuple[tuple[Any, ...], dict[str, Any]]:  # returns args, kwargs
+    """Create the positional and keyword arguments to call a function tool from
+    the raw function output from the LLM.
+
+    Argument-validation failures (bad JSON, pydantic ValidationError, missing
+    required params) are surfaced as :class:`ToolError` so the LLM gets a
+    concrete error message and can self-correct on its next turn.
+
+    When ``fnc_call`` is provided and ``json_arguments`` is a string, the
+    canonicalized JSON (post json_repair) is written back to
+    ``fnc_call.arguments`` BEFORE validation runs.
+    """
+    # phase 1: parse — raw JSON failures raise ToolError immediately (no
+    # canonical to provide since the input itself was unparseable)
+    if isinstance(json_arguments, dict):
+        args_dict = json_arguments
+    else:
+        try:
+            args_dict = parse_function_arguments(json_arguments)
+        except ValueError as e:
+            logger.error(
+                f"error parsing arguments for `{fnc.info.name}`",
+                extra={"function": fnc.info.name, "lk.pii.arguments": json_arguments},
+            )
+            raise ToolError(f"Error parsing arguments for `{fnc.info.name}`: {e}") from e
+
+        # write canonical BEFORE validation so a downstream validation failure
+        # still leaves valid JSON in chat history
+        if fnc_call is not None:
+            canonical = json.dumps(args_dict, default=str)
+            if canonical != json_arguments:
+                fnc_call.arguments = canonical
+
+    # phase 2: validate + bind
+    try:
+        return _prepare_function_arguments(fnc=fnc, args_dict=args_dict, call_ctx=call_ctx)
+    except ToolError:
+        raise
+    except (pydantic.ValidationError, ValueError, TypeError) as e:
+        logger.error(
+            f"error parsing arguments for `{fnc.info.name}`",
+            extra={"function": fnc.info.name, "lk.pii.arguments": json_arguments},
+        )
+        raise ToolError(f"Error parsing arguments for `{fnc.info.name}`: {e}") from e
+    except Exception:
+        logger.exception(
+            f"error parsing arguments for `{fnc.info.name}`",
+            extra={"function": fnc.info.name, "lk.pii.arguments": json_arguments},
+        )
+        raise
+
+
+def validated_arguments(
+    fnc: FunctionTool | RawFunctionTool, args_dict: dict[str, Any]
+) -> dict[str, Any]:
+    """A tool call's arguments after schema validation, keyed by parameter name.
+
+    Every declared parameter is present — an omitted one carries its default — and
+    values are coerced to their annotated types, so ``{"order_id": "5"}`` and
+    ``{"order_id": "5", "locale": None}`` produce the same mapping, as do ``1`` and
+    ``1.0`` for a ``float`` parameter. That makes this the form to compare two calls
+    on (see ``DuplicateScope``), not the raw arguments the LLM emitted.
+
+    Raises the same validation errors as calling the tool would. Raw function tools
+    have no per-parameter schema, so their arguments are returned exactly as sent.
+    """
+    if isinstance(fnc, RawFunctionTool):
+        return args_dict
+
+    model_type = function_arguments_to_pydantic_model(fnc)
+
+    # Strict LLM schemas represent defaulted fields as nullable (see
+    # _ensure_strict_json_schema): null means "use the default". Resolve
+    # the sentinel, including in nested models, before validation.
+    schema = model_type.model_json_schema()
+    args_dict = _inject_schema_defaults(args_dict, schema=schema, root=schema)
+
+    model = model_type.model_validate(args_dict)  # can raise ValidationError
+    return _shallow_model_dump(model)
+
+
+def _prepare_function_arguments(
+    *,
+    fnc: FunctionTool | RawFunctionTool,
+    args_dict: dict[str, Any],
+    call_ctx: RunContext[Any] | None,
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    signature = inspect.signature(fnc)
+    type_hints = get_type_hints(fnc, include_extras=True)
+
+    if isinstance(fnc, FunctionTool):
+        raw_fields = validated_arguments(fnc, args_dict)
+    elif isinstance(fnc, RawFunctionTool):
+        # e.g async def open_gate(self, raw_arguments: dict[str, object]):
+        # raw_arguments is required when using raw function tools
+        raw_fields = {
+            "raw_arguments": args_dict,
+        }
+    else:
+        raise ValueError(f"Unsupported function tool type: {type(fnc)}")
+
+    # inject RunContext (or subclasses) if needed
+    context_dict = {}
+    for param_name, _ in signature.parameters.items():
+        type_hint = type_hints[param_name]
+        if not is_context_type(type_hint, allow_subclasses=True) or call_ctx is None:
+            continue
+
+        expected_type = get_origin(type_hint) or type_hint
+        if isinstance(call_ctx, expected_type):
+            context_dict[param_name] = call_ctx
+        else:
+            logger.error(
+                f"context type mismatch for parameter '{param_name}': "
+                f"expected {expected_type.__name__}, got {type(call_ctx).__name__}"
+            )
+
+    bound = signature.bind(**{**raw_fields, **context_dict})
+    bound.apply_defaults()
+    return bound.args, bound.kwargs
+
+
+def _shallow_model_dump(model: BaseModel, *, by_alias: bool = False) -> dict[str, Any]:
+    result = {}
+    for name, field_info in model.__class__.model_fields.items():
+        key = field_info.alias if by_alias and field_info.alias else name
+        result[key] = getattr(model, name)
+    return result
+
+
+@dataclass
+class ThinkingTokenFilter:
+    """State for stripping thinking tokens from streamed content."""
+
+    start_tag: str = THINK_TAG_START
+    end_tag: str = THINK_TAG_END
+    _buffer: str = ""
+    _end_marker: str | None = None
+
+
+def _partial_marker_length(content: str, markers: tuple[str, ...]) -> int:
+    return max(
+        (
+            length
+            for marker in markers
+            for length in range(1, min(len(content), len(marker) - 1) + 1)
+            if content.endswith(marker[:length])
+        ),
+        default=0,
+    )
+
+
+def _flatten_delta_content(content: Any) -> str | None:
+    """Flatten list-shaped streaming delta content to its concatenated text.
+
+    The OpenAI-compatible ecosystem allows ``delta.content`` to be a list of
+    typed content parts (``[{"type": "text", "text": ...}]``) instead of a
+    plain string — Mistral emits this shape on some streamed chunks — and the
+    openai SDK constructs stream models without validation, so the list
+    reaches us as-is when the plugin points at such a provider (#6323).
+    """
+    if content is None or isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+                continue
+            text = part.get("text") if isinstance(part, dict) else getattr(part, "text", None)
+            if isinstance(text, str):
+                parts.append(text)
+        # no text part at all carries no content, unlike a part that carries an
+        # empty string - that one is kept, like a plain "" delta
+        return "".join(parts) if parts else None
+    logger.warning(
+        "unexpected streaming delta content type %s; dropping the chunk", type(content).__name__
+    )
+    return None
+
+
+def strip_thinking_tokens(
+    content: str | list[Any] | None, state: ThinkingTokenFilter, *, final: bool = False
+) -> str | None:
+    content = _flatten_delta_content(content)
+    if content is not None:
+        state._buffer += content
+
+    visible: list[str] = []
+    while state._buffer:
+        if state._end_marker is not None:
+            idx = state._buffer.find(state._end_marker)
+            if idx < 0:
+                keep = _partial_marker_length(state._buffer, (state._end_marker,))
+                state._buffer = state._buffer[-keep:] if keep else ""
+                break
+
+            state._buffer = state._buffer[idx + len(state._end_marker) :]
+            state._end_marker = None
+            continue
+
+        idx = state._buffer.find(state.start_tag)
+        if idx >= 0:
+            visible.append(state._buffer[:idx])
+            state._buffer = state._buffer[idx + len(state.start_tag) :]
+            if state.end_tag == "":
+                # For empty end tag, we do not look for an end tag: the rest is visible.
+                visible.append(state._buffer)
+                state._buffer = ""
+                break   # break out of the while loop
+            else:
+                state._end_marker = state.end_tag
+            continue
+
+        keep = _partial_marker_length(state._buffer, (state.start_tag,))
+        visible.append(state._buffer[:-keep] if keep else state._buffer)
+        state._buffer = state._buffer[-keep:] if keep else ""
+        break
+
+    if final:
+        if state._end_marker is None:
+            visible.append(state._buffer)
+        state._buffer = ""
+        state._end_marker = None
+
+    result = "".join(visible)
+    return result or ("" if content == "" else None)
+
+
+def _is_valid_function_output(value: Any) -> bool:
+    VALID_TYPES = (str, int, float, bool, complex, type(None))
+
+    if isinstance(value, VALID_TYPES):
+        return True
+    elif (
+        isinstance(value, list)
+        or isinstance(value, set)
+        or isinstance(value, frozenset)
+        or isinstance(value, tuple)
+    ):
+        return all(_is_valid_function_output(item) for item in value)
+    elif isinstance(value, dict):
+        return all(
+            isinstance(key, VALID_TYPES) and _is_valid_function_output(val)
+            for key, val in value.items()
+        )
+    return False
+
+
+@dataclass
+class FunctionCallResult:
+    fnc_call: FunctionCall
+    fnc_call_out: FunctionCallOutput
+    raw_output: Any
+    raw_exception: BaseException | None
+    fnc_call_updates: list[tuple[FunctionCall, FunctionCallOutput]] = field(default_factory=list)
+    """Synthesized pairs from any ``ctx.update()`` calls during this standalone
+    execution. Empty unless the tool actually called ``ctx.update()``."""
+
+
+def make_function_call_output(
+    *,
+    fnc_call: FunctionCall,
+    output: Any,
+    exception: BaseException | None,
+) -> FunctionCallResult:
+    """Create a FunctionCallResult, handling ToolError, StopResponse, and validation."""
+    from .chat_context import FunctionCallOutput
+    from .tool_context import StopResponse, ToolError
+
+    if isinstance(output, BaseException):
+        exception = output
+        output = None
+
+    if isinstance(exception, ToolError):
+        return FunctionCallResult(
+            fnc_call=fnc_call,
+            fnc_call_out=FunctionCallOutput(
+                name=fnc_call.name,
+                call_id=fnc_call.call_id,
+                output=exception.message,
+                is_error=True,
+            ),
+            raw_output=output,
+            raw_exception=exception,
+        )
+
+    if isinstance(exception, StopResponse):
+        # StopResponse asks for silence, not for the call to go unanswered
+        return FunctionCallResult(
+            fnc_call=fnc_call,
+            fnc_call_out=FunctionCallOutput(
+                name=fnc_call.name,
+                call_id=fnc_call.call_id,
+                output="",
+                is_error=False,
+                reply_required=False,
+            ),
+            raw_output=output,
+            raw_exception=exception,
+        )
+
+    if exception is not None:
+        return FunctionCallResult(
+            fnc_call=fnc_call,
+            fnc_call_out=FunctionCallOutput(
+                name=fnc_call.name,
+                call_id=fnc_call.call_id,
+                output="An internal error occurred",
+                is_error=True,
+            ),
+            raw_output=output,
+            raw_exception=exception,
+        )
+
+    if not _is_valid_function_output(output):
+        logger.error(
+            f"AI function `{fnc_call.name}` returned an invalid output",
+            extra={"call_id": fnc_call.call_id, "lk.pii.output": output},
+        )
+        return FunctionCallResult(
+            fnc_call=fnc_call,
+            fnc_call_out=FunctionCallOutput(
+                name=fnc_call.name,
+                call_id=fnc_call.call_id,
+                output="the tool returned an invalid output",
+                is_error=True,
+            ),
+            raw_output=output,
+            raw_exception=None,
+        )
+
+    return FunctionCallResult(
+        fnc_call=fnc_call,
+        fnc_call_out=FunctionCallOutput(
+            name=fnc_call.name,
+            call_id=fnc_call.call_id,
+            output=str(output or ""),
+            is_error=False,
+        ),
+        raw_output=output,
+        raw_exception=None,
+    )
+
+
+async def execute_function_call(
+    tool_call: FunctionToolCall,
+    tool_ctx: ToolContext,
+    *,
+    call_ctx: RunContext[Any] | None = None,
+) -> FunctionCallResult:
+    """Execute a function tool call and return the result."""
+    from .chat_context import FunctionCall, FunctionCallOutput
+
+    fnc_call = FunctionCall(
+        call_id=tool_call.call_id,
+        name=tool_call.name,
+        arguments=tool_call.arguments or "{}",
+        extra=tool_call.extra or {},
+    )
+
+    function_tool = tool_ctx.function_tools.get(tool_call.name)
+    if function_tool is None:
+        logger.warning(f"unknown AI function `{tool_call.name}`")
+        # Name the available tools so the model can self-correct
+        msg = (
+            f"Unknown function: {tool_call.name} - available tools: "
+            f"{', '.join(tool_ctx.function_tools.keys())}"
+        )
+        return FunctionCallResult(
+            fnc_call=fnc_call,
+            fnc_call_out=FunctionCallOutput(
+                name=tool_call.name,
+                call_id=tool_call.call_id,
+                output=msg,
+                is_error=True,
+            ),
+            raw_output=None,
+            raw_exception=ValueError(msg),
+        )
+
+    try:
+        raw_args = tool_call.arguments or "{}"
+        fnc_args, fnc_kwargs = prepare_function_arguments(
+            fnc=function_tool,
+            json_arguments=raw_args,
+            call_ctx=call_ctx,
+            fnc_call=fnc_call,
+        )
+        result = function_tool(*fnc_args, **fnc_kwargs)
+        if asyncio.iscoroutine(result):
+            result = await result
+
+        out = make_function_call_output(fnc_call=fnc_call, output=result, exception=None)
+
+    except Exception as e:
+        if not isinstance(e, ToolError):
+            logger.exception(
+                f"exception executing AI function `{tool_call.name}`",
+                extra={"call_id": tool_call.call_id, "lk.pii.arguments": tool_call.arguments},
+            )
+        out = make_function_call_output(fnc_call=fnc_call, output=None, exception=e)
+
+    # surface any ctx.update() calls so callers can inspect them
+    if call_ctx is not None and call_ctx._updates:
+        out.fnc_call_updates = list(call_ctx._updates)
+    return out


### PR DESCRIPTION
Add _MODEL_THINK_TAGS entry for google/gemini-3.5-flash with empty end tag to match the observed behavior where the thought token has no closing delimiter. The strip_thinking_tokens function already handles empty end tags correctly by treating the remainder as visible content after the start tag is found.

Fixes issue where thought tokens were leaked into delta.content and spoken to callers via TTS/transcription.

Closes #6942