### PR TITLE
fix(inference): keep a reference to the STT session.update task

### DIFF
--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -888,6 +888,7 @@ class SpeechStream(stt.SpeechStream):
         self._speech_duration: float = 0
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._vad: vad.VAD | None = vad_instance
+        self._session_update_tasks: set[asyncio.Task[None]] = set()
 
     def update_options(
         self,
@@ -923,7 +924,11 @@ class SpeechStream(stt.SpeechStream):
                 "type": "session.update",
                 "settings": settings,
             }
-            asyncio.ensure_future(self._send_session_update(update_msg))
+            # Hold the task: the loop only weakly references it, and a collected one
+            # means self._opts moved on while the server was never told.
+            task = asyncio.create_task(self._send_session_update(update_msg))
+            self._session_update_tasks.add(task)
+            task.add_done_callback(self._session_update_tasks.discard)
 
     def _on_end_of_speech(self) -> None:
         if self._pending_extra is not None:
@@ -1060,6 +1065,9 @@ class SpeechStream(stt.SpeechStream):
                 await utils.aio.gracefully_cancel(*tasks)
         finally:
             self._ws = None
+            if self._session_update_tasks:
+                await utils.aio.gracefully_cancel(*self._session_update_tasks)
+                self._session_update_tasks.clear()
             if ws is not None:
                 await ws.close()
             if vad_stream is not None:


### PR DESCRIPTION
## The bug

`SpeechStream.update_options` updates `self._opts` and then tells the server about it:

```python
asyncio.ensure_future(self._send_session_update(update_msg))
```

The event loop holds only a **weak** reference to that future, so it can be garbage collected before the message is ever sent.

The failure is silent and one-sided. Local options say the model, language or extras changed; the server was never told; the stream keeps transcribing with the old settings. Nothing raises, nothing logs, and the caller has no way to notice.

The pending future is also never cancelled when the run loop tears the websocket down, so it can outlive the socket it was meant to write to.

## The fix

Hold the task in a set that discards itself on completion, and cancel anything still pending in the run loop's `finally`, right next to the `gracefully_cancel` already there for the send/recv/vad tasks.

No behaviour change on the success path — the update is still sent in the background and `update_options` still returns immediately.

## How it was found

`ruff --select RUF006` (`asyncio-dangling-task`). The repo's `[tool.ruff.lint] select` is currently `E, W, F, I, B, C4, UP`, so `RUF` is not enabled and this rule never runs in CI.

Across `livekit-agents` and `livekit-plugins` the rule currently reports **8 findings**. This PR is the only one in core; the other seven are covered by #7050 (inworld), #7051 (soniox) and #7052 (aws), plus one in `livekit-plugins-hamming` that sits inside `_reset_runtime_for_tests` and is harmless.

Worth noting my own AST scan missed this one because it only looked for `create_task` — `ensure_future` has the same weak-reference semantics and ruff checks both.

If it would be useful, I am happy to send a follow-up that fixes the hamming case and adds `"RUF"` (or just `RUF006`) to the ruff select, so the whole class is caught in CI rather than one plugin at a time. Say the word and I will open it once these have landed.

## Checks

`ruff check`, `ruff check --select RUF006` and `ruff format --check` all pass on the changed file.
