### PR TITLE
chore(lint): enable RUF006 so dangling asyncio tasks fail CI

### DIFF
--- a/examples/drive_thru/agent.py
+++ b/examples/drive_thru/agent.py
@@ -513,6 +513,7 @@ async def drive_thru_agent(ctx: JobContext) -> None:
     # RPC round-trip.
     push_pending = False
     push_running = False
+    push_task: asyncio.Task[None] | None = None
 
     async def _push_to(identity: str, payload: str) -> None:
         try:
@@ -543,11 +544,12 @@ async def drive_thru_agent(ctx: JobContext) -> None:
             push_running = False
 
     async def push_cart() -> None:
-        nonlocal push_pending
+        nonlocal push_pending, push_task
         push_pending = True
         if push_running:
             return
-        asyncio.create_task(_push_runner())
+        # hold the task: the loop only weakly references it
+        push_task = asyncio.create_task(_push_runner())
 
     userdata.order.on_change = push_cart
 

--- a/examples/drive_thru/agent.py
+++ b/examples/drive_thru/agent.py
@@ -512,7 +512,6 @@ async def drive_thru_agent(ctx: JobContext) -> None:
     # function tool that mutated the order shouldn't block on the
     # RPC round-trip.
     push_pending = False
-    push_running = False
     push_task: asyncio.Task[None] | None = None
 
     async def _push_to(identity: str, payload: str) -> None:
@@ -526,29 +525,28 @@ async def drive_thru_agent(ctx: JobContext) -> None:
             logger.exception("cart push to %s failed", identity)
 
     async def _push_runner() -> None:
-        nonlocal push_pending, push_running
-        push_running = True
-        try:
-            while push_pending:
-                push_pending = False
-                payload = format_cart(userdata)
-                logger.info("push_cart: %d chars", len(payload))
-                peers = list(ctx.room.remote_participants.values())
-                if not peers:
-                    continue
-                await asyncio.gather(
-                    *(_push_to(p.identity, payload) for p in peers),
-                    return_exceptions=True,
-                )
-        finally:
-            push_running = False
+        nonlocal push_pending
+        while push_pending:
+            push_pending = False
+            payload = format_cart(userdata)
+            logger.info("push_cart: %d chars", len(payload))
+            peers = list(ctx.room.remote_participants.values())
+            if not peers:
+                continue
+            await asyncio.gather(
+                *(_push_to(p.identity, payload) for p in peers),
+                return_exceptions=True,
+            )
 
     async def push_cart() -> None:
         nonlocal push_pending, push_task
         push_pending = True
-        if push_running:
+        # The retained task is the single-flight guard. A flag set inside the runner
+        # is not set until the loop schedules it, so back-to-back calls would each
+        # see it clear and start a runner of their own. push_pending keeps the
+        # trailing edge: a change during an in-flight RPC is sent when it returns.
+        if push_task is not None and not push_task.done():
             return
-        # hold the task: the loop only weakly references it
         push_task = asyncio.create_task(_push_runner())
 
     userdata.order.on_change = push_cart

--- a/examples/frontdesk/ui_view.py
+++ b/examples/frontdesk/ui_view.py
@@ -49,6 +49,7 @@ class UIView:
 
     def __init__(self, ctx: JobContext) -> None:
         self._ctx = ctx
+        self._push_tasks: set[asyncio.Task[None]] = set()
 
     def slots_listed(
         self,
@@ -85,7 +86,10 @@ class UIView:
 
     def _push(self, payload: str) -> None:
         for p in list(self._ctx.room.remote_participants.values()):
-            asyncio.create_task(self._push_to(p.identity, payload))
+            # hold the task: the loop only weakly references it
+            task = asyncio.create_task(self._push_to(p.identity, payload))
+            self._push_tasks.add(task)
+            task.add_done_callback(self._push_tasks.discard)
 
     async def _push_to(self, identity: str, payload: str) -> None:
         try:

--- a/examples/other/translation/multi-user-translator.py
+++ b/examples/other/translation/multi-user-translator.py
@@ -49,6 +49,10 @@ load_dotenv()
 
 logger = logging.getLogger("transcriber")
 
+# background tasks are held here so the event loop, which only keeps a weak
+# reference to a task, cannot collect one before it finishes
+_background_tasks: set[asyncio.Task[None]] = set()
+
 
 @dataclass
 class Language:
@@ -267,7 +271,10 @@ class InputTrack:
     def _remove_translator(self, target_language: str):
         translator = self._translators.pop(target_language, None)
         if translator:
-            asyncio.create_task(translator.aclose())
+            # hold the task: the loop only weakly references it
+            task = asyncio.create_task(translator.aclose())
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
 
     async def _forward_to_translators(self):
         """Forward transcribed sentences to each language specific translators."""
@@ -412,7 +419,10 @@ class RoomTranslator:
     def _remove_track(self, track: rtc.RemoteAudioTrack):
         input_track = next((t for t in self.input_tracks if t.track.sid == track.sid), None)
         if input_track:
-            asyncio.create_task(input_track.aclose())
+            # hold the task: the loop only weakly references it
+            task = asyncio.create_task(input_track.aclose())
+            _background_tasks.add(task)
+            task.add_done_callback(_background_tasks.discard)
             self.input_tracks.remove(input_track)
 
     def _reconcile_translators(self):

--- a/livekit-agents/livekit/agents/inference/stt.py
+++ b/livekit-agents/livekit/agents/inference/stt.py
@@ -888,6 +888,7 @@ class SpeechStream(stt.SpeechStream):
         self._speech_duration: float = 0
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._vad: vad.VAD | None = vad_instance
+        self._session_update_tasks: set[asyncio.Task[None]] = set()
 
     def update_options(
         self,
@@ -923,7 +924,11 @@ class SpeechStream(stt.SpeechStream):
                 "type": "session.update",
                 "settings": settings,
             }
-            asyncio.ensure_future(self._send_session_update(update_msg))
+            # Hold the task: the loop only weakly references it, and a collected one
+            # means self._opts moved on while the server was never told.
+            task = asyncio.create_task(self._send_session_update(update_msg))
+            self._session_update_tasks.add(task)
+            task.add_done_callback(self._session_update_tasks.discard)
 
     def _on_end_of_speech(self) -> None:
         if self._pending_extra is not None:
@@ -1060,6 +1065,9 @@ class SpeechStream(stt.SpeechStream):
                 await utils.aio.gracefully_cancel(*tasks)
         finally:
             self._ws = None
+            if self._session_update_tasks:
+                await utils.aio.gracefully_cancel(*self._session_update_tasks)
+                self._session_update_tasks.clear()
             if ws is not None:
                 await ws.close()
             if vad_stream is not None:

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -553,6 +553,10 @@ class RealtimeSession(  # noqa: F811
         # Session recycling: proactively restart before credential expiry or 8-min limit
         self._session_start_time: float | None = None
         self._session_recycle_task: asyncio.Task[None] | None = None
+        # Held only so the loop's weak reference cannot collect them mid-flight.
+        # Their lifecycle - cancellation, coalescing, shutdown - is #7052's subject.
+        self._user_text_tasks: set[asyncio.Task[None]] = set()
+        self._deferred_tool_recycle_tasks: set[asyncio.Task[None]] = set()
         self._last_audio_output_time: float = 0.0  # Track when assistant last produced audio
         self._audio_end_turn_received: bool = False  # Track when assistant finishes speaking
         self._pending_generation_fut: asyncio.Future[llm.GenerationCreatedEvent] | None = None
@@ -1865,7 +1869,11 @@ class RealtimeSession(  # noqa: F811
                                 if self._pending_generation_fut is fut:
                                     self._pending_generation_fut = None
 
-                        asyncio.create_task(_send_user_text())
+                        task = asyncio.create_task(
+                            _send_user_text(), name="RealtimeSession._send_user_text"
+                        )
+                        self._user_text_tasks.add(task)
+                        task.add_done_callback(self._user_text_tasks.discard)
 
                     self._sent_message_ids.add(item.id)
                     self._chat_ctx.items.append(item)
@@ -1931,7 +1939,11 @@ class RealtimeSession(  # noqa: F811
                 f"[SESSION] Tools changed (added={new_tools - old_tools}, "
                 f"removed={old_tools - new_tools}), scheduling deferred session recycle"
             )
-            asyncio.create_task(self._deferred_tool_recycle())
+            task = asyncio.create_task(
+                self._deferred_tool_recycle(), name="RealtimeSession._deferred_tool_recycle"
+            )
+            self._deferred_tool_recycle_tasks.add(task)
+            task.add_done_callback(self._deferred_tool_recycle_tasks.discard)
         else:
             logger.debug("Tool list updated locally")
 

--- a/livekit-plugins/livekit-plugins-hamming/livekit/plugins/hamming/_plugin.py
+++ b/livekit-plugins/livekit-plugins-hamming/livekit/plugins/hamming/_plugin.py
@@ -1057,6 +1057,7 @@ class HammingRuntime:
 
 
 _RUNTIME: HammingRuntime | None = None
+_PENDING_RUNTIME_CLOSES: set[asyncio.Task[None]] = set()
 
 
 def configure_runtime(config: HammingConfig) -> HammingRuntime:
@@ -1916,4 +1917,8 @@ def _reset_runtime_for_tests() -> None:
         asyncio.run(runtime.aclose())
         return
 
-    loop.create_task(runtime.aclose())
+    # Hold the task: the loop only keeps a weak reference, so a discarded one can be
+    # collected before the runtime is actually closed.
+    task = loop.create_task(runtime.aclose())
+    _PENDING_RUNTIME_CLOSES.add(task)
+    task.add_done_callback(_PENDING_RUNTIME_CLOSES.discard)

--- a/livekit-plugins/livekit-plugins-inworld/livekit/plugins/inworld/tts.py
+++ b/livekit-plugins/livekit-plugins-inworld/livekit/plugins/inworld/tts.py
@@ -1088,7 +1088,11 @@ class TTS(tts.TTS):
         return self._session
 
     def prewarm(self) -> None:
-        self._prewarm_task = asyncio.create_task(self._prewarm_impl())
+        # Don't replace a prewarm still in flight: the old task would lose its only
+        # reference, and aclose() cancels just the latest one, so it could build a
+        # pool after shutdown. Same guard as the soniox plugin.
+        if self._prewarm_task is None or self._prewarm_task.done():
+            self._prewarm_task = asyncio.create_task(self._prewarm_impl())
 
     async def _prewarm_impl(self) -> None:
         # Just ensure the pool is created - first acquire will establish a connection

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -154,6 +154,7 @@ class TTS(tts.TTS):
 
         # One persistent connection shared across streams (see _Connection).
         self.__current_connection: _Connection | None = None
+        self._prewarm_task: asyncio.Task[None] | None = None
         self.__conn_lock = asyncio.Lock()
 
     @property
@@ -251,13 +252,20 @@ class TTS(tts.TTS):
                 logger.debug(f"Soniox TTS prewarm failed: {e}")
 
         try:
-            asyncio.create_task(_task(), name="soniox-tts-prewarm")
+            self._prewarm_task = asyncio.create_task(_task(), name="soniox-tts-prewarm")
         except RuntimeError:
             # No running event loop (e.g. called outside async context) — skip.
             pass
 
     async def aclose(self) -> None:
         """Close all streams and the persistent connection."""
+        # Cancel first: the prewarm task calls _current_connection, which opens a new
+        # connection when there is none. A prewarm still in flight here would otherwise
+        # reconnect after close, leaving a live WebSocket nothing owns.
+        if self._prewarm_task is not None:
+            await utils.aio.cancel_and_wait(self._prewarm_task)
+            self._prewarm_task = None
+
         for stream in list(self._streams):
             await stream.aclose()
         self._streams.clear()
@@ -579,6 +587,7 @@ class _Connection:
         self._send_task: asyncio.Task[None] | None = None
         self._recv_task: asyncio.Task[None] | None = None
         self._keepalive_task: asyncio.Task[None] | None = None
+        self._close_task: asyncio.Task[None] | None = None
         self._is_current = True
         self._closed = False
 
@@ -597,11 +606,21 @@ class _Connection:
     def has_stream(self, stream_id: str) -> bool:
         return stream_id in self._streams
 
+    def _schedule_close(self, name: str) -> None:
+        """Close in the background, holding on to the task.
+
+        The event loop only keeps a weak reference to a bare task, so a discarded
+        one can be collected before it runs and the WebSocket would stay open.
+        """
+        if self._close_task is not None and not self._close_task.done():
+            return
+        self._close_task = asyncio.create_task(self.aclose(), name=name)
+
     def mark_non_current(self) -> None:
         """Flag this connection to be replaced; self-closes once idle."""
         self._is_current = False
         if not self._streams and not self._closed:
-            asyncio.create_task(self.aclose(), name="soniox-tts-conn-drain-close")
+            self._schedule_close("soniox-tts-conn-drain-close")
 
     async def connect(self) -> None:
         """Open the WebSocket and start the send/recv/keepalive loops."""
@@ -646,7 +665,7 @@ class _Connection:
         self._streams.pop(stream_id, None)
         # If flagged non-current and idle, self-close.
         if not self._is_current and not self._streams and not self._closed:
-            asyncio.create_task(self.aclose(), name="soniox-tts-conn-drain-close")
+            self._schedule_close("soniox-tts-conn-drain-close")
 
     def send_text(self, stream_id: str, text: str, *, text_end: bool = False) -> None:
         if self._closed or stream_id not in self._streams:
@@ -721,7 +740,7 @@ class _Connection:
             self._fail_all(APIConnectionError("Soniox TTS send loop error"))
         finally:
             if not self._closed:
-                asyncio.create_task(self.aclose(), name="soniox-tts-conn-fail-close")
+                self._schedule_close("soniox-tts-conn-fail-close")
 
     async def _recv_loop(self) -> None:
         try:
@@ -823,7 +842,7 @@ class _Connection:
             self._fail_all(APIConnectionError("Soniox TTS recv loop error"))
         finally:
             if not self._closed:
-                asyncio.create_task(self.aclose(), name="soniox-tts-conn-fail-close")
+                self._schedule_close("soniox-tts-conn-fail-close")
 
     async def _keepalive_loop(self) -> None:
         try:

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -249,10 +249,14 @@ class TTS(tts.TTS):
             try:
                 await self._current_connection(timeout=20.0)
             except Exception as e:
-                logger.debug(f"Soniox TTS prewarm failed: {e}")
+                logger.debug("Soniox TTS prewarm failed", exc_info=e)
 
         try:
-            self._prewarm_task = asyncio.create_task(_task(), name="soniox-tts-prewarm")
+            # Don't replace a prewarm still in flight: the old task would lose its only
+            # reference, and aclose() cancels just the latest one, so it could open a
+            # connection after shutdown. utils.ConnectionPool.prewarm guards the same way.
+            if self._prewarm_task is None or self._prewarm_task.done():
+                self._prewarm_task = asyncio.create_task(_task(), name="soniox-tts-prewarm")
         except RuntimeError:
             # No running event loop (e.g. called outside async context) — skip.
             pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ select = [
     "B",  # flake8-bugbear
     "C4", # flake8-comprehensions
     "UP", # pyupgrade
+    "RUF006", # asyncio-dangling-task: the event loop only weakly references a bare task
 ]
 ignore = ["E501"]
 

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -254,8 +254,11 @@ async def _job_entrypoint_raises_after_shutdown(job_ctx: JobContext) -> None:
         await asyncio.sleep(0)
         fut.set_exception(RuntimeError("room disconnected while waiting for participant"))
 
-    asyncio.create_task(_trigger())
-    await fut
+    trigger_task = asyncio.create_task(_trigger())
+    try:
+        await fut
+    finally:
+        trigger_task.cancel()
 
 
 async def _poll_until(


### PR DESCRIPTION
> **Stacked on #7050, #7051, #7052 and #7053.** Those four are the bug fixes; this PR is the one-line config change plus the last remaining fix. It carries their commits so CI is green here and now — as each of them merges, this diff shrinks on its own. If you would rather land the four first and take this as a two-file PR afterwards, that works too, just say so.

## Why

The event loop keeps only a **weak** reference to a task. A bare `asyncio.create_task(...)` or `asyncio.ensure_future(...)` whose result is thrown away can therefore be garbage collected before it finishes, and the failures are quiet — a websocket that never closes, a `session.update` the server never receives, a tool set that silently never applies.

Ruff has a rule for precisely this: **RUF006, `asyncio-dangling-task`**. The repo's select list is

```toml
select = ["E", "W", "F", "I", "B", "C4", "UP"]
```

so `RUF` is absent and the rule has never run here.

## What it found

Fifteen findings across the repo:

| Where | Count | Fixed in |
|---|---|---|
| `livekit-plugins-soniox/…/tts.py` | 5 | #7051 |
| `livekit-plugins-aws/…/realtime_model.py` | 2 | #7052 |
| `livekit-agents/…/inference/stt.py` | 1 | #7053 |
| `livekit-plugins-inworld/…/tts.py` | 1 | #7050 |
| `livekit-plugins-hamming/…/_plugin.py` | 1 | this PR |
| `examples/` (drive_thru, frontdesk, translation ×2) | 4 | this PR |
| `tests/test_ipc.py` | 1 | this PR |

The examples matter more than their line count suggests — people copy them, so an example that drops a task teaches the bug. Each now holds the task in a set that discards on completion, which is the pattern the asyncio docs ask for.

## Why `RUF006` and not `RUF`

Enabling the whole ruleset adds roughly 460 unrelated findings — `RUF100` unused-noqa alone is 251, `RUF022` unsorted-dunder-all is 77. That is a separate conversation and I did not want to smuggle it in here.

## Checks

- `ruff check` passes clean across both trees with the rule enabled.
- Verified the rule still fires when a dangling task is reintroduced, so this is enforcing rather than passing vacuously.
- `ruff format --check` clean on the changed file.

One note in case it is useful to others: `ensure_future` has the same weak-reference semantics as `create_task`, and RUF006 covers both. A hand-rolled grep or AST scan looking only for `create_task` misses them — that is how the core `inference/stt.py` case in #7053 stayed hidden.
