### PR TITLE
feat(google): support custom prompt config for STT chirp_3

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/stt.py
@@ -98,6 +98,7 @@ class STTOptions:
     speech_start_timeout: NotGivenOr[float] = NOT_GIVEN
     speech_end_timeout: NotGivenOr[float] = NOT_GIVEN
     endpointing_sensitivity: NotGivenOr[EndpointingSensitivity] = NOT_GIVEN
+    custom_prompt_config: NotGivenOr[cloud_speech_v2.CustomPromptConfig] = NOT_GIVEN
 
     @property
     def version(self) -> int:
@@ -165,6 +166,7 @@ class STT(stt.STT):
         speech_start_timeout: NotGivenOr[float] = NOT_GIVEN,
         speech_end_timeout: NotGivenOr[float] = NOT_GIVEN,
         endpointing_sensitivity: NotGivenOr[EndpointingSensitivity] = NOT_GIVEN,
+        custom_prompt_config: NotGivenOr[cloud_speech_v2.CustomPromptConfig] = NOT_GIVEN,
         use_streaming: NotGivenOr[bool] = NOT_GIVEN,
     ):
         """
@@ -206,6 +208,7 @@ class STT(stt.STT):
                 and accuracy when detecting end-of-speech. Only supported with chirp_3.
                 Options: ENDPOINTING_SENSITIVITY_STANDARD (default),
                 ENDPOINTING_SENSITIVITY_SHORT, ENDPOINTING_SENSITIVITY_SUPERSHORT (default: None)
+            custom_prompt_config (CustomPromptConfig): custom prompt configuration for recognition (default: None)
             use_streaming(bool): whether to use streaming for recognition (default: True)
         """
         if is_given(endpointing_sensitivity) and model != "chirp_3":
@@ -234,6 +237,12 @@ class STT(stt.STT):
             enable_word_time_offsets = enable_word_time_offsets
         else:
             enable_word_time_offsets = True
+
+        if is_given(custom_prompt_config) and model != "chirp_3":
+            logger.warning(
+                "custom_prompt_config is only supported with the chirp_3 model; ignoring."
+            )
+            custom_prompt_config = NOT_GIVEN
 
         super().__init__(
             capabilities=stt.STTCapabilities(
@@ -289,6 +298,7 @@ class STT(stt.STT):
             speech_start_timeout=speech_start_timeout,
             speech_end_timeout=speech_end_timeout,
             endpointing_sensitivity=endpointing_sensitivity,
+            custom_prompt_config=custom_prompt_config,
         )
         # user-tuned (phrase, boost) pairs, kept separate so keyterm updates can't clobber them
         self._user_keywords: list[tuple[str, float]] = list(keywords) if is_given(keywords) else []
@@ -404,6 +414,9 @@ class STT(stt.STT):
                     enable_word_time_offsets=config.enable_word_time_offsets,
                     enable_word_confidence=config.enable_word_confidence,
                     profanity_filter=config.profanity_filter,
+                    custom_prompt_config=config.custom_prompt_config
+                    if is_given(config.custom_prompt_config)
+                    else None,
                 ),
                 denoiser_config=config.denoiser_config
                 if is_given(config.denoiser_config)
@@ -509,6 +522,7 @@ class STT(stt.STT):
         speech_start_timeout: NotGivenOr[float] = NOT_GIVEN,
         speech_end_timeout: NotGivenOr[float] = NOT_GIVEN,
         endpointing_sensitivity: NotGivenOr[EndpointingSensitivity] = NOT_GIVEN,
+        custom_prompt_config: NotGivenOr[cloud_speech_v2.CustomPromptConfig] = NOT_GIVEN,
     ) -> None:
         if is_given(languages):
             if isinstance(languages, str):
@@ -574,6 +588,26 @@ class STT(stt.STT):
                 endpointing_sensitivity = NOT_GIVEN
             else:
                 self._config.endpointing_sensitivity = endpointing_sensitivity
+        if is_given(custom_prompt_config):
+            if self._config.model != "chirp_3":
+                logger.warning(
+                    "custom_prompt_config is only supported with the chirp_3 model; ignoring."
+                )
+                custom_prompt_config = NOT_GIVEN
+            else:
+                self._config.custom_prompt_config = custom_prompt_config
+        elif (
+            is_given(model)
+            and self._config.model != "chirp_3"
+            and is_given(self._config.custom_prompt_config)
+        ):
+            # model was switched away from chirp_3; a previously configured prompt is no
+            # longer valid for the new model and must not be sent with it.
+            logger.warning(
+                "model changed away from chirp_3; clearing previously configured "
+                "custom_prompt_config."
+            )
+            self._config.custom_prompt_config = NOT_GIVEN
 
         for stream in self._streams:
             stream.update_options(
@@ -590,6 +624,7 @@ class STT(stt.STT):
                 speech_start_timeout=speech_start_timeout,
                 speech_end_timeout=speech_end_timeout,
                 endpointing_sensitivity=endpointing_sensitivity,
+                custom_prompt_config=custom_prompt_config,
             )
 
     def _get_merged_keywords(self) -> list[tuple[str, float]]:
@@ -683,6 +718,7 @@ class SpeechStream(stt.SpeechStream):
         speech_start_timeout: NotGivenOr[float] = NOT_GIVEN,
         speech_end_timeout: NotGivenOr[float] = NOT_GIVEN,
         endpointing_sensitivity: NotGivenOr[EndpointingSensitivity] = NOT_GIVEN,
+        custom_prompt_config: NotGivenOr[cloud_speech_v2.CustomPromptConfig] = NOT_GIVEN,
     ) -> None:
         if is_given(languages):
             if isinstance(languages, str):
@@ -719,6 +755,16 @@ class SpeechStream(stt.SpeechStream):
             self._config.speech_end_timeout = speech_end_timeout
         if is_given(endpointing_sensitivity):
             self._config.endpointing_sensitivity = endpointing_sensitivity
+        if is_given(custom_prompt_config):
+            self._config.custom_prompt_config = custom_prompt_config
+        elif (
+            is_given(model)
+            and self._config.model != "chirp_3"
+            and is_given(self._config.custom_prompt_config)
+        ):
+            # model was switched away from chirp_3; a previously configured prompt is no
+            # longer valid for the new model and must not be sent with it.
+            self._config.custom_prompt_config = NOT_GIVEN
 
         self._reconnect_event.set()
 
@@ -766,6 +812,9 @@ class SpeechStream(stt.SpeechStream):
                         enable_spoken_punctuation=self._config.spoken_punctuation,
                         enable_word_confidence=self._config.enable_word_confidence,
                         profanity_filter=self._config.profanity_filter,
+                        custom_prompt_config=self._config.custom_prompt_config
+                        if is_given(self._config.custom_prompt_config)
+                        else None,
                     ),
                     denoiser_config=self._config.denoiser_config
                     if is_given(self._config.denoiser_config)

--- a/livekit-plugins/livekit-plugins-google/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-google/pyproject.toml
@@ -23,7 +23,9 @@ classifiers = [
 ]
 dependencies = [
     "google-auth >= 2, < 3",
-    "google-cloud-speech >= 2, < 3",
+    # 2.36 is the floor for cloud_speech_v2.CustomPromptConfig /
+    # RecognitionFeatures.custom_prompt_config, used by STT's custom_prompt_config option.
+    "google-cloud-speech >= 2.36, < 3",
     "google-cloud-texttospeech >= 2.32, < 3",
     # 2.13 is the floor for the Live transcription surface this package uses:
     # LiveServerContent.interim_input_transcription landed in 2.9 and

--- a/tests/test_plugin_google_stt.py
+++ b/tests/test_plugin_google_stt.py
@@ -574,6 +574,104 @@ async def test_voice_activity_timeout_v2_model(mock_google_adc):
     assert stt_v1._config.version == 1
 
 
+async def test_custom_prompt_config_chirp_3(mock_google_adc):
+    """Test custom_prompt_config is applied when using the chirp_3 model."""
+    from livekit.plugins.google import STT
+
+    custom_prompt_config = cloud_speech_v2.CustomPromptConfig(custom_prompt="answer briefly")
+    stt = STT(model="chirp_3", custom_prompt_config=custom_prompt_config)
+    assert stt._config.custom_prompt_config == custom_prompt_config
+
+
+async def test_custom_prompt_config_ignored_for_non_chirp_3_model(mock_google_adc):
+    """Test custom_prompt_config is ignored for models other than chirp_3."""
+    from livekit.agents.types import NOT_GIVEN
+    from livekit.plugins.google import STT
+
+    custom_prompt_config = cloud_speech_v2.CustomPromptConfig(custom_prompt="answer briefly")
+    stt = STT(model="long", custom_prompt_config=custom_prompt_config)
+    assert stt._config.custom_prompt_config is NOT_GIVEN
+
+
+async def test_custom_prompt_config_update_options(mock_google_adc):
+    """Test custom_prompt_config can be updated dynamically, and new values are
+    ignored for models other than chirp_3."""
+    from livekit.agents.types import NOT_GIVEN
+    from livekit.plugins.google import STT
+
+    stt = STT(model="chirp_3")
+    custom_prompt_config = cloud_speech_v2.CustomPromptConfig(custom_prompt="answer briefly")
+    stt.update_options(custom_prompt_config=custom_prompt_config)
+    assert stt._config.custom_prompt_config == custom_prompt_config
+
+    # switching the model away from chirp_3 must drop the now-invalid prompt
+    stt.update_options(model="long")
+    assert stt._config.custom_prompt_config is NOT_GIVEN
+
+    other_custom_prompt_config = cloud_speech_v2.CustomPromptConfig(custom_prompt="be verbose")
+    stt.update_options(custom_prompt_config=other_custom_prompt_config)
+    assert stt._config.custom_prompt_config is NOT_GIVEN
+
+
+async def test_custom_prompt_config_cleared_on_model_switch_from_chirp_3(mock_google_adc):
+    """Test that switching from chirp_3 to another V2 model clears a previously
+    configured custom_prompt_config, so it is not forwarded to a rebuilt
+    non-streaming RecognitionConfig."""
+    from livekit.agents.types import NOT_GIVEN
+    from livekit.plugins.google import STT
+
+    custom_prompt_config = cloud_speech_v2.CustomPromptConfig(custom_prompt="answer briefly")
+    stt = STT(model="chirp_3", custom_prompt_config=custom_prompt_config)
+    assert stt._config.custom_prompt_config == custom_prompt_config
+
+    stt.update_options(model="telephony")
+    assert stt._config.custom_prompt_config is NOT_GIVEN
+
+    config = stt._build_recognition_config(sample_rate=16000, num_channels=1)
+    assert not config.features.custom_prompt_config.custom_prompt
+
+
+async def test_custom_prompt_config_cleared_on_stream_model_switch_from_chirp_3(mock_google_adc):
+    """Test that SpeechStream.update_options also clears a previously configured
+    custom_prompt_config when the model moves away from chirp_3, so an active
+    stream's rebuilt StreamingRecognitionConfig no longer carries the stale prompt."""
+    from livekit.agents.types import NOT_GIVEN
+
+    client = _FakeSpeechClient()
+    custom_prompt_config = cloud_speech_v2.CustomPromptConfig(custom_prompt="answer briefly")
+    options = _default_stt_options()
+    options.model = "chirp_3"
+    options.custom_prompt_config = custom_prompt_config
+    stream = SpeechStream(
+        stt=_FakeSTT(),
+        conn_options=APIConnectOptions(max_retry=0, timeout=0.1),
+        pool=_FakeConnectionPool(client),
+        recognizer_cb=lambda _client: "",
+        config=options,
+    )
+
+    try:
+        assert stream._config.custom_prompt_config == custom_prompt_config
+
+        stream.update_options(model="telephony")
+        assert stream._config.custom_prompt_config is NOT_GIVEN
+
+        streaming_config = stream._build_streaming_config()
+        assert not streaming_config.config.features.custom_prompt_config.custom_prompt
+    finally:
+        await stream.aclose()
+
+
+async def test_custom_prompt_config_in_recognition_config(mock_google_adc):
+    """Test custom_prompt_config is wired into the built RecognitionConfig."""
+    from livekit.plugins.google import STT
+
+    custom_prompt_config = cloud_speech_v2.CustomPromptConfig(custom_prompt="answer briefly")
+    stt = STT(model="chirp_3", custom_prompt_config=custom_prompt_config)
+    config = stt._build_recognition_config(sample_rate=16000, num_channels=1)
+    assert config.features.custom_prompt_config.custom_prompt == "answer briefly"
+
+
 async def test_voice_activity_timeout_update(mock_google_adc):
     """Test that timeout options can be updated dynamically."""
     from livekit.plugins.google import STT


### PR DESCRIPTION
## Summary

Google Speech-to-Text V2 supports a custom prompt when using the `chirp_3` model. This adds a `custom_prompt_config` option to `livekit.plugins.google.STT` so callers can pass a `cloud_speech_v2.CustomPromptConfig` through to the recognition config.

- Added `custom_prompt_config: NotGivenOr[cloud_speech_v2.CustomPromptConfig]` to `STT.__init__` and `STT.update_options`, following the same wiring pattern already used for the existing chirp_3-only `endpointing_sensitivity` option (`STTOptions` → constructor/`update_options` → `SpeechStream` → recognition config).
- If a non-`chirp_3` model is configured, `custom_prompt_config` is ignored with a warning log rather than raising, consistent with how `endpointing_sensitivity` is handled today.
- Wired into both the non-streaming `RecognitionConfig.features` and the streaming `StreamingRecognitionConfig.features`.
- Default is `NOT_GIVEN`, so this is fully backward compatible — no behavior changes for existing callers.

## Test plan

Added unit tests to `tests/test_plugin_google_stt.py` (network-free, using the existing `mock_google_adc` fixture pattern from the `test_voice_activity_timeout_*` tests):

- `test_custom_prompt_config_chirp_3` — value is applied when `model="chirp_3"`.
- `test_custom_prompt_config_ignored_for_non_chirp_3_model` — value is ignored (stays `NOT_GIVEN`) for other models.
- `test_custom_prompt_config_update_options` — value can be updated dynamically via `update_options`, and updates are still ignored for non-chirp_3 models.
- `test_custom_prompt_config_in_recognition_config` — the configured value is correctly wired into the built `RecognitionConfig.features.custom_prompt_config`.

uv run pytest tests/test_plugin_google_stt.py --plugin google -v All 21 tests pass. `make lint` / `make type-check` pass for the changed files (pre-existing, unrelated mypy errors remain in other plugins — `bithuman`/`aws` missing third-party stubs).