### PR TITLE
feat(perplexity): deprecate chat completions helpers

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from dataclasses import asdict, dataclass
 from typing import Any, Literal
 from urllib.parse import urlparse
@@ -744,9 +745,16 @@ class LLM(llm.LLM):
         """
         Create a new instance of PerplexityAI LLM.
 
-        ``api_key`` must be set to your TogetherAI API key, either using the argument or by setting
+        ``api_key`` must be set to your Perplexity API key, either using the argument or by setting
         the ``PERPLEXITY_API_KEY`` environmental variable.
         """
+        warnings.warn(
+            "`openai.LLM.with_perplexity()` uses Sonar Chat Completions and is deprecated. "
+            "Install `livekit-plugins-perplexity` and use `perplexity.responses.LLM` for "
+            "the Perplexity Agent API.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         api_key = api_key or os.environ.get("PERPLEXITY_API_KEY")
         if api_key is None:

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -729,7 +729,7 @@ class LLM(llm.LLM):
     @staticmethod
     def with_perplexity(
         *,
-        model: str | PerplexityChatModels = "llama-3.1-sonar-small-128k-chat",
+        model: str | PerplexityChatModels = "sonar-pro",
         api_key: str | None = None,
         base_url: str = "https://api.perplexity.ai",
         client: openai.AsyncClient | None = None,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -745,6 +745,11 @@ class LLM(llm.LLM):
         """
         Create a new instance of PerplexityAI LLM.
 
+        .. deprecated::
+            This helper uses Sonar Chat Completions. Install
+            ``livekit-plugins-perplexity`` and use ``perplexity.responses.LLM``
+            for the Perplexity Agent API.
+
         ``api_key`` must be set to your Perplexity API key, either using the argument or by setting
         the ``PERPLEXITY_API_KEY`` environmental variable.
         """

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -116,12 +116,10 @@ CerebrasChatModels = Literal[
 ]
 
 PerplexityChatModels = Literal[
-    "llama-3.1-sonar-small-128k-online",
-    "llama-3.1-sonar-small-128k-chat",
-    "llama-3.1-sonar-large-128k-online",
-    "llama-3.1-sonar-large-128k-chat",
-    "llama-3.1-8b-instruct",
-    "llama-3.1-70b-instruct",
+    "sonar",
+    "sonar-pro",
+    "sonar-reasoning-pro",
+    "sonar-deep-research",
 ]
 
 DeepSeekChatModels = Literal[

--- a/livekit-plugins/livekit-plugins-perplexity/README.md
+++ b/livekit-plugins/livekit-plugins-perplexity/README.md
@@ -1,7 +1,6 @@
 # Perplexity plugin for LiveKit Agents
 
-Support for [Perplexity](https://www.perplexity.ai/) LLMs via the OpenAI-compatible
-chat completions endpoint at `https://api.perplexity.ai`.
+Support for [Perplexity](https://www.perplexity.ai/) models through the Agent API.
 
 See [https://docs.livekit.io/agents/models/llm/perplexity/](https://docs.livekit.io/agents/models/llm/perplexity/) for more information.
 
@@ -21,20 +20,21 @@ You'll need an API key from Perplexity. It can be passed directly or set as the
 ```python
 from livekit.plugins import perplexity
 
-llm = perplexity.LLM(
-    model="sonar-pro",
+llm = perplexity.responses.LLM(
+    model="perplexity/sonar",
     # api_key picked up from PERPLEXITY_API_KEY if omitted
 )
 ```
 
-The plugin reuses the OpenAI plugin's chat completions transport with
-`base_url="https://api.perplexity.ai"` and forwards an `X-Pplx-Integration`
-attribution header on every outgoing request.
+The Responses LLM uses `base_url="https://api.perplexity.ai/v1"`, disables
+websocket transport, and sends an `X-Pplx-Integration` attribution header on
+its OpenAI-compatible client.
 
-## Agent API usage
+## Migrating from Chat Completions
 
-Perplexity's Agent API is compatible with OpenAI's Responses API and is
-available through the `perplexity.responses` submodule.
+The `perplexity.LLM` class and `openai.LLM.with_perplexity()` use Sonar Chat
+Completions and are deprecated. Replace either legacy path with the Responses
+LLM:
 
 ```python
 from livekit.plugins import perplexity
@@ -45,6 +45,5 @@ llm = perplexity.responses.LLM(
 )
 ```
 
-The Responses LLM uses `base_url="https://api.perplexity.ai/v1"`, disables
-websocket transport, and sends the same `X-Pplx-Integration` attribution header
-on its OpenAI-compatible client.
+See Perplexity's [migration guide](https://docs.perplexity.ai/docs/agent-api/migrate-from-sonar/overview)
+for request and model changes when moving from Sonar to the Agent API.

--- a/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/__init__.py
+++ b/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/__init__.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Perplexity plugin for LiveKit Agents
+"""Perplexity plugin for LiveKit Agents.
 
-Wraps Perplexity's OpenAI-compatible chat completions endpoint at
-``https://api.perplexity.ai`` so it can be used as a drop-in LLM for LiveKit
-voice agents.
+Use ``perplexity.responses.LLM`` for Perplexity's Agent API. The legacy
+``perplexity.LLM`` class uses Sonar Chat Completions and is deprecated.
 """
 
 from livekit.agents import Plugin

--- a/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/llm.py
+++ b/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/llm.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 
 import httpx
 import openai
@@ -55,6 +56,12 @@ class LLM(OpenAILLM):
         ``api_key`` must be set to your Perplexity API key, either using the argument or by
         setting the ``PERPLEXITY_API_KEY`` environmental variable.
         """
+        warnings.warn(
+            "`perplexity.LLM` uses Sonar Chat Completions and is deprecated. "
+            "Use `perplexity.responses.LLM` for the Perplexity Agent API.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         api_key = api_key if is_given(api_key) else os.environ.get("PERPLEXITY_API_KEY", "")
         if not api_key:
             raise ValueError(

--- a/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/llm.py
+++ b/livekit-plugins/livekit-plugins-perplexity/livekit/plugins/perplexity/llm.py
@@ -53,6 +53,10 @@ class LLM(OpenAILLM):
         """
         Create a new instance of Perplexity LLM.
 
+        .. deprecated::
+            This client uses Sonar Chat Completions. Use
+            ``perplexity.responses.LLM`` for the Perplexity Agent API.
+
         ``api_key`` must be set to your Perplexity API key, either using the argument or by
         setting the ``PERPLEXITY_API_KEY`` environmental variable.
         """

--- a/tests/test_plugin_perplexity.py
+++ b/tests/test_plugin_perplexity.py
@@ -11,6 +11,11 @@ pytestmark = pytest.mark.plugin("perplexity")
 MIGRATION_TARGET = "perplexity.responses.LLM"
 
 
+def create_legacy_llm() -> LLM:
+    with pytest.warns(DeprecationWarning):
+        return LLM()
+
+
 def test_legacy_plugin_llm_warns_with_migration_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -34,7 +39,7 @@ def test_legacy_openai_factory_uses_supported_default_and_warns(
 
 def test_default_model_and_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
-    llm = LLM()
+    llm = create_legacy_llm()
     assert llm.model == "sonar-pro"
     assert PERPLEXITY_BASE_URL == "https://api.perplexity.ai"
     # AsyncClient stores the configured base URL on _base_url.
@@ -44,7 +49,7 @@ def test_default_model_and_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_attribution_header_attached(monkeypatch: pytest.MonkeyPatch) -> None:
     """X-Pplx-Integration must be attached on every outgoing chat request."""
     monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
-    llm = LLM()
+    llm = create_legacy_llm()
     extra_headers = llm._opts.extra_headers
     assert extra_headers is not None
     assert extra_headers["X-Pplx-Integration"] == f"livekit-agents/{__version__}"
@@ -52,10 +57,10 @@ def test_attribution_header_attached(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_missing_api_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
-    with pytest.raises(ValueError, match="PERPLEXITY_API_KEY"):
+    with pytest.warns(DeprecationWarning), pytest.raises(ValueError, match="PERPLEXITY_API_KEY"):
         LLM()
 
 
 def test_provider_name(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
-    assert LLM().provider == "Perplexity"
+    assert create_legacy_llm().provider == "Perplexity"

--- a/tests/test_plugin_perplexity.py
+++ b/tests/test_plugin_perplexity.py
@@ -21,13 +21,14 @@ def test_legacy_plugin_llm_warns_with_migration_path(
     assert MIGRATION_TARGET in str(warning_info[0].message)
 
 
-def test_legacy_openai_factory_warns_with_migration_path(
+def test_legacy_openai_factory_uses_supported_default_and_warns(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
     with pytest.warns(DeprecationWarning) as warning_info:
-        openai.LLM.with_perplexity(model="sonar-pro")
+        llm = openai.LLM.with_perplexity()
 
+    assert llm.model == "sonar-pro"
     assert MIGRATION_TARGET in str(warning_info[0].message)
 
 

--- a/tests/test_plugin_perplexity.py
+++ b/tests/test_plugin_perplexity.py
@@ -2,10 +2,33 @@ from __future__ import annotations
 
 import pytest
 
+from livekit.plugins import openai
 from livekit.plugins.perplexity import LLM, __version__
 from livekit.plugins.perplexity.llm import PERPLEXITY_BASE_URL
 
 pytestmark = pytest.mark.plugin("perplexity")
+
+MIGRATION_TARGET = "perplexity.responses.LLM"
+
+
+def test_legacy_plugin_llm_warns_with_migration_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
+    with pytest.warns(DeprecationWarning) as warning_info:
+        LLM()
+
+    assert MIGRATION_TARGET in str(warning_info[0].message)
+
+
+def test_legacy_openai_factory_warns_with_migration_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
+    with pytest.warns(DeprecationWarning) as warning_info:
+        openai.LLM.with_perplexity(model="sonar-pro")
+
+    assert MIGRATION_TARGET in str(warning_info[0].message)
 
 
 def test_default_model_and_base_url(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_plugin_perplexity.py
+++ b/tests/test_plugin_perplexity.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.plugin("perplexity")
 MIGRATION_TARGET = "perplexity.responses.LLM"
 
 
-def create_legacy_llm() -> LLM:
+def _create_legacy_llm() -> LLM:
     with pytest.warns(DeprecationWarning):
         return LLM()
 
@@ -39,7 +39,7 @@ def test_legacy_openai_factory_uses_supported_default_and_warns(
 
 def test_default_model_and_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
-    llm = create_legacy_llm()
+    llm = _create_legacy_llm()
     assert llm.model == "sonar-pro"
     assert PERPLEXITY_BASE_URL == "https://api.perplexity.ai"
     # AsyncClient stores the configured base URL on _base_url.
@@ -49,7 +49,7 @@ def test_default_model_and_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_attribution_header_attached(monkeypatch: pytest.MonkeyPatch) -> None:
     """X-Pplx-Integration must be attached on every outgoing chat request."""
     monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
-    llm = create_legacy_llm()
+    llm = _create_legacy_llm()
     extra_headers = llm._opts.extra_headers
     assert extra_headers is not None
     assert extra_headers["X-Pplx-Integration"] == f"livekit-agents/{__version__}"
@@ -63,4 +63,4 @@ def test_missing_api_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_provider_name(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
-    assert create_legacy_llm().provider == "Perplexity"
+    assert _create_legacy_llm().provider == "Perplexity"

--- a/tests/test_plugin_perplexity_responses.py
+++ b/tests/test_plugin_perplexity_responses.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.plugin("perplexity")
 def test_default_model_base_url_and_transport(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
     llm = responses.LLM()
-    assert llm.model == "sonar-pro"
+    assert llm.model == "perplexity/sonar"
     assert llm._opts.use_websocket is False
     assert PERPLEXITY_RESPONSES_BASE_URL == "https://api.perplexity.ai/v1"
     assert str(llm._client.base_url).startswith("https://api.perplexity.ai/v1")


### PR DESCRIPTION
## Why

The Python integrations `perplexity.LLM` and `openai.LLM.with_perplexity()` still use Sonar Chat Completions. Users need an actionable migration path to the existing `perplexity.responses.LLM` Agent API client before Sonar is retired.

The OpenAI helper also defaults to `llama-3.1-sonar-small-128k-chat`, which is no longer served, so its zero-configuration path fails before users can migrate.

## What changed

- Emit actionable `DeprecationWarning`s from both Python Chat Completions entry points.
- Add pdoc deprecation directives so both migration paths appear in generated API reference documentation.
- Restore `openai.LLM.with_perplexity()` to a working `sonar-pro` default and replace its retired model type literals with current Sonar model IDs.
- Make the Agent API client the primary Perplexity README example and document migration from both legacy entry points.
- Update the package module description to distinguish the recommended Responses client from the legacy client.
- Correct the stale Responses default-model assertion from `sonar-pro` to `perplexity/sonar`.
- Exercise the OpenAI helper without a model override so the retired-default regression cannot be masked again, and explicitly handle the warning in existing legacy-client tests.

## Behavior and scope

This is a soft deprecation: existing explicit Chat Completions configurations continue to construct, while callers receive a standard Python deprecation warning with the replacement API. Zero-configuration `with_perplexity()` callers temporarily regain a supported Sonar default and receive the same migration warning.

The generated pdoc output renders both directives as deprecation callouts. The native Responses client remains unchanged: it defaults to `perplexity/sonar`, selects HTTP at `https://api.perplexity.ai/v1/`, reads `PERPLEXITY_API_KEY`, and sets the LiveKit attribution header.

Coordinated Node change: [livekit/agents-js#2392](https://github.com/livekit/agents-js/pull/2392).

Coordinated Perplexity guide: [ppl-ai/api-docs#807](https://github.com/ppl-ai/api-docs/pull/807).

Tracking: [Sonar to Agent migration](https://www.perplexity.ai/projects/sonar-to-agent-migration-AvXYcgZRTK6NO0y2XS9S2Q), [API-3590](https://linear.app/perplexity/issue/API-3590), and [API-3389](https://linear.app/perplexity/issue/API-3389).
