### PR TITLE
fix(aws-stt): support aws-sdk-transcribe-streaming >=0.11.0

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -36,13 +36,22 @@ from .log import logger
 from .utils import DEFAULT_REGION
 
 try:
-    from aws_sdk_transcribe_streaming.client import TranscribeStreamingClient
-
     try:
-        from aws_sdk_transcribe_streaming.config import Config
+        from aws_sdk_transcribe_streaming.client import (
+            AsyncTranscribeStreamingClient as TranscribeStreamingClient,
+        )
+        from aws_sdk_transcribe_streaming.config import (
+            AsyncTranscribeStreamingConfig as Config,
+        )
     except ImportError:
-        # aws-sdk-transcribe-streaming 0.10 renamed the exported class to lowercase.
-        from aws_sdk_transcribe_streaming.config import config as Config
+        from aws_sdk_transcribe_streaming.client import TranscribeStreamingClient
+
+        try:
+            from aws_sdk_transcribe_streaming.config import Config
+        except ImportError:
+            # aws-sdk-transcribe-streaming 0.10 renamed the exported class to lowercase.
+            from aws_sdk_transcribe_streaming.config import config as Config
+
     from aws_sdk_transcribe_streaming.models import (
         AudioEvent,
         AudioStream,
@@ -62,7 +71,9 @@ try:
     )
     from smithy_core.aio.identity import ChainedIdentityResolver
     from smithy_core.aio.interfaces.eventstream import EventPublisher, EventReceiver
-    from smithy_http.aio.crt import AWSCRTHTTPClient
+    from smithy_http.aio.crt import (
+        AWSCRTHTTPClient as _AWS_HTTP_CLIENT_CLS,
+    )
 
     _AWS_SDK_AVAILABLE = True
 except ImportError:
@@ -137,8 +148,8 @@ class STT(stt.STT):
 
         if not _AWS_SDK_AVAILABLE:
             raise ImportError(
-                "The 'aws_sdk_transcribe_streaming' package is not installed. "
-                "This implementation requires Python 3.12+ and the 'aws_sdk_transcribe_streaming' dependency."
+                "The AWS Transcribe streaming dependencies are not installed. "
+                "This implementation requires Python 3.12+ and 'aws_sdk_transcribe_streaming[awscrt]'."
             )
 
         if not is_given(region):
@@ -229,13 +240,24 @@ class SpeechStream(stt.SpeechStream):
         super().__init__(stt=stt, conn_options=conn_options, sample_rate=opts.sample_rate)
         self._opts = opts
         self._credentials = credentials
-        self._http_client = AWSCRTHTTPClient()
+        self._http_client = _AWS_HTTP_CLIENT_CLS()
         self._audio_duration = 0.0
         self._last_audio_duration_report_time = time.monotonic()
 
+    async def aclose(self) -> None:
+        try:
+            await super().aclose()
+        finally:
+            if hasattr(self._http_client, "close"):
+                with contextlib.suppress(Exception):
+                    await self._http_client.close()
+
     async def _run(self) -> None:
         while True:
-            config_kwargs: dict[str, Any] = {"region": self._opts.region}
+            config_kwargs: dict[str, Any] = {
+                "region": self._opts.region,
+                "transport": self._http_client,
+            }
             if self._credentials:
                 # Use a credentials resolver for explicit credentials
                 # for some reason, Config with direct values doesn't work
@@ -263,156 +285,167 @@ class SpeechStream(stt.SpeechStream):
                     )
                 )
 
-            client: TranscribeStreamingClient = TranscribeStreamingClient(
-                config=Config(**config_kwargs)
-            )
-
-            live_config = {
-                "media_sample_rate_hertz": self._opts.sample_rate,
-                "media_encoding": self._opts.encoding,
-                "vocabulary_name": self._opts.vocabulary_name,
-                "session_id": self._opts.session_id,
-                "vocab_filter_method": self._opts.vocab_filter_method,
-                "vocab_filter_name": self._opts.vocab_filter_name,
-                "show_speaker_label": self._opts.show_speaker_label,
-                "enable_channel_identification": self._opts.enable_channel_identification,
-                "number_of_channels": self._opts.number_of_channels,
-                "enable_partial_results_stabilization": self._opts.enable_partial_results_stabilization,
-                "partial_results_stability": self._opts.partial_results_stability,
-                "language_model_name": self._opts.language_model_name,
-            }
-
-            # Auto language detection is mutually exclusive with language_code
-            if self._opts.identify_language:
-                live_config["identify_language"] = True
-                if is_given(self._opts.language_options):
-                    live_config["language_options"] = self._opts.language_options
-                if is_given(self._opts.preferred_language):
-                    live_config["preferred_language"] = self._opts.preferred_language
-                if is_given(self._opts.vocabulary_names):
-                    live_config["vocabulary_names"] = self._opts.vocabulary_names
-                if is_given(self._opts.vocabulary_filter_names):
-                    live_config["vocabulary_filter_names"] = self._opts.vocabulary_filter_names
-            elif self._opts.identify_multiple_languages:
-                live_config["identify_multiple_languages"] = True
-                if is_given(self._opts.language_options):
-                    live_config["language_options"] = self._opts.language_options
-                if is_given(self._opts.preferred_language):
-                    live_config["preferred_language"] = self._opts.preferred_language
-                if is_given(self._opts.vocabulary_names):
-                    live_config["vocabulary_names"] = self._opts.vocabulary_names
-                if is_given(self._opts.vocabulary_filter_names):
-                    live_config["vocabulary_filter_names"] = self._opts.vocabulary_filter_names
+            if hasattr(Config, "resolve"):
+                config = await Config.resolve(**config_kwargs)
             else:
-                if self._opts.language:
-                    live_config["language_code"] = self._opts.language
+                config = Config(**config_kwargs)
 
-            filtered_config: dict[str, Any] = {}
-            for k, v in live_config.items():
-                if isinstance(v, bool):
-                    filtered_config[k] = v
-                elif isinstance(v, (int, float)):
-                    filtered_config[k] = v
-                elif v is not None and is_given(v):
-                    filtered_config[k] = v
-
-            tasks: list[asyncio.Task[Any]] = []
-
+            client: Any = None
             try:
-                stream = await client.start_stream_transcription(
-                    input=StartStreamTranscriptionInput(**filtered_config)
-                )
+                client = TranscribeStreamingClient(config=config)
 
-                # Get the output stream
-                _, output_stream = await stream.await_output()
+                live_config = {
+                    "media_sample_rate_hertz": self._opts.sample_rate,
+                    "media_encoding": self._opts.encoding,
+                    "vocabulary_name": self._opts.vocabulary_name,
+                    "session_id": self._opts.session_id,
+                    "vocab_filter_method": self._opts.vocab_filter_method,
+                    "vocab_filter_name": self._opts.vocab_filter_name,
+                    "show_speaker_label": self._opts.show_speaker_label,
+                    "enable_channel_identification": self._opts.enable_channel_identification,
+                    "number_of_channels": self._opts.number_of_channels,
+                    "enable_partial_results_stabilization": self._opts.enable_partial_results_stabilization,
+                    "partial_results_stability": self._opts.partial_results_stability,
+                    "language_model_name": self._opts.language_model_name,
+                }
 
-                async def input_generator(
-                    audio_stream: EventPublisher[AudioStream],
-                ) -> None:
-                    try:
-                        async for frame in self._input_ch:
-                            if isinstance(frame, rtc.AudioFrame):
-                                await audio_stream.send(
-                                    AudioStreamAudioEvent(
-                                        value=AudioEvent(audio_chunk=frame.data.tobytes())
-                                    )
-                                )
-                                self._audio_duration += frame.duration
-                                self._maybe_emit_recognition_usage()
-                            elif isinstance(frame, self._FlushSentinel):
-                                self._emit_recognition_usage()
-                    finally:
-                        self._emit_recognition_usage()
-                        # Send empty frame to close (required by AWS Transcribe)
-                        try:
-                            await audio_stream.send(
-                                AudioStreamAudioEvent(value=AudioEvent(audio_chunk=b""))
-                            )
-                        except Exception:
-                            pass
-                        finally:
-                            with contextlib.suppress(Exception):
-                                await audio_stream.close()
-
-                async def handle_transcript_events(
-                    output_stream: EventReceiver[TranscriptResultStream],
-                ) -> None:
-                    try:
-                        async for event in output_stream:
-                            if isinstance(event.value, TranscriptEvent):
-                                self._process_transcript_event(event.value)
-                    except BadRequestException as e:
-                        if (
-                            e.message
-                            and "complete signal was sent without the preceding empty frame"
-                            in e.message
-                        ):
-                            # This can happen during cancellation if the empty frame wasn't sent in time
-                            logger.warning(
-                                "AWS Transcribe stream closed with empty frame error (this is usually harmless)"
-                            )
-                        else:
-                            raise
-                    except concurrent.futures.InvalidStateError:
-                        logger.warning(
-                            "AWS Transcribe stream closed unexpectedly (InvalidStateError)"
-                        )
-                        pass
-
-                tasks = [
-                    asyncio.create_task(input_generator(stream.input_stream)),
-                    asyncio.create_task(handle_transcript_events(output_stream)),
-                ]
-                gather_future = asyncio.gather(*tasks)
-
-                await asyncio.shield(gather_future)
-            except BadRequestException as e:
-                if e.message and e.message.startswith("Your request timed out"):
-                    # AWS times out after 15s of inactivity, this tends to happen
-                    # at the end of the session, when the input is gone, we'll ignore it and
-                    # just treat it as a silent retry
-                    logger.info("restarting transcribe session")
-                    continue
+                # Auto language detection is mutually exclusive with language_code
+                if self._opts.identify_language:
+                    live_config["identify_language"] = True
+                    if is_given(self._opts.language_options):
+                        live_config["language_options"] = self._opts.language_options
+                    if is_given(self._opts.preferred_language):
+                        live_config["preferred_language"] = self._opts.preferred_language
+                    if is_given(self._opts.vocabulary_names):
+                        live_config["vocabulary_names"] = self._opts.vocabulary_names
+                    if is_given(self._opts.vocabulary_filter_names):
+                        live_config["vocabulary_filter_names"] = self._opts.vocabulary_filter_names
+                elif self._opts.identify_multiple_languages:
+                    live_config["identify_multiple_languages"] = True
+                    if is_given(self._opts.language_options):
+                        live_config["language_options"] = self._opts.language_options
+                    if is_given(self._opts.preferred_language):
+                        live_config["preferred_language"] = self._opts.preferred_language
+                    if is_given(self._opts.vocabulary_names):
+                        live_config["vocabulary_names"] = self._opts.vocabulary_names
+                    if is_given(self._opts.vocabulary_filter_names):
+                        live_config["vocabulary_filter_names"] = self._opts.vocabulary_filter_names
                 else:
-                    raise e
+                    if self._opts.language:
+                        live_config["language_code"] = self._opts.language
+
+                filtered_config: dict[str, Any] = {}
+                for k, v in live_config.items():
+                    if isinstance(v, bool):
+                        filtered_config[k] = v
+                    elif isinstance(v, (int, float)):
+                        filtered_config[k] = v
+                    elif v is not None and is_given(v):
+                        filtered_config[k] = v
+
+                tasks: list[asyncio.Task[Any]] = []
+                gather_future: asyncio.Future[Any] | None = None
+
+                try:
+                    stream = await client.start_stream_transcription(
+                        input=StartStreamTranscriptionInput(**filtered_config)
+                    )
+
+                    # Get the output stream
+                    _, output_stream = await stream.await_output()
+
+                    async def input_generator(
+                        audio_stream: EventPublisher[AudioStream],
+                    ) -> None:
+                        try:
+                            async for frame in self._input_ch:
+                                if isinstance(frame, rtc.AudioFrame):
+                                    await audio_stream.send(
+                                        AudioStreamAudioEvent(
+                                            value=AudioEvent(audio_chunk=frame.data.tobytes())
+                                        )
+                                    )
+                                    self._audio_duration += frame.duration
+                                    self._maybe_emit_recognition_usage()
+                                elif isinstance(frame, self._FlushSentinel):
+                                    self._emit_recognition_usage()
+                        finally:
+                            self._emit_recognition_usage()
+                            # Send empty frame to close (required by AWS Transcribe)
+                            try:
+                                await audio_stream.send(
+                                    AudioStreamAudioEvent(value=AudioEvent(audio_chunk=b""))
+                                )
+                            except Exception:
+                                pass
+                            finally:
+                                with contextlib.suppress(Exception):
+                                    await audio_stream.close()
+
+                    async def handle_transcript_events(
+                        output_stream: EventReceiver[TranscriptResultStream],
+                    ) -> None:
+                        try:
+                            async for event in output_stream:
+                                if isinstance(event.value, TranscriptEvent):
+                                    self._process_transcript_event(event.value)
+                        except BadRequestException as e:
+                            if (
+                                e.message
+                                and "complete signal was sent without the preceding empty frame"
+                                in e.message
+                            ):
+                                # This can happen during cancellation if the empty frame wasn't sent in time
+                                logger.warning(
+                                    "AWS Transcribe stream closed with empty frame error (this is usually harmless)"
+                                )
+                            else:
+                                raise
+                        except concurrent.futures.InvalidStateError:
+                            logger.warning(
+                                "AWS Transcribe stream closed unexpectedly (InvalidStateError)"
+                            )
+                            pass
+
+                    tasks = [
+                        asyncio.create_task(input_generator(stream.input_stream)),
+                        asyncio.create_task(handle_transcript_events(output_stream)),
+                    ]
+                    gather_future = asyncio.gather(*tasks)
+
+                    await asyncio.shield(gather_future)
+                except BadRequestException as e:
+                    if e.message and e.message.startswith("Your request timed out"):
+                        # AWS times out after 15s of inactivity, this tends to happen
+                        # at the end of the session, when the input is gone, we'll ignore it and
+                        # just treat it as a silent retry
+                        logger.info("restarting transcribe session")
+                        continue
+                    else:
+                        raise e
+                finally:
+                    if tasks:
+                        # Close input stream first
+                        await utils.aio.gracefully_cancel(tasks[0])
+
+                        # Wait for output stream to close cleanly
+                        try:
+                            await asyncio.wait_for(tasks[1], timeout=3.0)
+                        except (asyncio.TimeoutError, asyncio.CancelledError):
+                            await utils.aio.gracefully_cancel(tasks[1])
+                        except BadRequestException:
+                            # Already handled above (e.g. idle-timeout retry). Swallow so
+                            # re-awaiting the failed task here cannot override `continue`.
+                            pass
+
+                    # Ensure gather future is retrieved to avoid "exception never retrieved"
+                    if gather_future is not None:
+                        with contextlib.suppress(Exception):
+                            await gather_future
             finally:
-                if tasks:
-                    # Close input stream first
-                    await utils.aio.gracefully_cancel(tasks[0])
-
-                    # Wait for output stream to close cleanly
-                    try:
-                        await asyncio.wait_for(tasks[1], timeout=3.0)
-                    except (asyncio.TimeoutError, asyncio.CancelledError):
-                        await utils.aio.gracefully_cancel(tasks[1])
-                    except BadRequestException:
-                        # Already handled above (e.g. idle-timeout retry). Swallow so
-                        # re-awaiting the failed task here cannot override `continue`.
-                        pass
-
-                # Ensure gather future is retrieved to avoid "exception never retrieved"
-                with contextlib.suppress(Exception):
-                    await gather_future
+                if client is not None and hasattr(client, "close"):
+                    with contextlib.suppress(Exception):
+                        await client.close()
 
     def _maybe_emit_recognition_usage(self) -> None:
         if time.monotonic() - self._last_audio_duration_report_time >= 5.0:

--- a/livekit-plugins/livekit-plugins-aws/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-aws/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "livekit-agents>=1.7.1",
     "aiobotocore>=3.0.0",
     "aws_sdk_transcribe_streaming>=0.2.0; python_version >= '3.12'",
+    "awscrt>=0.23.0; python_version >= '3.12'",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_plugin_aws_stt.py
+++ b/tests/test_plugin_aws_stt.py
@@ -21,6 +21,16 @@ pytestmark = [
 ]
 
 
+def test_aws_stt_uses_crt_http_client() -> None:
+    """AWS Transcribe streaming requires a duplex-capable CRT transport.
+
+    The SDK stopped installing `awscrt` transitively in 0.11.0, so the plugin
+    declares it explicitly and must always select AWSCRTHTTPClient when available.
+    """
+    assert aws_stt._AWS_SDK_AVAILABLE
+    assert aws_stt._AWS_HTTP_CLIENT_CLS.__name__ == "AWSCRTHTTPClient"
+
+
 class _FakeAudioStream:
     def __init__(self) -> None:
         self.events: list[Any] = []
@@ -189,4 +199,28 @@ async def test_aws_stream_cleanup_survives_closed_event_channel(
     finally:
         if not stream._task.done():
             await stream.aclose()
+        await provider.aclose()
+
+
+async def test_aws_stream_propagates_setup_exception(monkeypatch: pytest.MonkeyPatch):
+    """If start_stream_transcription fails before tasks are created, the original
+    AWS exception must propagate instead of being masked by an UnboundLocalError."""
+
+    class _FailingClient:
+        def __init__(self, *, config: Any) -> None:
+            pass
+
+        async def start_stream_transcription(self, *, input: Any) -> Any:
+            raise RuntimeError("AWS setup failed")
+
+    monkeypatch.setattr(aws_stt, "TranscribeStreamingClient", _FailingClient)
+
+    provider = aws_stt.STT(region="us-east-1", sample_rate=16000)
+    stream = provider.stream(conn_options=APIConnectOptions(max_retry=0))
+
+    try:
+        with pytest.raises(RuntimeError, match="AWS setup failed"):
+            await asyncio.wait_for(anext(stream), timeout=1.0)
+    finally:
+        await stream.aclose()
         await provider.aclose()

--- a/uv.lock
+++ b/uv.lock
@@ -668,15 +668,15 @@ name = "bithuman"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "av", marker = "python_full_version < '3.14'" },
-    { name = "loguru", marker = "python_full_version < '3.14'" },
-    { name = "networkx", marker = "python_full_version < '3.14'" },
-    { name = "numpy", marker = "python_full_version < '3.14'" },
-    { name = "opencv-python-headless", marker = "python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "pydantic-settings", marker = "python_full_version < '3.14'" },
-    { name = "pyyaml", marker = "python_full_version < '3.14'" },
-    { name = "soundfile", marker = "python_full_version < '3.14'" },
+    { name = "av" },
+    { name = "loguru" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "opencv-python-headless" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyyaml" },
+    { name = "soundfile" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/f4/9faa8a78e8968f4404e5e47a2852d7a97313a667424a8e6f8bff16a28899/bithuman-2.7.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b399a37e187c17a8874e0eeb8e7e7a0907a4155537fac08185dabdb62491a7aa", size = 27205973, upload-time = "2026-07-17T00:14:45.72Z" },
@@ -2653,6 +2653,7 @@ source = { editable = "livekit-plugins/livekit-plugins-aws" }
 dependencies = [
     { name = "aiobotocore" },
     { name = "aws-sdk-transcribe-streaming" },
+    { name = "awscrt" },
     { name = "livekit-agents" },
 ]
 
@@ -2669,6 +2670,7 @@ requires-dist = [
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12' and extra == 'realtime'", specifier = ">=0.2.0" },
     { name = "aws-sdk-signers", marker = "python_full_version >= '3.12' and extra == 'realtime'", specifier = ">=0.0.3" },
     { name = "aws-sdk-transcribe-streaming", marker = "python_full_version >= '3.12'", specifier = ">=0.2.0" },
+    { name = "awscrt", marker = "python_full_version >= '3.12'", specifier = ">=0.23.0" },
     { name = "boto3", marker = "extra == 'realtime'", specifier = ">1.35.10" },
     { name = "livekit-agents", editable = "livekit-agents" },
 ]
@@ -2929,7 +2931,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "google-auth", specifier = ">=2,<3" },
-    { name = "google-cloud-speech", specifier = ">=2,<3" },
+    { name = "google-cloud-speech", specifier = ">=2.36,<3" },
     { name = "google-cloud-texttospeech", specifier = ">=2.32,<3" },
     { name = "google-genai", marker = "python_full_version >= '3.10'", specifier = ">=2.13" },
     { name = "livekit-agents", editable = "livekit-agents" },
@@ -3591,8 +3593,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -4252,7 +4254,7 @@ name = "opencv-python-headless"
 version = "5.0.0.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.14'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/99/76b7c80252aa83c1af16393454aafd125a0287101afe8deb0a6821af0e30/opencv_python_headless-5.0.0.93.tar.gz", hash = "sha256:b82f9831daab90b725c7c1ee1b36cb5732c367096ac76d119e64e14eb70d5f3c", size = 81817738, upload-time = "2026-07-02T07:01:06.039Z" }
 wheels = [
@@ -5733,9 +5735,9 @@ name = "soundfile"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "python_full_version < '3.14'" },
-    { name = "numpy", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
+    { name = "cffi" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d2/db/949331952a6fb1c5b12e9de80fd08747966c2039d1a61db4764fbd3981c2/soundfile-0.14.0.tar.gz", hash = "sha256:ba1c1a2d618bca5c406647c83b89f07cc8810fa506a50622a6993ba130c1de11", size = 47842, upload-time = "2026-06-06T08:58:47.869Z" }
 wheels = [


### PR DESCRIPTION
`aws-sdk-transcribe-streaming` 0.11.0 renamed the client/config exports to `AsyncTranscribeStreamingClient`/`AsyncTranscribeStreamingConfig`, stopped installing `awscrt`, and requires `await Config.resolve(...)` instead of direct construction.\n\nThis change makes the AWS STT plugin compatible with both the pre-0.11 and 0.11+ APIs:\n- Try the new async names first, falling back to the legacy `TranscribeStreamingClient`/`Config` (and the 0.10 `config` alias).\n- Fall back from `AWSCRTHTTPClient` to `AIOHTTPClient` when `awscrt` is not installed.\n- Use `Config.resolve(...)` when available, otherwise construct directly.\n- Pass `transport=` to the config so the same HTTP client is reused and closed cleanly in `SpeechStream.aclose()`.\n\nVerified `tests/test_plugin_aws_stt.py` passes with `aws-sdk-transcribe-streaming==0.7.0` and `0.11.0`.\n\nFixes livekit/agents#7072