### PR TITLE
fix(voice): preserve held end-of-speech timing

### DIFF
--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -712,6 +712,13 @@ class AudioRecognition:
         events_to_emit = list(self._transcript_buffer)
         self._transcript_buffer.clear()
         for ev in events_to_emit:
+            if ev.type == stt.SpeechEventType.END_OF_SPEECH and ev.speech_end_time is None:
+                # Preserve the provider's original turn-end arrival when an adaptive
+                # interruption gate releases buffered events later. Anchoring the EOU
+                # bounce to replay time creates a fresh endpointing window in which a
+                # subsequently buffered START_OF_SPEECH can cancel a turn that had
+                # already ended at the provider.
+                ev = replace(ev, speech_end_time=ev.created_at)
             logger.trace("re-emitting held STT event", extra={"event": ev.type})
             self._process_stt_event(ev)
 

--- a/tests/test_interruption_hold_window.py
+++ b/tests/test_interruption_hold_window.py
@@ -180,9 +180,23 @@ def test_flushing_held_transcripts_preserves_provider_order() -> None:
     recognition._flush_held_transcripts()
 
     emitted = [call.args[0] for call in recognition._process_stt_event.call_args_list]  # type: ignore[attr-defined]
-    assert emitted == events
+    assert emitted[:2] == events[:2]
+    assert emitted[2].type == SpeechEventType.END_OF_SPEECH
+    assert emitted[2].created_at == events[2].created_at
+    assert emitted[2].speech_end_time == events[2].created_at
     assert not recognition._transcript_buffer
     assert not recognition._transcript_gate_active
+
+
+def test_flushing_held_end_of_speech_preserves_original_arrival_time() -> None:
+    recognition = _make_recognition(vad_sos=5.0)
+    end_of_speech = SpeechEvent(type=SpeechEventType.END_OF_SPEECH, created_at=5.2)
+    recognition._transcript_buffer.append(end_of_speech)
+
+    recognition._flush_held_transcripts()
+
+    emitted = recognition._process_stt_event.call_args.args[0]  # type: ignore[attr-defined]
+    assert emitted.speech_end_time == end_of_speech.created_at
 
 
 def test_new_overlap_rearms_a_released_gate() -> None:


### PR DESCRIPTION
## Summary

- preserve the original arrival time when an adaptive interruption gate replays a buffered END_OF_SPEECH event
- prevent replay time from creating a fresh endpointing window in which a later START_OF_SPEECH can cancel an already-ended provider turn
- add focused unit coverage for the timestamp contract and provider ordering

## Verification

- 46 focused adaptive interruption and audio EOU tests passed
- Ruff format and lint passed on the changed files

This changes only buffered adaptive-event timing; it adds no timeout, forced commit, lexical rule, or application workaround.