### PR TITLE
Add Arize AX to OpenTelemetry examples

### DIFF
--- a/examples/homepage/knowledge_base/products/agent-observability.md
+++ b/examples/homepage/knowledge_base/products/agent-observability.md
@@ -28,7 +28,7 @@ METRICS:
 AgentSession emits a metrics_collected event with detailed metrics including VAD metrics like idle time and inference duration, STT metrics like audio duration, EOU metrics like end of utterance delay and transcription delay, LLM metrics like token counts and time to first token, and TTS metrics like audio duration and time to first byte. Total conversation latency can be approximated as end_of_utterance_delay plus LLM time to first token plus TTS time to first byte. You can also use UsageCollector to aggregate LLM, TTS, and STT usage for cost estimation.
 
 OPENTELEMETRY:
-The Python SDK supports OpenTelemetry integration. You can set a tracer provider to export spans to any OpenTelemetry-compatible backend like LangFuse.
+The Python SDK supports OpenTelemetry integration. You can set a tracer provider to export spans to any OpenTelemetry-compatible backend, including Arize AX, Langfuse, Jaeger, Grafana Tempo, and Honeycomb.
 
 SHARING WITH SUPPORT:
 You can share specific session insights with LiveKit support on Ship plan or higher. Enable sharing from the session's Agent Insights tab to generate a link you can email to support.

--- a/examples/voice_agents/otel_trace.py
+++ b/examples/voice_agents/otel_trace.py
@@ -1,6 +1,7 @@
 import logging
 
 from dotenv import load_dotenv
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.util.types import AttributeValue
 
@@ -27,7 +28,7 @@ load_dotenv()
 
 # This example shows how to trace the agent session with OpenTelemetry.
 # It exports spans over OTLP/HTTP, so it works with any OTLP-compatible backend
-# (Langfuse, Jaeger, Grafana Tempo, Honeycomb, etc.). To enable tracing, set the trace
+# (Arize AX, Langfuse, Jaeger, Grafana Tempo, Honeycomb, etc.). To enable tracing, set the trace
 # provider with `set_tracer_provider` at the module level or inside the entrypoint
 # before `AgentSession.start()`.
 #
@@ -45,6 +46,15 @@ load_dotenv()
 #       headers={"Authorization": f"Basic {auth}", "x-langfuse-ingestion-version": "4"},
 #   )
 # Refer to their docs for latest instructions: https://langfuse.com/integrations/native/opentelemetry#opentelemetry-endpoint
+#
+# Worked example — Arize AX: the endpoint is `https://otlp.arize.com/v1/traces`.
+# Pass your Space ID and API key as OTLP headers, and set the project name as a resource attribute:
+#   setup_otel(
+#       endpoint="https://otlp.arize.com/v1/traces",
+#       headers={"space_id": space_id, "api_key": api_key},
+#       resource_attributes={"openinference.project.name": "livekit-agent"},
+#   )
+# Refer to the Arize guide for the full LiveKit setup: https://arize.com/docs/ax/integrations/python-agent-frameworks/livekit/livekit-agents-tracing
 
 
 def setup_otel(
@@ -52,13 +62,14 @@ def setup_otel(
     *,
     endpoint: str | None = None,
     headers: dict[str, str] | None = None,
+    resource_attributes: dict[str, AttributeValue] | None = None,
 ) -> TracerProvider:
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
     # When endpoint/headers are None, the exporter falls back to the standard
     # OTEL_EXPORTER_OTLP_* environment variables.
-    trace_provider = TracerProvider()
+    trace_provider = TracerProvider(resource=Resource.create(resource_attributes or {}))
     trace_provider.add_span_processor(
         BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint, headers=headers))
     )


### PR DESCRIPTION
## Summary
- Add Arize AX to the list of OTLP-compatible backends in the voice agent OpenTelemetry example.
- Include the Arize AX OTLP/HTTP endpoint, required headers, and project metadata example.
- Update the agent observability knowledge-base text to name multiple OTLP-compatible backends.

## Notes
This is a docs/example-only update. The existing example already supports arbitrary OTLP/HTTP endpoints and headers through `setup_otel`; this adds provider-specific guidance for users sending LiveKit agent traces to Arize AX.

## Testing
- `git diff --check`