### PR TITLE
fix(voice): flush recorder resampler tails at run end

### DIFF
--- a/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
+++ b/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
@@ -104,6 +104,8 @@ class _Track:
         """Place the resampler tail while its run can still be written."""
         if self._resampler is not None:
             self._place(self._resampler.flush())
+            self._resampler = None
+            self._source_rate = None
         self._run_start = None
         self._run_samples = 0
 

--- a/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
+++ b/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
@@ -104,6 +104,8 @@ class _Track:
         """Place the resampler tail while its run can still be written."""
         if self._resampler is not None:
             self._place(self._resampler.flush())
+        self._run_start = None
+        self._run_samples = 0
 
     def _place(self, frames: list[rtc.AudioFrame]) -> None:
         if not frames:

--- a/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
+++ b/livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py
@@ -48,6 +48,11 @@ class _Flush:
     until: float
 
 
+@dataclass
+class _EndRun:
+    channel: int
+
+
 class _Track:
     """One channel of the recording, holding runs of audio placed on the absolute timeline."""
 
@@ -84,30 +89,32 @@ class _Track:
 
     def push(self, started_at: float, frame: rtc.AudioFrame) -> None:
         """Add audio that began at ``started_at``, extending the open run where it fits."""
-
-        def _place(frames: list[rtc.AudioFrame]) -> None:
-            if not frames:
-                return
-
-            assert self._run_start is not None
-            joined = np.concatenate([np.frombuffer(f.data, dtype=np.int16) for f in frames])
-            samples = joined.astype(np.float32) / 32768.0
-            start = round((self._run_start - self._t0) * self._sample_rate) + self._run_samples
-            self._placed.append((start, samples))
-            self._run_samples += len(samples)
-
         expected = (
             None
             if self._run_start is None
             else self._run_start + self._run_samples / self._sample_rate
         )
         if expected is None or abs(started_at - expected) > RESYNC_TOLERANCE:
-            if self._resampler is not None:
-                # whatever the resampler still holds is the tail of the run that just ended
-                _place(self._resampler.flush())
+            self.end_run()
             self._run_start, self._run_samples = started_at, 0
 
-        _place(self._resample(frame))
+        self._place(self._resample(frame))
+
+    def end_run(self) -> None:
+        """Place the resampler tail while its run can still be written."""
+        if self._resampler is not None:
+            self._place(self._resampler.flush())
+
+    def _place(self, frames: list[rtc.AudioFrame]) -> None:
+        if not frames:
+            return
+
+        assert self._run_start is not None
+        joined = np.concatenate([np.frombuffer(f.data, dtype=np.int16) for f in frames])
+        samples = joined.astype(np.float32) / 32768.0
+        start = round((self._run_start - self._t0) * self._sample_rate) + self._run_samples
+        self._placed.append((start, samples))
+        self._run_samples += len(samples)
 
     def take(self, start: int, end: int) -> np.ndarray:
         """The channel over ``[start, end)``, silent wherever nothing was placed."""
@@ -141,7 +148,7 @@ class RecorderIO:
         self._in_record: RecorderAudioInput | None = None
         self._out_record: RecorderAudioOutput | None = None
 
-        self._q: queue.Queue[_Captured | _Flush | None] = queue.Queue()
+        self._q: queue.Queue[_Captured | _Flush | _EndRun | None] = queue.Queue()
         self._session = agent_session
         self._sample_rate = sample_rate
         self._started = False
@@ -185,6 +192,8 @@ class RecorderIO:
                 await utils.aio.cancel_and_wait(self._write_atask)
                 self._write_atask = None
 
+            self._end_run(channel=0)
+            self._end_run(channel=1)
             self._q.put_nowait(_Flush(until=time.time()))
             self._q.put_nowait(None)
             await asyncio.shield(self._close_fut)
@@ -211,6 +220,9 @@ class RecorderIO:
             recording_io=self, audio_output=audio_output, on_played=on_played
         )
         return self._out_record
+
+    def _end_run(self, *, channel: int) -> None:
+        self._q.put_nowait(_EndRun(channel=channel))
 
     @property
     def recording(self) -> bool:
@@ -270,6 +282,10 @@ class RecorderIO:
                 while (item := self._q.get()) is not None:
                     if isinstance(item, _Captured):
                         tracks[item.channel].push(item.started_at, item.frame)
+                        continue
+
+                    if isinstance(item, _EndRun):
+                        tracks[item.channel].end_run()
                         continue
 
                     end = round((item.until - self._t0) * self._sample_rate)
@@ -397,6 +413,9 @@ class RecorderAudioOutput(io.AudioOutput):
                 offset=0.0,
                 duration=playback_position,
             )
+
+        if self.__recording_io.recording:
+            self.__recording_io._end_run(channel=1)
 
         self.__acc = []
         self.__pcm = None

--- a/tests/test_recorder_io.py
+++ b/tests/test_recorder_io.py
@@ -143,6 +143,20 @@ async def test_a_segment_in_flight_holds_the_timeline() -> None:
     assert output.pending_since is None
 
 
+async def test_finishing_output_marks_its_recorder_run_ended() -> None:
+    recorder = MagicMock(recording=True)
+    output = RecorderAudioOutput(
+        recording_io=recorder,
+        audio_output=None,
+        on_played=lambda _started_at, _frame: None,
+    )
+
+    await output.capture_frame(_tone(0.1))
+    output.on_playback_finished(playback_position=0.1, interrupted=False)
+
+    recorder._end_run.assert_called_once_with(channel=1)
+
+
 # ---------------------------------------------------------------------------
 # _Track: the absolute timeline
 # ---------------------------------------------------------------------------
@@ -201,6 +215,16 @@ def test_a_source_below_the_recording_rate_is_resampled_in_place() -> None:
     assert np.all(block[:48000] == 0.0)
     # 100ms of audio, twice as many samples at the recording rate; the samples the resampler
     # still held when the run ended are part of it
+    assert np.count_nonzero(block[48000:]) == pytest.approx(4800, abs=50)
+
+
+def test_ending_a_run_places_the_resampler_tail_before_the_writer_advances() -> None:
+    track = _Track(sample_rate=48000, t0=0.0)
+    track.push(1.0, _loud(2400, sample_rate=24000))  # 100ms at 24kHz
+    track.end_run()
+
+    block = track.take(0, 48000 * 2)
+    assert np.all(block[:48000] == 0.0)
     assert np.count_nonzero(block[48000:]) == pytest.approx(4800, abs=50)
 
 

--- a/tests/test_recorder_io.py
+++ b/tests/test_recorder_io.py
@@ -237,6 +237,16 @@ def test_ending_a_run_reanchors_the_next_segment_after_a_short_gap() -> None:
     assert [pos for pos, _ in track._placed] == [0, 150]
 
 
+def test_ending_a_resampled_run_twice_is_idempotent() -> None:
+    track = _Track(sample_rate=48000, t0=0.0)
+    track.push(1.0, _loud(2400, sample_rate=24000))
+    track.end_run()  # output playback ended
+    track.end_run()  # RecorderIO closed before another run began
+
+    block = track.take(0, 48000 * 2)
+    assert np.count_nonzero(block[48000:]) == pytest.approx(4800, abs=50)
+
+
 def test_a_stereo_source_is_mixed_down() -> None:
     track = _Track(sample_rate=1000, t0=0.0)
     track.push(0.0, _loud(100, channels=2))

--- a/tests/test_recorder_io.py
+++ b/tests/test_recorder_io.py
@@ -228,6 +228,15 @@ def test_ending_a_run_places_the_resampler_tail_before_the_writer_advances() -> 
     assert np.count_nonzero(block[48000:]) == pytest.approx(4800, abs=50)
 
 
+def test_ending_a_run_reanchors_the_next_segment_after_a_short_gap() -> None:
+    track = _Track(sample_rate=1000, t0=0.0)
+    track.push(0.0, _loud(100))
+    track.end_run()
+    track.push(0.15, _loud(100))  # the 50ms gap is below the drift tolerance
+
+    assert [pos for pos, _ in track._placed] == [0, 150]
+
+
 def test_a_stereo_source_is_mixed_down() -> None:
     track = _Track(sample_rate=1000, t0=0.0)
     track.push(0.0, _loud(100, channels=2))


### PR DESCRIPTION
## Summary
- flush each RecorderIO resampler when output playback finishes or the recorder closes
- queue the tail before the recorder timeline advances
- cover the output-end notification and a 24 kHz-to-48 kHz resampler tail

Fixes #7046

## Testing
- uv run --no-project --with-editable ./livekit-agents --with pytest --with pytest-asyncio --with pytest-asyncio-concurrent pytest tests/test_recorder_io.py (16 passed)
- uvx --from ruff==0.15.22 ruff check livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py tests/test_recorder_io.py
- uvx --from ruff==0.15.22 ruff format --check livekit-agents/livekit/agents/voice/recorder_io/recorder_io.py tests/test_recorder_io.py
- uv run --no-project --with-editable ./livekit-agents --with mypy mypy -m livekit.agents.voice.recorder_io