### PR TITLE
feat(metrics): expose reasoning_tokens in LLM metrics and traces

### DIFF
--- a/livekit-agents/livekit/agents/inference/llm.py
+++ b/livekit-agents/livekit/agents/inference/llm.py
@@ -474,12 +474,17 @@ class LLMStream(llm.LLMStream):
                     if chunk.usage is not None:
                         tokens_details = chunk.usage.prompt_tokens_details
                         cached_tokens = tokens_details.cached_tokens if tokens_details else 0
+                        completion_details = chunk.usage.completion_tokens_details
+                        reasoning_tokens = (
+                            completion_details.reasoning_tokens if completion_details else 0
+                        )
                         usage_chunk = llm.ChatChunk(
                             id=chunk.id,
                             usage=llm.CompletionUsage(
                                 completion_tokens=chunk.usage.completion_tokens or 0,
                                 prompt_tokens=chunk.usage.prompt_tokens or 0,
                                 prompt_cached_tokens=cached_tokens or 0,
+                                reasoning_tokens=reasoning_tokens or 0,
                                 total_tokens=chunk.usage.total_tokens or 0,
                                 service_tier=getattr(chunk, "service_tier", None),
                             ),

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -43,6 +43,12 @@ class CompletionUsage(BaseModel):
     """The number of tokens used to create the cache."""
     cache_read_tokens: int = 0
     """The number of tokens read from the cache."""
+    reasoning_tokens: int = 0
+    """The number of completion tokens spent on hidden reasoning.
+    Already counted in ``completion_tokens``; do not add it to totals. Only reported by
+    providers that break reasoning out separately (e.g. OpenAI-compatible responses
+    carrying ``completion_tokens_details.reasoning_tokens``), 0 everywhere else.
+    """
     total_tokens: int
     """The total number of tokens used (completion + prompt tokens)."""
     service_tier: str | None = None
@@ -382,6 +388,7 @@ class LLMStream(ABC):
             prompt_tokens=usage.prompt_tokens if usage else 0,
             prompt_cached_tokens=usage.prompt_cached_tokens if usage else 0,
             cache_creation_tokens=usage.cache_creation_tokens if usage else 0,
+            reasoning_tokens=usage.reasoning_tokens if usage else 0,
             total_tokens=usage.total_tokens if usage else 0,
             tokens_per_second=usage.completion_tokens / duration if usage else 0.0,
             metadata=Metadata(
@@ -408,6 +415,10 @@ class LLMStream(ABC):
                     trace_types.ATTR_GEN_AI_USAGE_OUTPUT_TOKENS: metrics.completion_tokens,
                 },
             )
+            if metrics.reasoning_tokens:
+                self._llm_request_span.set_attribute(
+                    trace_types.ATTR_GEN_AI_USAGE_REASONING_TOKENS, metrics.reasoning_tokens
+                )
             if completion_start_time:
                 self._llm_request_span.set_attribute(
                     trace_types.ATTR_LANGFUSE_COMPLETION_START_TIME, f'"{completion_start_time}"'

--- a/livekit-agents/livekit/agents/metrics/base.py
+++ b/livekit-agents/livekit/agents/metrics/base.py
@@ -34,6 +34,12 @@ class LLMMetrics(_BaseMetrics):
 
     Not all providers report this. ``prompt_cached_tokens`` covers cache reads.
     """
+    reasoning_tokens: int = 0
+    """The number of completion tokens spent on hidden reasoning.
+
+    Already counted in ``completion_tokens``; do not add it to totals. Not all providers
+    break reasoning out separately, and it is 0 when they don't.
+    """
     total_tokens: int
     tokens_per_second: float
     speech_id: str | None = None

--- a/livekit-agents/livekit/agents/metrics/usage.py
+++ b/livekit-agents/livekit/agents/metrics/usage.py
@@ -58,6 +58,8 @@ class LLMModelUsage(_BaseModelUsage):
     """Output audio tokens (for multimodal models)."""
     output_text_tokens: int = 0
     """Output text tokens."""
+    output_reasoning_tokens: int = 0
+    """Output tokens spent on hidden reasoning. Already counted in ``output_tokens``."""
 
     session_duration: float = 0.0
     """Total session connection duration in seconds (for session-based billing like xAI)."""
@@ -205,6 +207,7 @@ class ModelUsageCollector:
             usage.input_cached_tokens += metrics.prompt_cached_tokens
             usage.input_cache_creation_tokens += metrics.cache_creation_tokens
             usage.output_tokens += metrics.completion_tokens
+            usage.output_reasoning_tokens += metrics.reasoning_tokens
 
         elif isinstance(metrics, RealtimeModelMetrics):
             provider, model = self._extract_provider_model(metrics)

--- a/livekit-agents/livekit/agents/metrics/utils.py
+++ b/livekit-agents/livekit/agents/metrics/utils.py
@@ -36,6 +36,7 @@ def log_metrics(metrics: AgentMetrics, *, logger: logging.Logger | None = None) 
                 "prompt_cached_tokens": metrics.prompt_cached_tokens,
                 "cache_creation_tokens": metrics.cache_creation_tokens,
                 "completion_tokens": metrics.completion_tokens,
+                "reasoning_tokens": metrics.reasoning_tokens,
                 "tokens_per_second": round(metrics.tokens_per_second, 2),
             },
         )

--- a/livekit-agents/livekit/agents/telemetry/trace_types.py
+++ b/livekit-agents/livekit/agents/telemetry/trace_types.py
@@ -99,6 +99,7 @@ ATTR_GEN_AI_USAGE_INPUT_AUDIO_TOKENS = "gen_ai.usage.input_audio_tokens"
 ATTR_GEN_AI_USAGE_INPUT_CACHED_TOKENS = "gen_ai.usage.input_cached_tokens"
 ATTR_GEN_AI_USAGE_OUTPUT_TEXT_TOKENS = "gen_ai.usage.output_text_tokens"
 ATTR_GEN_AI_USAGE_OUTPUT_AUDIO_TOKENS = "gen_ai.usage.output_audio_tokens"
+ATTR_GEN_AI_USAGE_REASONING_TOKENS = "gen_ai.usage.reasoning_tokens"
 
 # OpenTelemetry GenAI event names (for structured logging)
 EVENT_GEN_AI_SYSTEM_MESSAGE = "gen_ai.system.message"

--- a/tests/test_inference_llm_usage.py
+++ b/tests/test_inference_llm_usage.py
@@ -64,3 +64,79 @@ async def test_null_usage_fields_do_not_crash_stream() -> None:
     assert usage.completion_tokens == 0
     assert usage.prompt_tokens == 7
     assert usage.total_tokens == 0
+
+
+# The gateway reports Gemini's thinking tokens as ``completion_tokens_details.reasoning_tokens``
+# on the OpenAI-compatible stream, and counts them inside ``completion_tokens`` (which it derives
+# as total - prompt). Reasoning is therefore a subset of the completion tokens, never an addition.
+_STREAM_WITH_REASONING_USAGE = b"""data: {"id":"chatcmpl-test","choices":[{"delta":{"content":"ok","role":"assistant"},"finish_reason":null,"index":0}],"created":0,"model":"m","object":"chat.completion.chunk"}
+
+data: {"id":"chatcmpl-test","choices":[{"delta":{},"finish_reason":"stop","index":0}],"created":0,"model":"m","object":"chat.completion.chunk"}
+
+data: {"id":"chatcmpl-test","choices":[],"created":0,"model":"m","object":"chat.completion.chunk","usage":{"completion_tokens":40,"prompt_tokens":7,"total_tokens":47,"completion_tokens_details":{"reasoning_tokens":32}}}
+
+data: [DONE]
+
+"""
+
+
+class _ReasoningUsageTransport(httpx.AsyncBaseTransport):
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        await request.aread()
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=_STREAM_WITH_REASONING_USAGE,
+            request=request,
+        )
+
+
+async def test_reasoning_tokens_are_reported_from_completion_tokens_details() -> None:
+    client = openai_sdk.AsyncClient(
+        api_key="test-key",
+        http_client=httpx.AsyncClient(transport=_ReasoningUsageTransport()),
+    )
+    model = openai.LLM(model="m", client=client)
+
+    chat_ctx = llm.ChatContext()
+    chat_ctx.add_message(role="user", content="hi")
+
+    usage_chunks: list[llm.CompletionUsage] = []
+    stream = model.chat(chat_ctx=chat_ctx)
+    try:
+        async for chunk in stream:
+            if chunk.usage is not None:
+                usage_chunks.append(chunk.usage)
+    finally:
+        await stream.aclose()
+        await model.aclose()
+
+    assert len(usage_chunks) == 1
+    usage = usage_chunks[0]
+    assert usage.reasoning_tokens == 32
+    assert usage.completion_tokens == 40
+    assert usage.total_tokens == 47
+
+
+async def test_reasoning_tokens_default_to_zero_without_details() -> None:
+    # Providers that don't break reasoning out omit ``completion_tokens_details`` entirely.
+    client = openai_sdk.AsyncClient(
+        api_key="test-key",
+        http_client=httpx.AsyncClient(transport=_NullUsageTransport()),
+    )
+    model = openai.LLM(model="m", client=client)
+
+    chat_ctx = llm.ChatContext()
+    chat_ctx.add_message(role="user", content="hi")
+
+    usage_chunks: list[llm.CompletionUsage] = []
+    stream = model.chat(chat_ctx=chat_ctx)
+    try:
+        async for chunk in stream:
+            if chunk.usage is not None:
+                usage_chunks.append(chunk.usage)
+    finally:
+        await stream.aclose()
+        await model.aclose()
+
+    assert usage_chunks[0].reasoning_tokens == 0

--- a/tests/test_metrics_usage.py
+++ b/tests/test_metrics_usage.py
@@ -49,3 +49,27 @@ def test_collector_aggregates_cache_creation_tokens() -> None:
     llm_usage = usage[0]
     assert isinstance(llm_usage, LLMModelUsage)
     assert llm_usage.input_cache_creation_tokens == 50
+
+
+def test_llm_metrics_defaults_reasoning_to_zero() -> None:
+    m = _llm_metrics()
+    assert m.reasoning_tokens == 0
+
+
+def test_llm_metrics_carries_reasoning_tokens() -> None:
+    m = _llm_metrics(reasoning_tokens=64)
+    assert m.reasoning_tokens == 64
+
+
+def test_collector_aggregates_reasoning_tokens() -> None:
+    collector = ModelUsageCollector()
+    collector.collect(_llm_metrics(completion_tokens=100, reasoning_tokens=64))
+    collector.collect(_llm_metrics(completion_tokens=50, reasoning_tokens=8))
+
+    usage = collector.flatten()
+    assert len(usage) == 1
+    llm_usage = usage[0]
+    assert isinstance(llm_usage, LLMModelUsage)
+    assert llm_usage.output_reasoning_tokens == 72
+    # reasoning is a subset of the output tokens, never added on top of them
+    assert llm_usage.output_tokens == 150

--- a/tests/test_trace_types_pii.py
+++ b/tests/test_trace_types_pii.py
@@ -100,6 +100,7 @@ SAFE_KEYS = frozenset(
         "gen_ai.usage.cache_read.input_tokens",
         "gen_ai.usage.output_text_tokens",
         "gen_ai.usage.output_audio_tokens",
+        "gen_ai.usage.reasoning_tokens",
         "gen_ai.system.message",
         "gen_ai.user.message",
         "gen_ai.assistant.message",


### PR DESCRIPTION
Carries `reasoning_tokens` from OpenAI-compatible usage payloads through to `LLMMetrics`, `LLMModelUsage`, the `log_metrics` line, and a new `gen_ai.usage.reasoning_tokens` span attribute. Reasoning is a **subset** of `completion_tokens`, never additive.

The inference gateway already returns `completion_tokens_details.reasoning_tokens`, but `inference/llm.py` never read it, so the value was dropped before reaching metrics or traces.