### PR TITLE
fix(soniox): keep references to the prewarm and self-close tasks

### DIFF
--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -154,6 +154,7 @@ class TTS(tts.TTS):
 
         # One persistent connection shared across streams (see _Connection).
         self.__current_connection: _Connection | None = None
+        self._prewarm_task: asyncio.Task[None] | None = None
         self.__conn_lock = asyncio.Lock()
 
     @property
@@ -251,13 +252,20 @@ class TTS(tts.TTS):
                 logger.debug(f"Soniox TTS prewarm failed: {e}")
 
         try:
-            asyncio.create_task(_task(), name="soniox-tts-prewarm")
+            self._prewarm_task = asyncio.create_task(_task(), name="soniox-tts-prewarm")
         except RuntimeError:
             # No running event loop (e.g. called outside async context) — skip.
             pass
 
     async def aclose(self) -> None:
         """Close all streams and the persistent connection."""
+        # Cancel first: the prewarm task calls _current_connection, which opens a new
+        # connection when there is none. A prewarm still in flight here would otherwise
+        # reconnect after close, leaving a live WebSocket nothing owns.
+        if self._prewarm_task is not None:
+            await utils.aio.cancel_and_wait(self._prewarm_task)
+            self._prewarm_task = None
+
         for stream in list(self._streams):
             await stream.aclose()
         self._streams.clear()
@@ -579,6 +587,7 @@ class _Connection:
         self._send_task: asyncio.Task[None] | None = None
         self._recv_task: asyncio.Task[None] | None = None
         self._keepalive_task: asyncio.Task[None] | None = None
+        self._close_task: asyncio.Task[None] | None = None
         self._is_current = True
         self._closed = False
 
@@ -597,11 +606,21 @@ class _Connection:
     def has_stream(self, stream_id: str) -> bool:
         return stream_id in self._streams
 
+    def _schedule_close(self, name: str) -> None:
+        """Close in the background, holding on to the task.
+
+        The event loop only keeps a weak reference to a bare task, so a discarded
+        one can be collected before it runs and the WebSocket would stay open.
+        """
+        if self._close_task is not None and not self._close_task.done():
+            return
+        self._close_task = asyncio.create_task(self.aclose(), name=name)
+
     def mark_non_current(self) -> None:
         """Flag this connection to be replaced; self-closes once idle."""
         self._is_current = False
         if not self._streams and not self._closed:
-            asyncio.create_task(self.aclose(), name="soniox-tts-conn-drain-close")
+            self._schedule_close("soniox-tts-conn-drain-close")
 
     async def connect(self) -> None:
         """Open the WebSocket and start the send/recv/keepalive loops."""
@@ -646,7 +665,7 @@ class _Connection:
         self._streams.pop(stream_id, None)
         # If flagged non-current and idle, self-close.
         if not self._is_current and not self._streams and not self._closed:
-            asyncio.create_task(self.aclose(), name="soniox-tts-conn-drain-close")
+            self._schedule_close("soniox-tts-conn-drain-close")
 
     def send_text(self, stream_id: str, text: str, *, text_end: bool = False) -> None:
         if self._closed or stream_id not in self._streams:
@@ -721,7 +740,7 @@ class _Connection:
             self._fail_all(APIConnectionError("Soniox TTS send loop error"))
         finally:
             if not self._closed:
-                asyncio.create_task(self.aclose(), name="soniox-tts-conn-fail-close")
+                self._schedule_close("soniox-tts-conn-fail-close")
 
     async def _recv_loop(self) -> None:
         try:
@@ -823,7 +842,7 @@ class _Connection:
             self._fail_all(APIConnectionError("Soniox TTS recv loop error"))
         finally:
             if not self._closed:
-                asyncio.create_task(self.aclose(), name="soniox-tts-conn-fail-close")
+                self._schedule_close("soniox-tts-conn-fail-close")
 
     async def _keepalive_loop(self) -> None:
         try:

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -249,10 +249,14 @@ class TTS(tts.TTS):
             try:
                 await self._current_connection(timeout=20.0)
             except Exception as e:
-                logger.debug(f"Soniox TTS prewarm failed: {e}")
+                logger.debug("Soniox TTS prewarm failed", exc_info=e)
 
         try:
-            self._prewarm_task = asyncio.create_task(_task(), name="soniox-tts-prewarm")
+            # Don't replace a prewarm still in flight: the old task would lose its only
+            # reference, and aclose() cancels just the latest one, so it could open a
+            # connection after shutdown. utils.ConnectionPool.prewarm guards the same way.
+            if self._prewarm_task is None or self._prewarm_task.done():
+                self._prewarm_task = asyncio.create_task(_task(), name="soniox-tts-prewarm")
         except RuntimeError:
             # No running event loop (e.g. called outside async context) — skip.
             pass


### PR DESCRIPTION
## The bug

Five `asyncio.create_task` calls in `soniox/tts.py` discard the task they create. The event loop only holds a **weak** reference to a bare task, so it can be garbage collected before it finishes.

### `_Connection` self-close (four sites)

The connection closes itself from `mark_non_current`, `unregister_stream`, and the `finally` of both `_send_loop` and `_recv_loop`:

```python
asyncio.create_task(self.aclose(), name="soniox-tts-conn-drain-close")
```

If that task is collected, `aclose()` never runs and the WebSocket stays open.

Worth noting the class already gets this right for its own loops — `_send_task`, `_recv_task` and `_keepalive_task` are all stored on the instance. The close tasks were the exception.

### `TTS.prewarm` — an ordering problem too

```python
async def _task() -> None:
    await self._current_connection(timeout=20.0)

asyncio.create_task(_task(), name="soniox-tts-prewarm")
```

`_current_connection` opens a new `_Connection` when there is none, and `aclose()` sets `__current_connection = None` after closing. So a prewarm still in flight when the TTS is closed **reconnects afterwards**, leaving a live WebSocket that nothing owns and nothing will close.

## The fix

The four self-close sites go through a small helper that keeps the task and skips scheduling a second close while one is still running:

```python
def _schedule_close(self, name: str) -> None:
    if self._close_task is not None and not self._close_task.done():
        return
    self._close_task = asyncio.create_task(self.aclose(), name=name)
```

`prewarm` stores its task, and `aclose()` cancels it before tearing the connection down — the same shape as `openai/tts.py`, and what `utils.ConnectionPool.prewarm()` does for the plugins that use it.

No behaviour change on the success path.

## Checks

`ruff check` and `ruff format --check` pass on the changed file.

---

Found with a small AST pass looking for `create_task` calls whose result is discarded — the same sweep that turned up #7050.
