### PR TITLE
fix(inworld): keep a reference to the prewarm task and cancel it on close

### DIFF
--- a/livekit-plugins/livekit-plugins-inworld/livekit/plugins/inworld/tts.py
+++ b/livekit-plugins/livekit-plugins-inworld/livekit/plugins/inworld/tts.py
@@ -42,7 +42,7 @@ from livekit.agents.types import (
     APIConnectOptions,
     NotGivenOr,
 )
-from livekit.agents.utils import is_given
+from livekit.agents.utils import aio, is_given
 from livekit.agents.voice.io import TimedString
 
 from .log import logger
@@ -964,6 +964,7 @@ class TTS(tts.TTS):
         self._idle_connection_timeout = idle_connection_timeout
         self._pool: _ConnectionPool | None = None
         self._pool_lock = asyncio.Lock()
+        self._prewarm_task: asyncio.Task[None] | None = None
         self._streams = weakref.WeakSet[SynthesizeStream]()
         self._sentence_tokenizer = (
             tokenizer
@@ -1087,7 +1088,7 @@ class TTS(tts.TTS):
         return self._session
 
     def prewarm(self) -> None:
-        asyncio.create_task(self._prewarm_impl())
+        self._prewarm_task = asyncio.create_task(self._prewarm_impl())
 
     async def _prewarm_impl(self) -> None:
         # Just ensure the pool is created - first acquire will establish a connection
@@ -1109,6 +1110,13 @@ class TTS(tts.TTS):
         return stream
 
     async def aclose(self) -> None:
+        # Cancel first: _prewarm_impl calls _get_pool, which builds a new pool when
+        # self._pool is None. A prewarm still in flight here would otherwise recreate
+        # the pool after it was closed, leaving a live connection nothing owns.
+        if self._prewarm_task is not None:
+            await aio.cancel_and_wait(self._prewarm_task)
+            self._prewarm_task = None
+
         for stream in list(self._streams):
             await stream.aclose()
 


### PR DESCRIPTION
## The bug

`TTS.prewarm()` throws away the task it creates:

```python
def prewarm(self) -> None:
    asyncio.create_task(self._prewarm_impl())
```

Two consequences.

**The task is only weakly referenced.** The event loop does not keep a strong reference to a bare task, so it can be garbage collected mid-execution and the prewarm silently never happens.

**The ordering one is worse.** `_prewarm_impl` calls `_get_pool`, which builds a fresh `_ConnectionPool` whenever `self._pool` is None:

```python
async def _get_pool(self) -> _ConnectionPool:
    async with self._pool_lock:
        if self._pool is None or self._pool._closed:
            self._pool = _ConnectionPool(...)
        return self._pool
```

and `aclose()` sets `self._pool = None` after closing it. So a prewarm still in flight when the TTS is closed **recreates the pool after close**, leaving a live websocket connection that nothing owns and nothing will ever close.

## The fix

Store the task and cancel it at the top of `aclose()`, before the pool is torn down.

This is the pattern already in the tree. `openai/tts.py` hand-rolls its prewarm the same way and holds the task:

```python
def prewarm(self) -> None:
    ...
    self._prewarm_task = asyncio.create_task(_prewarm())

async def aclose(self) -> None:
    if self._prewarm_task:
        await aio.cancel_and_wait(self._prewarm_task)
```

and `utils.ConnectionPool.prewarm()` — used by the fifteen other plugins — keeps `self._prewarm_task` and checks whether it is still running before starting another.

Inworld was the only plugin calling `asyncio.create_task` in `prewarm()` without holding on to the result.

## Checks

`ruff check` and `ruff format --check` pass on the changed file. No behaviour change on the success path: prewarm still runs in the background and is still fire-and-forget from the caller's point of view.

---

Found with a small AST pass over the repo looking for `create_task` calls whose result is discarded. Happy to send the other instances separately if useful.

