### PR TITLE
fix(aws): pin the CRT transport for Nova Sonic

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -45,6 +45,7 @@ from aws_sdk_bedrock_runtime.models import (
 from smithy_aws_core.identity import AWSCredentialsIdentity
 from smithy_aws_event_stream.exceptions import InvalidEventBytes
 from smithy_core.aio.interfaces.identity import IdentityResolver
+from smithy_http.aio.crt import AWSCRTHTTPClient
 
 from livekit import rtc
 from livekit.agents import (
@@ -609,6 +610,9 @@ class RealtimeSession(  # noqa: F811
         0.11 then dropped the old names entirely. Keep both construction paths so
         the locked 0.7 extra and a fresh pip install of 0.11 both import.
         See https://github.com/livekit/agents/issues/6994.
+
+        Sonic streams bidirectionally, so the transport has to be the CRT client.
+        0.11 defaults to aiohttp, which does not support duplex.
         """
         kwargs: dict[str, Any] = {
             "endpoint_uri": (
@@ -617,6 +621,7 @@ class RealtimeSession(  # noqa: F811
             "region": self._realtime_model._opts.region,
             "aws_credentials_identity_resolver": _get_credentials_resolver(),
             "user_agent_extra": "x-client-framework:livekit-plugins-aws[realtime]",
+            "transport": AWSCRTHTTPClient(),
         }
         if _BEDROCK_CONFIG_USES_RESOLVE:
             config = await _BedrockRuntimeConfig.resolve(**kwargs)

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -536,7 +536,6 @@ class RealtimeSession(  # noqa: F811
         self._audio_input_task = None
         self._stream_response = None
         self._bedrock_client = None
-        self._http_client: AWSCRTHTTPClient | None = None
         self._pending_tools: set[str] = set()
         self._is_sess_active = asyncio.Event()
         self._chat_ctx = llm.ChatContext.empty()
@@ -613,11 +612,8 @@ class RealtimeSession(  # noqa: F811
         See https://github.com/livekit/agents/issues/6994.
 
         Sonic streams bidirectionally, so the transport has to be the CRT client.
-        0.11 defaults to aiohttp, which does not support duplex. The session keeps
-        one transport, because every CRT client opens its own native event loop.
+        0.11 defaults to aiohttp, which does not support duplex.
         """
-        if self._http_client is None:
-            self._http_client = AWSCRTHTTPClient()
         kwargs: dict[str, Any] = {
             "endpoint_uri": (
                 f"https://bedrock-runtime.{self._realtime_model._opts.region}.amazonaws.com"
@@ -625,7 +621,7 @@ class RealtimeSession(  # noqa: F811
             "region": self._realtime_model._opts.region,
             "aws_credentials_identity_resolver": _get_credentials_resolver(),
             "user_agent_extra": "x-client-framework:livekit-plugins-aws[realtime]",
-            "transport": self._http_client,
+            "transport": AWSCRTHTTPClient(),
         }
         if _BEDROCK_CONFIG_USES_RESOLVE:
             config = await _BedrockRuntimeConfig.resolve(**kwargs)
@@ -793,7 +789,7 @@ class RealtimeSession(  # noqa: F811
             except Exception as e:
                 logger.debug(f"[SESSION] Error closing stream (expected): {e}")
 
-        # Step 6: Reset state for new session (the transport carries over)
+        # Step 6: Reset state for new session
         self._stream_response = None
         self._bedrock_client = None
         self._event_builder = seb(
@@ -2396,13 +2392,6 @@ class RealtimeSession(  # noqa: F811
             tasks.append(self._main_atask)
 
         await asyncio.gather(*tasks, return_exceptions=True)
-
-        # smithy-http < 0.5 has no close(); there the pool goes when the client does
-        if self._http_client is not None:
-            if close := getattr(self._http_client, "close", None):
-                await close()
-            self._http_client = None
-
         logger.debug(
             "chat context at session end", extra={"lk.pii.chat_ctx_items": self._chat_ctx.items}
         )

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py
@@ -536,6 +536,7 @@ class RealtimeSession(  # noqa: F811
         self._audio_input_task = None
         self._stream_response = None
         self._bedrock_client = None
+        self._http_client: AWSCRTHTTPClient | None = None
         self._pending_tools: set[str] = set()
         self._is_sess_active = asyncio.Event()
         self._chat_ctx = llm.ChatContext.empty()
@@ -612,8 +613,11 @@ class RealtimeSession(  # noqa: F811
         See https://github.com/livekit/agents/issues/6994.
 
         Sonic streams bidirectionally, so the transport has to be the CRT client.
-        0.11 defaults to aiohttp, which does not support duplex.
+        0.11 defaults to aiohttp, which does not support duplex. The session keeps
+        one transport, because every CRT client opens its own native event loop.
         """
+        if self._http_client is None:
+            self._http_client = AWSCRTHTTPClient()
         kwargs: dict[str, Any] = {
             "endpoint_uri": (
                 f"https://bedrock-runtime.{self._realtime_model._opts.region}.amazonaws.com"
@@ -621,7 +625,7 @@ class RealtimeSession(  # noqa: F811
             "region": self._realtime_model._opts.region,
             "aws_credentials_identity_resolver": _get_credentials_resolver(),
             "user_agent_extra": "x-client-framework:livekit-plugins-aws[realtime]",
-            "transport": AWSCRTHTTPClient(),
+            "transport": self._http_client,
         }
         if _BEDROCK_CONFIG_USES_RESOLVE:
             config = await _BedrockRuntimeConfig.resolve(**kwargs)
@@ -789,7 +793,7 @@ class RealtimeSession(  # noqa: F811
             except Exception as e:
                 logger.debug(f"[SESSION] Error closing stream (expected): {e}")
 
-        # Step 6: Reset state for new session
+        # Step 6: Reset state for new session (the transport carries over)
         self._stream_response = None
         self._bedrock_client = None
         self._event_builder = seb(
@@ -2392,6 +2396,13 @@ class RealtimeSession(  # noqa: F811
             tasks.append(self._main_atask)
 
         await asyncio.gather(*tasks, return_exceptions=True)
+
+        # smithy-http < 0.5 has no close(); there the pool goes when the client does
+        if self._http_client is not None:
+            if close := getattr(self._http_client, "close", None):
+                await close()
+            self._http_client = None
+
         logger.debug(
             "chat context at session end", extra={"lk.pii.chat_ctx_items": self._chat_ctx.items}
         )

--- a/livekit-plugins/livekit-plugins-aws/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-aws/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
 [project.optional-dependencies]
 realtime = [
     "aws-sdk-bedrock-runtime>=0.2.0; python_version >= '3.12'",
+    # Sonic needs duplex streaming, which only the CRT transport provides; bedrock-runtime
+    # 0.11 dropped it from its own base dependencies.
+    "smithy-http[awscrt]; python_version >= '3.12'",
     "aws-sdk-signers>=0.0.3; python_version >= '3.12'",
     "boto3>1.35.10",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2661,6 +2661,7 @@ realtime = [
     { name = "aws-sdk-bedrock-runtime" },
     { name = "aws-sdk-signers" },
     { name = "boto3" },
+    { name = "smithy-http", extra = ["awscrt"] },
 ]
 
 [package.metadata]
@@ -2671,6 +2672,7 @@ requires-dist = [
     { name = "aws-sdk-transcribe-streaming", marker = "python_full_version >= '3.12'", specifier = ">=0.2.0" },
     { name = "boto3", marker = "extra == 'realtime'", specifier = ">1.35.10" },
     { name = "livekit-agents", editable = "livekit-agents" },
+    { name = "smithy-http", extras = ["awscrt"], marker = "python_full_version >= '3.12' and extra == 'realtime'" },
 ]
 provides-extras = ["realtime"]
 
@@ -2929,7 +2931,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "google-auth", specifier = ">=2,<3" },
-    { name = "google-cloud-speech", specifier = ">=2,<3" },
+    { name = "google-cloud-speech", specifier = ">=2.36,<3" },
     { name = "google-cloud-texttospeech", specifier = ">=2.32,<3" },
     { name = "google-genai", marker = "python_full_version >= '3.10'", specifier = ">=2.13" },
     { name = "livekit-agents", editable = "livekit-agents" },


### PR DESCRIPTION
**Problem**

Nova Sonic streams audio in both directions on one connection. `aws-sdk-bedrock-runtime` 0.7 built its client on the CRT HTTP transport, which supports that. Version 0.11 moved to aiohttp, which does not, so a fresh install of the `realtime` extra fails to open the session.

**Fix**

The client config now passes an explicit `AWSCRTHTTPClient` as its transport, and the `realtime` extra declares `smithy-http[awscrt]` so the CRT client is installed. Behavior on the locked 0.7 does not change, because 0.7 already used the same client by default.

fix https://github.com/livekit/agents/issues/7042#issuecomment-5489051079
