### PR TITLE
fix: disable default AGC with noise cancellation

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -310,6 +310,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         self._pre_connect_audio_handler = pre_connect_audio_handler
         self._pre_connect_audio_publications: set[tuple[str, str]] = set()
         self._apm: rtc.AudioProcessingModule | None = None
+        self._stream_auto_gain_control: dict[rtc.AudioStream, bool] = {}
 
     @override
     def _process_frame(self, frame: rtc.AudioFrame) -> None:
@@ -331,12 +332,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             if is_given(self._auto_gain_control)
             else noise_cancellation is None
         )
-        if auto_gain_control and self._apm is None:
-            self._apm = rtc.AudioProcessingModule(auto_gain_control=True)
-        elif not auto_gain_control:
-            self._apm = None
-
-        return rtc.AudioStream.from_track(
+        stream = rtc.AudioStream.from_track(
             track=track,
             sample_rate=self._sample_rate,
             num_channels=self._num_channels,
@@ -344,6 +340,8 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             noise_cancellation=noise_cancellation,
             auto_close_noise_cancellation=False,
         )
+        self._stream_auto_gain_control[stream] = auto_gain_control
+        return stream
 
     @override
     async def _forward_task(
@@ -354,8 +352,14 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
     ) -> None:
+        auto_gain_control = self._stream_auto_gain_control.pop(stream)
         if old_task:
             await aio.cancel_and_wait(old_task)
+
+        if auto_gain_control and self._apm is None:
+            self._apm = rtc.AudioProcessingModule(auto_gain_control=True)
+        elif not auto_gain_control:
+            self._apm = None
 
         pre_connect_key = (participant.identity, publication.sid)
         if (

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -11,7 +11,8 @@ import livekit.rtc as rtc
 from livekit.rtc._proto.track_pb2 import AudioTrackFeature
 
 from ...log import logger
-from ...utils import aio, log_exceptions
+from ...types import NOT_GIVEN, NotGivenOr
+from ...utils import aio, is_given, log_exceptions
 from ..io import AudioInput, VideoInput
 from ._pre_connect_audio import PreConnectAudioHandler
 from .types import NoiseCancellationParams, NoiseCancellationSelector
@@ -285,7 +286,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         | NoiseCancellationSelector
         | rtc.FrameProcessor[rtc.AudioFrame]
         | None,
-        auto_gain_control: bool = True,
+        auto_gain_control: NotGivenOr[bool] = NOT_GIVEN,
         pre_connect_audio_handler: PreConnectAudioHandler | None,
         frame_size_ms: int = 50,
     ) -> None:
@@ -305,11 +306,10 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         self._num_channels = num_channels
         self._frame_size_ms = frame_size_ms
         self._noise_cancellation = noise_cancellation
+        self._auto_gain_control = auto_gain_control
         self._pre_connect_audio_handler = pre_connect_audio_handler
         self._pre_connect_audio_publications: set[tuple[str, str]] = set()
         self._apm: rtc.AudioProcessingModule | None = None
-        if auto_gain_control:
-            self._apm = rtc.AudioProcessingModule(auto_gain_control=True)
 
     @override
     def _process_frame(self, frame: rtc.AudioFrame) -> None:
@@ -325,6 +325,16 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
                 self._update_processor(noise_cancellation)
             else:
                 self._update_processor(None)
+
+        auto_gain_control = (
+            self._auto_gain_control
+            if is_given(self._auto_gain_control)
+            else noise_cancellation is None
+        )
+        if auto_gain_control and self._apm is None:
+            self._apm = rtc.AudioProcessingModule(auto_gain_control=True)
+        elif not auto_gain_control:
+            self._apm = None
 
         return rtc.AudioStream.from_track(
             track=track,

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -176,6 +176,9 @@ class _ParticipantInputStream(Generic[T], ABC):
         """Hook for subclasses to process frames in-place before forwarding."""
         pass
 
+    def _on_forward_task_done(self, stream: rtc.VideoStream | rtc.AudioStream) -> None:
+        pass
+
     @abstractmethod
     def _create_stream(
         self, track: rtc.RemoteTrack, participant: rtc.Participant
@@ -221,15 +224,17 @@ class _ParticipantInputStream(Generic[T], ABC):
             return False
 
         self._close_stream()
-        self._stream = self._create_stream(track, participant)
+        stream = self._create_stream(track, participant)
+        self._stream = stream
         self._track = track
         self._publication = publication
         forward_task = asyncio.create_task(
-            self._forward_task(self._forward_atask, self._stream, track, publication, participant)
+            self._forward_task(self._forward_atask, stream, track, publication, participant)
         )
         self._forward_atask = forward_task
         self._forward_tasks.add(forward_task)
         forward_task.add_done_callback(self._forward_tasks.discard)
+        forward_task.add_done_callback(lambda _task: self._on_forward_task_done(stream))
         return True
 
     def _on_track_unsubscribed(
@@ -316,6 +321,10 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
     def _process_frame(self, frame: rtc.AudioFrame) -> None:
         if self._apm is not None:
             self._apm.process_stream(frame)
+
+    @override
+    def _on_forward_task_done(self, stream: rtc.VideoStream | rtc.AudioStream) -> None:
+        self._stream_auto_gain_control.pop(cast(rtc.AudioStream, stream), None)
 
     @override
     def _create_stream(self, track: rtc.Track, participant: rtc.Participant) -> rtc.AudioStream:

--- a/livekit-agents/livekit/agents/voice/room_io/_input.py
+++ b/livekit-agents/livekit/agents/voice/room_io/_input.py
@@ -11,8 +11,7 @@ import livekit.rtc as rtc
 from livekit.rtc._proto.track_pb2 import AudioTrackFeature
 
 from ...log import logger
-from ...types import NOT_GIVEN, NotGivenOr
-from ...utils import aio, is_given, log_exceptions
+from ...utils import aio, log_exceptions
 from ..io import AudioInput, VideoInput
 from ._pre_connect_audio import PreConnectAudioHandler
 from .types import NoiseCancellationParams, NoiseCancellationSelector
@@ -176,9 +175,6 @@ class _ParticipantInputStream(Generic[T], ABC):
         """Hook for subclasses to process frames in-place before forwarding."""
         pass
 
-    def _on_forward_task_done(self, stream: rtc.VideoStream | rtc.AudioStream) -> None:
-        pass
-
     @abstractmethod
     def _create_stream(
         self, track: rtc.RemoteTrack, participant: rtc.Participant
@@ -224,17 +220,15 @@ class _ParticipantInputStream(Generic[T], ABC):
             return False
 
         self._close_stream()
-        stream = self._create_stream(track, participant)
-        self._stream = stream
+        self._stream = self._create_stream(track, participant)
         self._track = track
         self._publication = publication
         forward_task = asyncio.create_task(
-            self._forward_task(self._forward_atask, stream, track, publication, participant)
+            self._forward_task(self._forward_atask, self._stream, track, publication, participant)
         )
         self._forward_atask = forward_task
         self._forward_tasks.add(forward_task)
         forward_task.add_done_callback(self._forward_tasks.discard)
-        forward_task.add_done_callback(lambda _task: self._on_forward_task_done(stream))
         return True
 
     def _on_track_unsubscribed(
@@ -291,7 +285,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         | NoiseCancellationSelector
         | rtc.FrameProcessor[rtc.AudioFrame]
         | None,
-        auto_gain_control: NotGivenOr[bool] = NOT_GIVEN,
+        auto_gain_control: bool = True,
         pre_connect_audio_handler: PreConnectAudioHandler | None,
         frame_size_ms: int = 50,
     ) -> None:
@@ -311,20 +305,16 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         self._num_channels = num_channels
         self._frame_size_ms = frame_size_ms
         self._noise_cancellation = noise_cancellation
-        self._auto_gain_control = auto_gain_control
         self._pre_connect_audio_handler = pre_connect_audio_handler
         self._pre_connect_audio_publications: set[tuple[str, str]] = set()
         self._apm: rtc.AudioProcessingModule | None = None
-        self._stream_auto_gain_control: dict[rtc.AudioStream, bool] = {}
+        if auto_gain_control:
+            self._apm = rtc.AudioProcessingModule(auto_gain_control=True)
 
     @override
     def _process_frame(self, frame: rtc.AudioFrame) -> None:
         if self._apm is not None:
             self._apm.process_stream(frame)
-
-    @override
-    def _on_forward_task_done(self, stream: rtc.VideoStream | rtc.AudioStream) -> None:
-        self._stream_auto_gain_control.pop(cast(rtc.AudioStream, stream), None)
 
     @override
     def _create_stream(self, track: rtc.Track, participant: rtc.Participant) -> rtc.AudioStream:
@@ -336,12 +326,7 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             else:
                 self._update_processor(None)
 
-        auto_gain_control = (
-            self._auto_gain_control
-            if is_given(self._auto_gain_control)
-            else noise_cancellation is None
-        )
-        stream = rtc.AudioStream.from_track(
+        return rtc.AudioStream.from_track(
             track=track,
             sample_rate=self._sample_rate,
             num_channels=self._num_channels,
@@ -349,8 +334,6 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
             noise_cancellation=noise_cancellation,
             auto_close_noise_cancellation=False,
         )
-        self._stream_auto_gain_control[stream] = auto_gain_control
-        return stream
 
     @override
     async def _forward_task(
@@ -361,14 +344,8 @@ class _ParticipantAudioInputStream(_ParticipantInputStream[rtc.AudioFrame], Audi
         publication: rtc.RemoteTrackPublication,
         participant: rtc.RemoteParticipant,
     ) -> None:
-        auto_gain_control = self._stream_auto_gain_control.pop(stream)
         if old_task:
             await aio.cancel_and_wait(old_task)
-
-        if auto_gain_control and self._apm is None:
-            self._apm = rtc.AudioProcessingModule(auto_gain_control=True)
-        elif not auto_gain_control:
-            self._apm = None
 
         pre_connect_key = (participant.identity, publication.sid)
         if (

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -121,11 +121,7 @@ class RoomIO:
                 num_channels=input_audio_options.num_channels,
                 frame_size_ms=input_audio_options.frame_size_ms,
                 noise_cancellation=input_audio_options.noise_cancellation,
-                auto_gain_control=(
-                    input_audio_options.auto_gain_control
-                    if utils.is_given(input_audio_options.auto_gain_control)
-                    else input_audio_options.noise_cancellation is None
-                ),
+                auto_gain_control=input_audio_options.auto_gain_control,
                 pre_connect_audio_handler=self._pre_connect_audio_handler,
             )
 

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -121,7 +121,11 @@ class RoomIO:
                 num_channels=input_audio_options.num_channels,
                 frame_size_ms=input_audio_options.frame_size_ms,
                 noise_cancellation=input_audio_options.noise_cancellation,
-                auto_gain_control=input_audio_options.auto_gain_control,
+                auto_gain_control=(
+                    input_audio_options.auto_gain_control
+                    if utils.is_given(input_audio_options.auto_gain_control)
+                    else input_audio_options.noise_cancellation is None
+                ),
                 pre_connect_audio_handler=self._pre_connect_audio_handler,
             )
 

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -124,7 +124,10 @@ class RoomIO:
                 auto_gain_control=(
                     input_audio_options.auto_gain_control
                     if utils.is_given(input_audio_options.auto_gain_control)
-                    else input_audio_options.noise_cancellation is None
+                    else (
+                        input_audio_options.noise_cancellation is None
+                        or callable(input_audio_options.noise_cancellation)
+                    )
                 ),
                 pre_connect_audio_handler=self._pre_connect_audio_handler,
             )

--- a/livekit-agents/livekit/agents/voice/room_io/types.py
+++ b/livekit-agents/livekit/agents/voice/room_io/types.py
@@ -68,7 +68,8 @@ class AudioInputOptions:
     ) = None
     auto_gain_control: NotGivenOr[bool] = NOT_GIVEN
     """Enable automatic gain control (AGC) on the input audio.
-    If not given, enabled only when noise cancellation is not configured."""
+    If not given, disabled when noise cancellation is configured directly.
+    Set explicitly when using a noise cancellation selector."""
     pre_connect_audio: bool = True
     """Pre-connect audio enabled or not."""
     pre_connect_audio_timeout: float = 3.0

--- a/livekit-agents/livekit/agents/voice/room_io/types.py
+++ b/livekit-agents/livekit/agents/voice/room_io/types.py
@@ -66,8 +66,9 @@ class AudioInputOptions:
         | rtc.FrameProcessor[rtc.AudioFrame]
         | None
     ) = None
-    auto_gain_control: bool = True
-    """Enable automatic gain control (AGC) on the input audio. Enabled by default."""
+    auto_gain_control: NotGivenOr[bool] = NOT_GIVEN
+    """Enable automatic gain control (AGC) on the input audio.
+    If not given, enabled only when noise cancellation is not configured."""
     pre_connect_audio: bool = True
     """Pre-connect audio enabled or not."""
     pre_connect_audio_timeout: float = 3.0

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -736,21 +736,87 @@ async def test_audio_input_resolves_auto_gain_control(
         auto_gain_control=auto_gain_control,
         pre_connect_audio_handler=None,
     )
-    track, _, participant = _make_track_available_args()
+    stream.set_participant("test-user")
+    track, publication, participant = _make_track_available_args()
+    rtc_stream = _MockAudioStream()
 
     with (
         patch("livekit.rtc.AudioProcessingModule") as create_apm,
-        patch("livekit.rtc.AudioStream.from_track", return_value=_MockAudioStream()),
+        patch("livekit.rtc.AudioStream.from_track", return_value=rtc_stream),
     ):
-        stream._create_stream(track, participant)
+        assert stream._on_track_available(track, publication, participant)
+        await asyncio.wait_for(rtc_stream.started.wait(), timeout=1)
 
-    if expected_auto_gain_control:
-        assert stream._apm is create_apm.return_value
-        create_apm.assert_called_once_with(auto_gain_control=True)
-    else:
-        assert stream._apm is None
-        create_apm.assert_not_called()
+        if expected_auto_gain_control:
+            assert stream._apm is create_apm.return_value
+            create_apm.assert_called_once_with(auto_gain_control=True)
+        else:
+            assert stream._apm is None
+            create_apm.assert_not_called()
+
+        rtc_stream.end()
+        assert stream._forward_atask is not None
+        await stream._forward_atask
+
     await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_audio_input_waits_for_previous_track_before_changing_gain() -> None:
+    room = _FakeRoom()
+    nc_options = rtc.NoiseCancellationOptions(module_id="bvc", options={})
+    selections = iter([nc_options, None])
+    stream = _ParticipantAudioInputStream(
+        room,
+        sample_rate=24000,
+        num_channels=1,
+        noise_cancellation=lambda _params: next(selections),
+        auto_gain_control=NOT_GIVEN,
+        pre_connect_audio_handler=None,
+    )
+    stream.set_participant("test-user")
+    old_track, publication, participant = _make_track_available_args()
+    new_track = MagicMock()
+    old_stream = _NonClosingMockAudioStream()
+    new_stream = _MockAudioStream()
+    cancel_started = asyncio.Event()
+    allow_cancel = asyncio.Event()
+    cancel_and_wait = utils.aio.cancel_and_wait
+
+    async def delayed_cancel(*tasks: asyncio.Future) -> None:
+        cancel_started.set()
+        await allow_cancel.wait()
+        await cancel_and_wait(*tasks)
+
+    apm_created_before_cancel = False
+    try:
+        with (
+            patch("livekit.rtc.AudioProcessingModule") as create_apm,
+            patch(
+                "livekit.rtc.AudioStream.from_track",
+                side_effect=[old_stream, new_stream],
+            ),
+        ):
+            assert stream._on_track_available(old_track, publication, participant)
+            await asyncio.wait_for(old_stream.started.wait(), timeout=1)
+
+            with patch(
+                "livekit.agents.voice.room_io._input.aio.cancel_and_wait",
+                side_effect=delayed_cancel,
+            ):
+                publication.track = new_track
+                assert stream._on_track_available(new_track, publication, participant)
+                await asyncio.wait_for(cancel_started.wait(), timeout=1)
+                apm_created_before_cancel = create_apm.called
+                allow_cancel.set()
+                await asyncio.wait_for(new_stream.started.wait(), timeout=1)
+
+            create_apm.assert_called_once_with(auto_gain_control=True)
+    finally:
+        allow_cancel.set()
+        await stream.aclose()
+
+    assert not apm_created_before_cancel
 
 
 # -- audio output tests -------------------------------------------------------

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -20,7 +20,11 @@ from livekit.agents.voice.room_io._output import (
     _ParticipantTranscriptionOutput,
 )
 from livekit.agents.voice.room_io.room_io import RoomIO
-from livekit.agents.voice.room_io.types import NoiseCancellationParams
+from livekit.agents.voice.room_io.types import (
+    AudioInputOptions,
+    NoiseCancellationParams,
+    RoomOptions,
+)
 from livekit.rtc._proto.track_pb2 import AudioTrackFeature
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
@@ -308,6 +312,55 @@ async def test_roomio_aclose_unregisters_disconnect_and_closes_transcription_out
     room_io._tr_synchronizer.aclose.assert_awaited_once()
     room_io._user_tr_output.aclose.assert_awaited_once()
     room_io._agent_tr_output.aclose.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("noise_cancellation", "auto_gain_control", "expected_auto_gain_control"),
+    [
+        (None, NOT_GIVEN, True),
+        (rtc.NoiseCancellationOptions(module_id="bvc", options={}), NOT_GIVEN, False),
+        (lambda _params: None, NOT_GIVEN, False),
+        (rtc.NoiseCancellationOptions(module_id="bvc", options={}), True, True),
+        (None, False, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_roomio_resolves_auto_gain_control(
+    noise_cancellation,
+    auto_gain_control,
+    expected_auto_gain_control: bool,
+) -> None:
+    room = _FakeRoom()
+    agent_session = SimpleNamespace(
+        on=MagicMock(),
+        off=MagicMock(),
+        input=SimpleNamespace(audio=None, video=None),
+        output=SimpleNamespace(audio=None, transcription=None),
+    )
+    room_io = RoomIO(
+        agent_session,
+        room,
+        options=RoomOptions(
+            audio_input=AudioInputOptions(
+                noise_cancellation=noise_cancellation,
+                auto_gain_control=auto_gain_control,
+                pre_connect_audio=False,
+            ),
+            video_input=False,
+            audio_output=False,
+            text_output=False,
+        ),
+    )
+    audio_input = SimpleNamespace(aclose=AsyncMock())
+
+    with patch(
+        "livekit.agents.voice.room_io.room_io._ParticipantAudioInputStream",
+        return_value=audio_input,
+    ) as create_audio_input:
+        await room_io.start()
+
+    assert create_audio_input.call_args.kwargs["auto_gain_control"] is expected_auto_gain_control
+    await room_io.aclose()
 
 
 # -- frame processor lifecycle tests ------------------------------------------
@@ -704,148 +757,6 @@ async def test_selector_returns_noise_cancellation_options() -> None:
     assert stream._processor is None
 
     await stream.aclose()
-
-
-@pytest.mark.parametrize(
-    ("noise_cancellation", "auto_gain_control", "expected_auto_gain_control"),
-    [
-        (None, NOT_GIVEN, True),
-        (rtc.NoiseCancellationOptions(module_id="bvc", options={}), NOT_GIVEN, False),
-        (lambda _params: None, NOT_GIVEN, True),
-        (
-            lambda _params: rtc.NoiseCancellationOptions(module_id="bvc", options={}),
-            NOT_GIVEN,
-            False,
-        ),
-        (rtc.NoiseCancellationOptions(module_id="bvc", options={}), True, True),
-        (None, False, False),
-    ],
-)
-@pytest.mark.asyncio
-async def test_audio_input_resolves_auto_gain_control(
-    noise_cancellation,
-    auto_gain_control,
-    expected_auto_gain_control: bool,
-) -> None:
-    room = _FakeRoom()
-    stream = _ParticipantAudioInputStream(
-        room,
-        sample_rate=24000,
-        num_channels=1,
-        noise_cancellation=noise_cancellation,
-        auto_gain_control=auto_gain_control,
-        pre_connect_audio_handler=None,
-    )
-    stream.set_participant("test-user")
-    track, publication, participant = _make_track_available_args()
-    rtc_stream = _MockAudioStream()
-
-    with (
-        patch("livekit.rtc.AudioProcessingModule") as create_apm,
-        patch("livekit.rtc.AudioStream.from_track", return_value=rtc_stream),
-    ):
-        assert stream._on_track_available(track, publication, participant)
-        await asyncio.wait_for(rtc_stream.started.wait(), timeout=1)
-
-        if expected_auto_gain_control:
-            assert stream._apm is create_apm.return_value
-            create_apm.assert_called_once_with(auto_gain_control=True)
-        else:
-            assert stream._apm is None
-            create_apm.assert_not_called()
-
-        rtc_stream.end()
-        assert stream._forward_atask is not None
-        await stream._forward_atask
-
-    await stream.aclose()
-
-
-@pytest.mark.asyncio
-async def test_audio_input_waits_for_previous_track_before_changing_gain() -> None:
-    room = _FakeRoom()
-    nc_options = rtc.NoiseCancellationOptions(module_id="bvc", options={})
-    selections = iter([nc_options, None])
-    stream = _ParticipantAudioInputStream(
-        room,
-        sample_rate=24000,
-        num_channels=1,
-        noise_cancellation=lambda _params: next(selections),
-        auto_gain_control=NOT_GIVEN,
-        pre_connect_audio_handler=None,
-    )
-    stream.set_participant("test-user")
-    old_track, publication, participant = _make_track_available_args()
-    new_track = MagicMock()
-    old_stream = _NonClosingMockAudioStream()
-    new_stream = _MockAudioStream()
-    cancel_started = asyncio.Event()
-    allow_cancel = asyncio.Event()
-    cancel_and_wait = utils.aio.cancel_and_wait
-
-    async def delayed_cancel(*tasks: asyncio.Future) -> None:
-        cancel_started.set()
-        await allow_cancel.wait()
-        await cancel_and_wait(*tasks)
-
-    apm_created_before_cancel = False
-    try:
-        with (
-            patch("livekit.rtc.AudioProcessingModule") as create_apm,
-            patch(
-                "livekit.rtc.AudioStream.from_track",
-                side_effect=[old_stream, new_stream],
-            ),
-        ):
-            assert stream._on_track_available(old_track, publication, participant)
-            await asyncio.wait_for(old_stream.started.wait(), timeout=1)
-
-            with patch(
-                "livekit.agents.voice.room_io._input.aio.cancel_and_wait",
-                side_effect=delayed_cancel,
-            ):
-                publication.track = new_track
-                assert stream._on_track_available(new_track, publication, participant)
-                await asyncio.wait_for(cancel_started.wait(), timeout=1)
-                apm_created_before_cancel = create_apm.called
-                allow_cancel.set()
-                await asyncio.wait_for(new_stream.started.wait(), timeout=1)
-
-            create_apm.assert_called_once_with(auto_gain_control=True)
-    finally:
-        allow_cancel.set()
-        await stream.aclose()
-
-    assert not apm_created_before_cancel
-
-
-@pytest.mark.asyncio
-async def test_audio_input_discards_gain_metadata_when_forwarding_never_starts() -> None:
-    room = _FakeRoom()
-    stream = _ParticipantAudioInputStream(
-        room,
-        sample_rate=24000,
-        num_channels=1,
-        noise_cancellation=None,
-        auto_gain_control=NOT_GIVEN,
-        pre_connect_audio_handler=None,
-    )
-    stream.set_participant("test-user")
-    track, publication, participant = _make_track_available_args()
-    rtc_stream = _MockAudioStream()
-
-    try:
-        with patch("livekit.rtc.AudioStream.from_track", return_value=rtc_stream):
-            assert stream._on_track_available(track, publication, participant)
-            assert stream._forward_atask is not None
-            stream._forward_atask.cancel()
-            with pytest.raises(asyncio.CancelledError):
-                await stream._forward_atask
-            await asyncio.sleep(0)
-
-        assert not stream._stream_auto_gain_control
-    finally:
-        await stream.aclose()
 
 
 # -- audio output tests -------------------------------------------------------

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -819,6 +819,35 @@ async def test_audio_input_waits_for_previous_track_before_changing_gain() -> No
     assert not apm_created_before_cancel
 
 
+@pytest.mark.asyncio
+async def test_audio_input_discards_gain_metadata_when_forwarding_never_starts() -> None:
+    room = _FakeRoom()
+    stream = _ParticipantAudioInputStream(
+        room,
+        sample_rate=24000,
+        num_channels=1,
+        noise_cancellation=None,
+        auto_gain_control=NOT_GIVEN,
+        pre_connect_audio_handler=None,
+    )
+    stream.set_participant("test-user")
+    track, publication, participant = _make_track_available_args()
+    rtc_stream = _MockAudioStream()
+
+    try:
+        with patch("livekit.rtc.AudioStream.from_track", return_value=rtc_stream):
+            assert stream._on_track_available(track, publication, participant)
+            assert stream._forward_atask is not None
+            stream._forward_atask.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await stream._forward_atask
+            await asyncio.sleep(0)
+
+        assert not stream._stream_auto_gain_control
+    finally:
+        await stream.aclose()
+
+
 # -- audio output tests -------------------------------------------------------
 
 

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -20,11 +20,7 @@ from livekit.agents.voice.room_io._output import (
     _ParticipantTranscriptionOutput,
 )
 from livekit.agents.voice.room_io.room_io import RoomIO
-from livekit.agents.voice.room_io.types import (
-    AudioInputOptions,
-    NoiseCancellationParams,
-    RoomOptions,
-)
+from livekit.agents.voice.room_io.types import NoiseCancellationParams
 from livekit.rtc._proto.track_pb2 import AudioTrackFeature
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
@@ -312,54 +308,6 @@ async def test_roomio_aclose_unregisters_disconnect_and_closes_transcription_out
     room_io._tr_synchronizer.aclose.assert_awaited_once()
     room_io._user_tr_output.aclose.assert_awaited_once()
     room_io._agent_tr_output.aclose.assert_awaited_once()
-
-
-@pytest.mark.parametrize(
-    ("noise_cancellation", "auto_gain_control", "expected_auto_gain_control"),
-    [
-        (None, NOT_GIVEN, True),
-        (rtc.NoiseCancellationOptions(module_id="bvc", options={}), NOT_GIVEN, False),
-        (rtc.NoiseCancellationOptions(module_id="bvc", options={}), True, True),
-        (None, False, False),
-    ],
-)
-@pytest.mark.asyncio
-async def test_roomio_resolves_auto_gain_control(
-    noise_cancellation,
-    auto_gain_control,
-    expected_auto_gain_control: bool,
-) -> None:
-    room = _FakeRoom()
-    agent_session = SimpleNamespace(
-        on=MagicMock(),
-        off=MagicMock(),
-        input=SimpleNamespace(audio=None, video=None),
-        output=SimpleNamespace(audio=None, transcription=None),
-    )
-    room_io = RoomIO(
-        agent_session,
-        room,
-        options=RoomOptions(
-            audio_input=AudioInputOptions(
-                noise_cancellation=noise_cancellation,
-                auto_gain_control=auto_gain_control,
-                pre_connect_audio=False,
-            ),
-            video_input=False,
-            audio_output=False,
-            text_output=False,
-        ),
-    )
-    audio_input = SimpleNamespace(aclose=AsyncMock())
-
-    with patch(
-        "livekit.agents.voice.room_io.room_io._ParticipantAudioInputStream",
-        return_value=audio_input,
-    ) as create_audio_input:
-        await room_io.start()
-
-    assert create_audio_input.call_args.kwargs["auto_gain_control"] is expected_auto_gain_control
-    await room_io.aclose()
 
 
 # -- frame processor lifecycle tests ------------------------------------------
@@ -755,6 +703,53 @@ async def test_selector_returns_noise_cancellation_options() -> None:
 
     assert stream._processor is None
 
+    await stream.aclose()
+
+
+@pytest.mark.parametrize(
+    ("noise_cancellation", "auto_gain_control", "expected_auto_gain_control"),
+    [
+        (None, NOT_GIVEN, True),
+        (rtc.NoiseCancellationOptions(module_id="bvc", options={}), NOT_GIVEN, False),
+        (lambda _params: None, NOT_GIVEN, True),
+        (
+            lambda _params: rtc.NoiseCancellationOptions(module_id="bvc", options={}),
+            NOT_GIVEN,
+            False,
+        ),
+        (rtc.NoiseCancellationOptions(module_id="bvc", options={}), True, True),
+        (None, False, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_audio_input_resolves_auto_gain_control(
+    noise_cancellation,
+    auto_gain_control,
+    expected_auto_gain_control: bool,
+) -> None:
+    room = _FakeRoom()
+    stream = _ParticipantAudioInputStream(
+        room,
+        sample_rate=24000,
+        num_channels=1,
+        noise_cancellation=noise_cancellation,
+        auto_gain_control=auto_gain_control,
+        pre_connect_audio_handler=None,
+    )
+    track, _, participant = _make_track_available_args()
+
+    with (
+        patch("livekit.rtc.AudioProcessingModule") as create_apm,
+        patch("livekit.rtc.AudioStream.from_track", return_value=_MockAudioStream()),
+    ):
+        stream._create_stream(track, participant)
+
+    if expected_auto_gain_control:
+        assert stream._apm is create_apm.return_value
+        create_apm.assert_called_once_with(auto_gain_control=True)
+    else:
+        assert stream._apm is None
+        create_apm.assert_not_called()
     await stream.aclose()
 
 

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -319,7 +319,8 @@ async def test_roomio_aclose_unregisters_disconnect_and_closes_transcription_out
     [
         (None, NOT_GIVEN, True),
         (rtc.NoiseCancellationOptions(module_id="bvc", options={}), NOT_GIVEN, False),
-        (lambda _params: None, NOT_GIVEN, False),
+        (lambda _params: None, NOT_GIVEN, True),
+        (lambda _params: None, False, False),
         (rtc.NoiseCancellationOptions(module_id="bvc", options={}), True, True),
         (None, False, False),
     ],

--- a/tests/test_room_io.py
+++ b/tests/test_room_io.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from livekit import rtc
-from livekit.agents import utils
+from livekit.agents import NOT_GIVEN, utils
 from livekit.agents.voice.io import PlaybackFinishedEvent
 from livekit.agents.voice.room_io._input import (
     _ParticipantAudioInputStream,
@@ -20,7 +20,11 @@ from livekit.agents.voice.room_io._output import (
     _ParticipantTranscriptionOutput,
 )
 from livekit.agents.voice.room_io.room_io import RoomIO
-from livekit.agents.voice.room_io.types import NoiseCancellationParams
+from livekit.agents.voice.room_io.types import (
+    AudioInputOptions,
+    NoiseCancellationParams,
+    RoomOptions,
+)
 from livekit.rtc._proto.track_pb2 import AudioTrackFeature
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
@@ -308,6 +312,54 @@ async def test_roomio_aclose_unregisters_disconnect_and_closes_transcription_out
     room_io._tr_synchronizer.aclose.assert_awaited_once()
     room_io._user_tr_output.aclose.assert_awaited_once()
     room_io._agent_tr_output.aclose.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("noise_cancellation", "auto_gain_control", "expected_auto_gain_control"),
+    [
+        (None, NOT_GIVEN, True),
+        (rtc.NoiseCancellationOptions(module_id="bvc", options={}), NOT_GIVEN, False),
+        (rtc.NoiseCancellationOptions(module_id="bvc", options={}), True, True),
+        (None, False, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_roomio_resolves_auto_gain_control(
+    noise_cancellation,
+    auto_gain_control,
+    expected_auto_gain_control: bool,
+) -> None:
+    room = _FakeRoom()
+    agent_session = SimpleNamespace(
+        on=MagicMock(),
+        off=MagicMock(),
+        input=SimpleNamespace(audio=None, video=None),
+        output=SimpleNamespace(audio=None, transcription=None),
+    )
+    room_io = RoomIO(
+        agent_session,
+        room,
+        options=RoomOptions(
+            audio_input=AudioInputOptions(
+                noise_cancellation=noise_cancellation,
+                auto_gain_control=auto_gain_control,
+                pre_connect_audio=False,
+            ),
+            video_input=False,
+            audio_output=False,
+            text_output=False,
+        ),
+    )
+    audio_input = SimpleNamespace(aclose=AsyncMock())
+
+    with patch(
+        "livekit.agents.voice.room_io.room_io._ParticipantAudioInputStream",
+        return_value=audio_input,
+    ) as create_audio_input:
+        await room_io.start()
+
+    assert create_audio_input.call_args.kwargs["auto_gain_control"] is expected_auto_gain_control
+    await room_io.aclose()
 
 
 # -- frame processor lifecycle tests ------------------------------------------


### PR DESCRIPTION
Noise cancellation already manages input levels, so RoomIO should not apply automatic gain control by default at the same time. When `auto_gain_control` is omitted, AGC now turns on only when noise cancellation is absent. Explicit overrides remain supported.

Addresses AGT-3419

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> we should disable auto gain control when there is noise cancellation enabled.
>
> we should just make it NotGivenOr[bool] = NOT_GIVEN, and only set to True if there is no noise cancellation

</details>