### PR TITLE
fix(voice): drop the recognition turn a false interruption resumed over

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -4516,7 +4516,7 @@ class AgentActivity(RecognitionHooks):
     def _start_false_interruption_timer(self, timeout: float) -> None:
         self._cancel_false_interruption_timer()
 
-        def _on_false_interruption() -> None:
+        def _on_false_interruption(*, turn_dropped: bool) -> None:
             if self._paused_speech is None or (
                 self._current_speech and self._current_speech is not self._paused_speech.handle
             ):
@@ -4532,10 +4532,19 @@ class AgentActivity(RecognitionHooks):
                 and not self._paused_speech.handle.done()
             ):
                 if (recognition := self._audio_recognition) is not None:
-                    # the interruption was false, so the turn that raised it is abandoned: drop
-                    # it before the agent's next speech interval opens, or the next real
-                    # utterance inherits its speech-start anchor and buffered transcript
-                    recognition._clear_user_turn()
+                    # the interruption was false, so the turn that raised it is abandoned: let
+                    # it go before the agent's next speech interval opens, or the next real
+                    # utterance inherits its speech-start anchor
+                    if turn_dropped:
+                        # a decision ran and dropped this turn, so nothing is still in flight
+                        # for it: discard the buffered transcript too, or a confirmed
+                        # backchannel prepends itself to the next utterance
+                        recognition._clear_user_turn()
+                    else:
+                        # the timeout fired with no decision open, and turn_detection="stt"
+                        # starts no bounce on VAD END_OF_SPEECH — a slow stt final for real
+                        # speech may still be on its way, so keep whatever can still commit
+                        recognition._release_user_turn_anchors()
 
                 self._session._update_agent_state(
                     self._paused_speech.agent_state,
@@ -4571,7 +4580,7 @@ class AgentActivity(RecognitionHooks):
             if settled.cancelled() or (recognition is not None and recognition._closing.is_set()):
                 return  # torn down instead of decided; closing releases the pause itself
 
-            _on_false_interruption()
+            _on_false_interruption(turn_dropped=True)
 
         def _on_timeout() -> None:
             self._false_interruption_timer = None
@@ -4586,7 +4595,7 @@ class AgentActivity(RecognitionHooks):
                 eot_task.add_done_callback(_on_turn_settled)
                 return
 
-            _on_false_interruption()
+            _on_false_interruption(turn_dropped=False)
 
         self._false_interruption_timer = self._session._loop.call_later(timeout, _on_timeout)
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -4531,12 +4531,18 @@ class AgentActivity(RecognitionHooks):
                 and audio_output.can_pause
                 and not self._paused_speech.handle.done()
             ):
+                if (recognition := self._audio_recognition) is not None:
+                    # the interruption was false, so the turn that raised it is abandoned: drop
+                    # it before the agent's next speech interval opens, or the next real
+                    # utterance inherits its speech-start anchor and buffered transcript
+                    recognition._clear_user_turn()
+
                 self._session._update_agent_state(
                     self._paused_speech.agent_state,
                     otel_context=self._paused_speech.handle._agent_turn_context,
                 )
-                if self._audio_recognition and self._paused_speech.agent_state == "speaking":
-                    self._audio_recognition._on_start_of_agent_speech(started_at=time.time())
+                if recognition is not None and self._paused_speech.agent_state == "speaking":
+                    recognition._on_start_of_agent_speech(started_at=time.time())
                 if self.interruption_enabled:
                     self._disable_vad_interruption_soon()
                 audio_output.resume()

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -4516,7 +4516,7 @@ class AgentActivity(RecognitionHooks):
     def _start_false_interruption_timer(self, timeout: float) -> None:
         self._cancel_false_interruption_timer()
 
-        def _on_false_interruption(*, turn_dropped: bool) -> None:
+        def _on_false_interruption() -> None:
             if self._paused_speech is None or (
                 self._current_speech and self._current_speech is not self._paused_speech.handle
             ):
@@ -4532,18 +4532,16 @@ class AgentActivity(RecognitionHooks):
                 and not self._paused_speech.handle.done()
             ):
                 if (recognition := self._audio_recognition) is not None:
-                    # the interruption was false, so the turn that raised it is abandoned: let
-                    # it go before the agent's next speech interval opens, or the next real
-                    # utterance inherits its speech-start anchor
-                    if turn_dropped:
-                        # a decision ran and dropped this turn, so nothing is still in flight
-                        # for it: discard the buffered transcript too, or a confirmed
-                        # backchannel prepends itself to the next utterance
+                    # the interruption was false, so the turn that raised it is abandoned: let it
+                    # go before the agent's next speech interval opens, or the next real utterance
+                    # inherits its speech-start anchor. How much can go depends on whether the
+                    # turn was decided, which only the decision itself knows: this can be reached
+                    # with no decision ever made (turn_detection="stt" starts no bounce on VAD
+                    # END_OF_SPEECH), and then a slow stt final for real speech may still be on
+                    # its way.
+                    if recognition._user_turn_dropped:
                         recognition._clear_user_turn()
                     else:
-                        # the timeout fired with no decision open, and turn_detection="stt"
-                        # starts no bounce on VAD END_OF_SPEECH — a slow stt final for real
-                        # speech may still be on its way, so keep whatever can still commit
                         recognition._release_user_turn_anchors()
 
                 self._session._update_agent_state(
@@ -4580,7 +4578,7 @@ class AgentActivity(RecognitionHooks):
             if settled.cancelled() or (recognition is not None and recognition._closing.is_set()):
                 return  # torn down instead of decided; closing releases the pause itself
 
-            _on_false_interruption(turn_dropped=True)
+            _on_false_interruption()
 
         def _on_timeout() -> None:
             self._false_interruption_timer = None
@@ -4595,7 +4593,7 @@ class AgentActivity(RecognitionHooks):
                 eot_task.add_done_callback(_on_turn_settled)
                 return
 
-            _on_false_interruption(turn_dropped=False)
+            _on_false_interruption()
 
         self._false_interruption_timer = self._session._loop.call_later(timeout, _on_timeout)
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -283,6 +283,9 @@ class AudioRecognition:
         # used for manual commit_user_turn
         self._final_transcript_received = asyncio.Event()
         self._final_transcript_confidence: list[float] = []
+        # set by the end-of-turn decision; read by the false-interruption resume, which has to
+        # know whether this turn was decided and dropped or is simply still open
+        self._user_turn_dropped = False
         self._audio_transcript = ""
         self._audio_interim_transcript = ""
         # used for STTs that support preflight mode, so it could start preemptive generation earlier
@@ -989,6 +992,7 @@ class AudioRecognition:
         self._speech_start_time = None
         self._vad_speech_started = False
         self._last_emitted_prediction = None
+        self._user_turn_dropped = False
         self._turn_tracker = _UserTurnTracker()
 
         # end any in-progress user_turn span so the next speech starts a fresh one
@@ -1004,6 +1008,7 @@ class AudioRecognition:
         self._last_speaking_time = None
         self._vad_speech_started = False
         self._user_turn_committed = False
+        self._user_turn_dropped = False
         self._last_emitted_prediction = None
         if self._turn_detector_stream is not None:
             self._turn_detector_stream.flush(reason="clear_user_turn")
@@ -1377,6 +1382,7 @@ class AudioRecognition:
             if not self._vad_speech_started:
                 self._speech_start_time = speech_start_time
                 self._vad_speech_started = True
+                self._user_turn_dropped = False
 
             self._cancel_transcription_timeout()
 
@@ -1767,6 +1773,9 @@ class AudioRecognition:
                     self._turn_detector_stream.flush(reason="turn committed")
                     self._turn_detector_prediction_fut = None
                     self._turn_detector_flushed = True
+
+            # a dropped turn keeps accumulating, so nothing else records the verdict
+            self._user_turn_dropped = not committed
 
             # reset turn-scoped barge-in state once per logical turn (commit or drop)
             self._turn_backchannel_over_agent = False

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -980,6 +980,16 @@ class AudioRecognition:
         self._turn_detector_prediction_fut = None
         return stream
 
+    def _open_user_turn(self, speech_start_time: float) -> None:
+        """Anchor a new logical user turn, superseding the previous turn's verdict.
+
+        Every path that takes a fresh ``_speech_start_time`` goes through here.
+        ``_user_turn_dropped`` describes the turn that just ended, and reading it against
+        this one is how a real transcript ends up discarded.
+        """
+        self._speech_start_time = speech_start_time
+        self._user_turn_dropped = False
+
     def _release_user_turn_anchors(self) -> None:
         """Release an open turn's anchors without discarding what could still arrive.
 
@@ -1362,11 +1372,12 @@ class AudioRecognition:
         elif ev.type == stt.SpeechEventType.START_OF_SPEECH and self._turn_detection_mode == "stt":
             # If the plugin provided a server onset timestamp, use it;
             # otherwise fall back to message arrival time.
-            if self._speech_start_time is None:
-                self._speech_start_time = ev.speech_start_time or time.time()
+            if (speech_start_time := self._speech_start_time) is None:
+                speech_start_time = ev.speech_start_time or time.time()
+                self._open_user_turn(speech_start_time)
 
-            with tracer.use_span(self._ensure_user_turn_span(start_time=self._speech_start_time)):
-                self._hooks.on_start_of_speech(None, speech_start_time=self._speech_start_time)
+            with tracer.use_span(self._ensure_user_turn_span(start_time=speech_start_time)):
+                self._hooks.on_start_of_speech(None, speech_start_time=speech_start_time)
 
             self._speaking = True
             self._last_speaking_time = stt_last_speaking_time
@@ -1380,9 +1391,8 @@ class AudioRecognition:
             speech_start_time = time.time() - ev.speech_duration - ev.inference_duration
             self._active_vad_speech_started_at = speech_start_time
             if not self._vad_speech_started:
-                self._speech_start_time = speech_start_time
+                self._open_user_turn(speech_start_time)
                 self._vad_speech_started = True
-                self._user_turn_dropped = False
 
             self._cancel_transcription_timeout()
 
@@ -1410,7 +1420,7 @@ class AudioRecognition:
                 self._last_speaking_time = time.time()
 
                 if self._speech_start_time is None:
-                    self._speech_start_time = time.time() - ev.raw_accumulated_speech
+                    self._open_user_turn(time.time() - ev.raw_accumulated_speech)
                 if self._speaking and self._turn_detector_prediction_fut is not None:
                     if self._turn_detector_stream is not None:
                         self._turn_detector_stream.cancel_inference()

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -977,6 +977,23 @@ class AudioRecognition:
         self._turn_detector_prediction_fut = None
         return stream
 
+    def _release_user_turn_anchors(self) -> None:
+        """Release an open turn's anchors without discarding what could still arrive.
+
+        For a turn abandoned before any end-of-turn decision ran: its speech-start anchor
+        must not be inherited by the next utterance, but an stt final for this speech may
+        still be in flight. Unlike `_clear_user_turn`, the transcript, the accumulated
+        confidence, the turn detector's buffer and the stt pipeline are left alone, so a
+        late final can still commit the turn.
+        """
+        self._speech_start_time = None
+        self._vad_speech_started = False
+        self._last_emitted_prediction = None
+        self._turn_tracker = _UserTurnTracker()
+
+        # end any in-progress user_turn span so the next speech starts a fresh one
+        self._end_user_turn_span()
+
     def _clear_user_turn(self) -> None:
         self._audio_transcript = ""
         self._audio_interim_transcript = ""

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -14,7 +14,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 
-from livekit.agents import Agent, AgentSession, TurnHandlingOptions
+from livekit.agents import Agent, AgentSession, TurnHandlingOptions, vad
 from livekit.agents.inference import OverlappingSpeechEvent
 from livekit.agents.voice.agent_activity import AgentActivity, _PausedSpeechInfo
 from livekit.agents.voice.audio_recognition import (
@@ -385,3 +385,44 @@ async def test_resume_is_immediate_when_no_turn_decision_is_open(
 
     assert [name for name, _ in events] == ["resume"]
     assert events[0][1] - t0 == pytest.approx(FALSE_INTERRUPTION_TIMEOUT, abs=0.1)
+
+
+async def test_resume_drops_the_turn_it_resumed_over(monkeypatch: pytest.MonkeyPatch) -> None:
+    # a confirmed false interruption abandons the recognition turn that caused it; leaving that
+    # turn open lets the next real utterance inherit its anchor, because _on_vad_event only
+    # takes a new _speech_start_time while _vad_speech_started is still False
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = _session()
+    activity, _ = _paused_activity(session)
+
+    stale_start = time.time() - 12.0
+
+    activity.on_end_of_speech(None)
+    recognition = _recognition(activity, last_speaking_time=time.time() - VAD_MIN_SILENCE)
+    activity._audio_recognition = recognition
+    # the VAD turn behind the interruption: opened, never transcribed
+    recognition._speech_start_time = stale_start
+    recognition._vad_speech_started = True
+    # a confirmed backchannel is what makes the turn drop rather than commit
+    recognition._turn_backchannel_over_agent = True
+    recognition._run_eou_detection(MagicMock(), trigger="vad")
+
+    await asyncio.sleep(MAX_DELAY + 0.3)
+    assert activity._paused_speech is None  # the speech resumed
+
+    # the later, real utterance
+    onset = time.time()
+    await recognition._on_vad_event(
+        vad.VADEvent(
+            type=vad.VADEventType.START_OF_SPEECH,
+            samples_index=0,
+            timestamp=onset,
+            speech_duration=0.1,
+            silence_duration=0.0,
+        )
+    )
+    await session.aclose()
+
+    assert recognition._speech_start_time == pytest.approx(onset - 0.1, abs=0.1)

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -426,3 +426,40 @@ async def test_resume_drops_the_turn_it_resumed_over(monkeypatch: pytest.MonkeyP
     await session.aclose()
 
     assert recognition._speech_start_time == pytest.approx(onset - 0.1, abs=0.1)
+
+
+async def test_resume_without_a_turn_decision_keeps_a_late_transcript_alive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # turn_detection="stt" starts no eou bounce on VAD END_OF_SPEECH, so the resume timer fires
+    # with no decision open. The speech may have been real with a slow stt final still on its
+    # way: letting the turn go must release its anchor without taking the pipeline — and the
+    # transcript it can still commit — with it
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = _session()
+    activity, _ = _paused_activity(session)
+
+    recognition = _recognition(activity, last_speaking_time=time.time() - VAD_MIN_SILENCE)
+    activity._audio_recognition = recognition
+    recognition._speech_start_time = time.time() - 12.0
+    recognition._vad_speech_started = True
+    recognition._audio_transcript = "what the caller actually said"
+    pipeline = MagicMock()
+    pipeline.aclose = AsyncMock()
+    recognition._stt_pipeline = pipeline
+
+    # no _run_eou_detection: on an stt pipeline the bounce waits for the stt final
+    activity.on_end_of_speech(None)
+    assert recognition._end_of_turn_task is None
+
+    await asyncio.sleep(FALSE_INTERRUPTION_TIMEOUT + 0.2)
+    await session.aclose()
+
+    assert activity._paused_speech is None  # the speech resumed
+    assert recognition._speech_start_time is None  # the anchor is released
+    # everything a late final needs to commit the turn survived
+    assert recognition._audio_transcript == "what the caller actually said"
+    assert recognition._stt_pipeline is pipeline
+    pipeline.aclose.assert_not_called()

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -102,6 +102,7 @@ def _recognition(hooks: AgentActivity, last_speaking_time: float) -> AudioRecogn
     ar._vad_speech_started = False
     ar._end_of_turn_task = None
     ar._user_turn_committed = False
+    ar._user_turn_dropped = False
     ar._vad = None
     ar._last_language = None
     ar._last_emitted_prediction = None
@@ -463,3 +464,42 @@ async def test_resume_without_a_turn_decision_keeps_a_late_transcript_alive(
     assert recognition._audio_transcript == "what the caller actually said"
     assert recognition._stt_pipeline is pipeline
     pipeline.aclose.assert_not_called()
+
+
+async def test_a_backchannel_dropped_before_the_timeout_does_not_leak_forward(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # the shipped false_interruption_timeout is 2s and a confirmed backchannel drops in a few
+    # hundred ms, so the decision normally lands well before the resume timer. The verdict has
+    # to survive that gap: a dropped turn keeps its transcript, which would otherwise be
+    # prepended to the next real utterance (_audio_transcript accumulates)
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = _session()
+    activity, handle = _paused_activity(session)
+    # a resume timer that outlives the turn decision, unlike the module default
+    late_timeout = MAX_DELAY + 0.3
+    activity._paused_speech = _PausedSpeechInfo(
+        handle=handle, agent_state="speaking", timeout=late_timeout
+    )
+
+    activity.on_end_of_speech(None)
+    recognition = _recognition(activity, last_speaking_time=time.time() - VAD_MIN_SILENCE)
+    activity._audio_recognition = recognition
+    recognition._speech_start_time = time.time() - 12.0
+    recognition._vad_speech_started = True
+    recognition._audio_transcript = "mm-hmm"
+    recognition._turn_backchannel_over_agent = True
+    recognition._run_eou_detection(MagicMock(), trigger="vad")
+
+    # the turn is dropped here, while the resume timer is still running
+    await asyncio.sleep(MAX_DELAY + 0.1)
+    assert recognition._user_turn_dropped is True
+
+    await asyncio.sleep(late_timeout - MAX_DELAY + 0.2)
+    await session.aclose()
+
+    assert activity._paused_speech is None  # the speech resumed
+    assert recognition._speech_start_time is None
+    assert recognition._audio_transcript == ""  # nothing left to prepend

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -14,7 +14,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 
-from livekit.agents import Agent, AgentSession, TurnHandlingOptions, vad
+from livekit.agents import Agent, AgentSession, TurnHandlingOptions, stt, vad
 from livekit.agents.inference import OverlappingSpeechEvent
 from livekit.agents.voice.agent_activity import AgentActivity, _PausedSpeechInfo
 from livekit.agents.voice.audio_recognition import (
@@ -46,6 +46,7 @@ def _recognition(hooks: AgentActivity, last_speaking_time: float) -> AudioRecogn
     ar._session = MagicMock()
     ar._hooks = hooks
     ar._stt = None  # realtime model, no STT
+    ar._stt_aligned_transcript = False
     ar._audio_transcript = ""
     ar._turn_detection_mode = None
     ar._turn_detector = MagicMock(spec=_StreamingTurnDetector)
@@ -503,3 +504,42 @@ async def test_a_backchannel_dropped_before_the_timeout_does_not_leak_forward(
     assert activity._paused_speech is None  # the speech resumed
     assert recognition._speech_start_time is None
     assert recognition._audio_transcript == ""  # nothing left to prepend
+
+
+async def test_an_stt_anchored_turn_supersedes_the_previous_verdict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # the resume timer is also armed from the stt hooks, so a session can anchor its next turn
+    # through _on_stt_event rather than a VAD start. The dropped verdict belongs to the turn
+    # that ended: read against the new one it would erase a real transcript
+    monkeypatch.setenv("LIVEKIT_API_KEY", "k")
+    monkeypatch.setenv("LIVEKIT_API_SECRET", "s")
+
+    session = _session()
+    activity, _ = _paused_activity(session)
+
+    recognition = _recognition(activity, last_speaking_time=time.time() - VAD_MIN_SILENCE)
+    activity._audio_recognition = recognition
+    recognition._turn_detection_mode = "stt"
+    # the previous turn was decided and dropped
+    recognition._user_turn_dropped = True
+
+    # the next turn takes its anchor from the stt stream, never from a VAD start
+    onset = time.time()
+    await recognition._on_stt_event(
+        stt.SpeechEvent(
+            type=stt.SpeechEventType.START_OF_SPEECH,
+            alternatives=[stt.SpeechData(language="en", text="", start_time=onset)],
+        )
+    )
+    assert recognition._speech_start_time == pytest.approx(onset, abs=1.0)
+    assert recognition._user_turn_dropped is False
+
+    # a slow final for this new turn is still on its way when the resume fires
+    recognition._audio_transcript = "what the caller actually said"
+    activity.on_end_of_speech(None)
+    await asyncio.sleep(FALSE_INTERRUPTION_TIMEOUT + 0.2)
+    await session.aclose()
+
+    assert activity._paused_speech is None
+    assert recognition._audio_transcript == "what the caller actually said"


### PR DESCRIPTION
## Summary

Fixes #7063.

When a false interruption is confirmed and the paused agent speech resumes, `_on_false_interruption` never closes the `AudioRecognition` turn that raised the interruption. The turn stays open, and `_on_vad_event` only takes a fresh anchor while `_vad_speech_started` is still `False`:

```python
# audio_recognition.py, _on_vad_event, START_OF_SPEECH
if not self._vad_speech_started:
    self._speech_start_time = speech_start_time
    self._vad_speech_started = True
```

So the *next real utterance* inherits the abandoned turn's `_speech_start_time`, and `ChatMessage.metrics.started_speaking_at` can predate agent speech that actually came first. The guard from #6093 / #6098 doesn't catch it because the resulting metrics stay internally consistent — the anchor is stale, not impossible.

This clears the turn in the `resumed` branch of `_on_false_interruption`, in the order the issue asks for: clear → `_on_start_of_agent_speech` → `audio_output.resume()`.

## Why here and not in the drop path

`_bounce_eou_task` resets the anchors only when the turn *commits*. On a drop it resets just `_turn_backchannel_over_agent`, `_overlap_in_current_turn` and `_user_turn_committed` — which is right in general, because a dropped turn usually means the user isn't finished and the turn should keep accumulating. A confirmed false interruption is the one case where a drop means the opposite: the agent is resuming *over* that turn, so it has been decided to be noise.

## Notes for review

- **Only the `resumed` branch.** `_pause_enabled()` gates `resume_false_interruption` / `can_pause` / `audio_enabled` before `_paused_speech` is set, and the timer is only armed when `_paused_speech` is set — so with resume disabled this code is never reached.
- **Two entry paths, two levels of reset.** `_on_turn_settled` runs after a decision dropped the turn, so nothing is in flight and the full `_clear_user_turn()` applies — it is also needed there, since a confirmed backchannel's transcript would otherwise prepend itself to the next utterance. `_on_timeout` can run with no decision ever open (`turn_detection="stt"` starts no bounce on VAD `END_OF_SPEECH`), where a slow stt final for real speech may still be on its way; there only the inherited anchors are released, via `_release_user_turn_anchors()`. The first version of this PR cleared unconditionally and lost that final — see the discussion below.
- **No live turn can be wiped.** `on_start_of_speech` calls `_cancel_false_interruption_timer()`, closing both entry paths. In the sub-tick window where the timer callback wins, the clear is harmless: `_vad_speech_started` goes `False`, so the VAD `START_OF_SPEECH` processed right after takes its own anchor. This is also why the fix doesn't need the `_last_speaking_time == last_speaking_time` guard the commit path uses.
- **`_clear_user_turn()` swaps the STT pipeline, `_release_user_turn_anchors()` doesn't.** The full clear stays as-is because the issue requires the buffered transcript not to survive a confirmed drop, and it's the existing "discard this turn" primitive that the public `clear_user_turn()` already uses. If you'd rather express the narrow reset as a keyword on `_clear_user_turn` than as a second method, say so — it's a shared primitive, so the shape seemed like your call.

## Test

`tests/test_false_interruption_resume.py::test_resume_drops_the_turn_it_resumed_over`, built on the helpers already in that file.

It drives the harder entry path: with `FALSE_INTERRUPTION_TIMEOUT = 0.3` and `MAX_DELAY = 0.5` the timer fires while the end-of-turn decision is still open, so the resume goes through `_false_interruption_pending` → `_on_turn_settled` → `_on_false_interruption`. The assertion is on the observable anchor rather than an internal flag: after the resume a real VAD `START_OF_SPEECH` is delivered, and `_speech_start_time` must equal *that* onset. Without the fix it comes back ~12.7 s stale — the same order of magnitude as the 12.151 s reported in the issue.

`test_resume_without_a_turn_decision_keeps_a_late_transcript_alive` covers the other entry path: no bounce is started, so the timer fires with no decision open, and the test asserts the anchor is released while the transcript and the stt pipeline — everything a late final needs to commit — survive. Against the first commit it fails on `assert '' == 'what the caller actually said'`.

## Testing

- `uv run pytest tests/test_false_interruption_resume.py` → 11 passed (was 9); each new test fails without its fix and passes with it
- `uv run pytest --unit` → 2307 passed, 5 skipped
- `uv run ruff format --check` and `uv run ruff check` → clean
- `uv run python scripts/check_types.py` (mypy strict) → no issues in 644 source files
