### PR TITLE
fix(google): support Gemma 4 thinking levels

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -46,6 +46,16 @@ def _is_gemini_3_model(model: str) -> bool:
     return "gemini-3" in model.lower() or model.lower().startswith("gemini-3")
 
 
+def _is_gemma_4_model(model: str) -> bool:
+    """Check if model is Gemma 4 series."""
+    return model.lower().startswith("gemma-4-")
+
+
+def _supports_thinking_level(model: str) -> bool:
+    """Check if model configures thinking with a level rather than a token budget."""
+    return _is_gemini_3_model(model) or _is_gemma_4_model(model)
+
+
 def _function_calling_config(
     tool_choice: NotGivenOr[ToolChoice], function_tools: Iterable[str]
 ) -> types.FunctionCallingConfig | None:
@@ -364,7 +374,8 @@ class LLM(llm.LLM):
 
         # Handle thinking_config based on model version
         if is_given(self._opts.thinking_config):
-            is_gemini_3 = _is_gemini_3_model(self._opts.model)
+            supports_thinking_level = _supports_thinking_level(self._opts.model)
+            is_gemma_4 = _is_gemma_4_model(self._opts.model)
             is_gemini_3_flash = _is_gemini_3_flash_model(self._opts.model)
             thinking_cfg = self._opts.thinking_config
 
@@ -378,21 +389,54 @@ class LLM(llm.LLM):
                 _budget = thinking_cfg.thinking_budget
                 _level = getattr(thinking_cfg, "thinking_level", None)
 
-            if is_gemini_3:
-                # Gemini 3: only support thinking_level
-                if _budget is not None and _level is None:
-                    logger.warning(
-                        f"Model {self._opts.model} is Gemini 3 which does not support thinking_budget. "
-                        "Please use thinking_level ('low' or 'high') instead. Ignoring thinking_budget."
-                    )
-                if _level is None:
-                    # If no thinking_level is provided, use the fastest thinking level
-                    if is_gemini_3_flash:
-                        _level = "minimal"
+            if supports_thinking_level:
+                # Gemini 3 and Gemma 4 use thinking_level rather than thinking_budget.
+                if is_gemma_4:
+                    if _budget is not None and _level is None:
+                        raise ValueError(
+                            f"Model {self._opts.model} does not support thinking_budget. "
+                            "Please use thinking_level ('minimal' or 'high') instead."
+                        )
+
+                    if _level is not None:
+                        level_value = (
+                            _level.value if isinstance(_level, types.ThinkingLevel) else _level
+                        )
+                        if level_value.lower() not in {"minimal", "high"}:
+                            raise ValueError(
+                                f"Model {self._opts.model} only supports thinking_level "
+                                "'minimal' or 'high'."
+                            )
+
+                    # Preserve include_thoughts and let the API choose its default when no
+                    # thinking_level was provided. If a valid level accompanies a legacy
+                    # budget, drop only the unsupported budget.
+                    if isinstance(thinking_cfg, dict):
+                        extra["thinking_config"] = {
+                            key: value
+                            for key, value in thinking_cfg.items()
+                            if key != "thinking_budget"
+                        }
                     else:
-                        _level = "low"
-                # Use thinking_level only (pass as dict since SDK may not have this field yet)
-                extra["thinking_config"] = {"thinking_level": _level}
+                        extra["thinking_config"] = cast(
+                            types.ThinkingConfig, thinking_cfg
+                        ).model_copy(update={"thinking_budget": None})
+                else:
+                    if _budget is not None and _level is None:
+                        logger.warning(
+                            f"Model {self._opts.model} is Gemini 3 which does not support "
+                            "thinking_budget. Please use thinking_level ('low' or 'high') "
+                            "instead. Ignoring thinking_budget."
+                        )
+
+                    if _level is None:
+                        # If no thinking_level is provided, use the fastest thinking level.
+                        if is_gemini_3_flash:
+                            _level = "minimal"
+                        else:
+                            _level = "low"
+                    # Use thinking_level only (pass as dict since SDK may not have this field yet)
+                    extra["thinking_config"] = {"thinking_level": _level}
 
             else:
                 # Gemini 2.5 and earlier: only support thinking_budget

--- a/tests/test_google_thought_signatures.py
+++ b/tests/test_google_thought_signatures.py
@@ -4,6 +4,7 @@ from livekit.plugins.google.llm import (
     _is_gemini_3_flash_model,
     _is_gemini_3_model,
     _requires_thought_signatures,
+    _supports_thinking_level,
 )
 
 pytestmark = pytest.mark.unit
@@ -29,6 +30,7 @@ class TestGeminiModelDetection:
             # Gemini 1.5 models - should return False
             ("gemini-1.5-pro", False),
             # Other models - should return False
+            ("gemma-4-31b-it", False),
             ("gpt-4", False),
             ("claude-3", False),
         ],
@@ -57,6 +59,23 @@ class TestGeminiModelDetection:
     @pytest.mark.parametrize(
         "model,expected",
         [
+            ("gemini-3-pro-preview", True),
+            ("gemini-3-flash-preview", True),
+            ("gemma-4-31b-it", True),
+            ("gemma-4-26b-a4b-it", True),
+            ("GEMMA-4-31B-IT", True),
+            ("gemini-2.5-flash", False),
+            ("gemma-3-27b-it", False),
+            ("gemma-40-31b-it", False),
+            ("gemma-4foo-31b-it", False),
+        ],
+    )
+    def test_supports_thinking_level(self, model: str, expected: bool):
+        assert _supports_thinking_level(model) == expected
+
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
             # Gemini 3 models - should return True (requires thought signatures)
             ("gemini-3-pro-preview", True),
             ("gemini-3-flash-preview", True),
@@ -76,6 +95,7 @@ class TestGeminiModelDetection:
             # Gemini 1.5 models - should return False
             ("gemini-1.5-pro", False),
             # Other models - should return False
+            ("gemma-4-31b-it", False),
             ("gpt-4", False),
             ("claude-3", False),
         ],

--- a/tests/test_plugin_google_llm.py
+++ b/tests/test_plugin_google_llm.py
@@ -347,6 +347,123 @@ class TestMediaResolution:
         assert config.generation_config.media_resolution is None
 
 
+class TestThinkingConfig:
+    @staticmethod
+    async def _single_response_async_iter():
+        yield types.GenerateContentResponse(
+            candidates=[
+                types.Candidate(
+                    content=types.Content(role="model", parts=[types.Part(text="ok")]),
+                    finish_reason=types.FinishReason.STOP,
+                )
+            ],
+        )
+
+    @classmethod
+    async def _capture_config(
+        cls, *, model: str, thinking_config: types.ThinkingConfigOrDict
+    ) -> types.GenerateContentConfig:
+        captured: dict = {}
+
+        async def fake_stream(**kwargs):
+            captured["config"] = kwargs.get("config")
+            return cls._single_response_async_iter()
+
+        llm_ = LLM(model=model, api_key="test", thinking_config=thinking_config)
+        with patch.object(
+            llm_._client.aio.models,
+            "generate_content_stream",
+            AsyncMock(side_effect=fake_stream),
+        ):
+            stream = llm_.chat(chat_ctx=llm.ChatContext.empty())
+            try:
+                async for _ in stream:
+                    pass
+            finally:
+                await stream.aclose()
+
+        return captured["config"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "thinking_config,expected_level,expected_include_thoughts",
+        [
+            (
+                types.ThinkingConfig(
+                    thinking_level=types.ThinkingLevel.MINIMAL, include_thoughts=True
+                ),
+                types.ThinkingLevel.MINIMAL,
+                True,
+            ),
+            (
+                {
+                    "thinking_level": "high",
+                    "thinking_budget": 0,
+                    "include_thoughts": False,
+                },
+                types.ThinkingLevel.HIGH,
+                False,
+            ),
+        ],
+    )
+    async def test_gemma_4_passes_supported_thinking_levels(
+        self,
+        thinking_config: types.ThinkingConfigOrDict,
+        expected_level: types.ThinkingLevel,
+        expected_include_thoughts: bool,
+    ):
+        config = await self._capture_config(
+            model="gemma-4-31b-it",
+            thinking_config=thinking_config,
+        )
+
+        assert config.thinking_config is not None
+        assert config.thinking_config.thinking_level == expected_level
+        assert config.thinking_config.include_thoughts is expected_include_thoughts
+        assert config.thinking_config.thinking_budget is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "thinking_config,expected_include_thoughts",
+        [
+            ({}, None),
+            ({"include_thoughts": True}, True),
+            (types.ThinkingConfig(include_thoughts=False), False),
+        ],
+    )
+    async def test_gemma_4_preserves_config_without_thinking_level(
+        self,
+        thinking_config: types.ThinkingConfigOrDict,
+        expected_include_thoughts: bool | None,
+    ):
+        config = await self._capture_config(model="gemma-4-31b-it", thinking_config=thinking_config)
+
+        assert config.thinking_config is not None
+        assert config.thinking_config.thinking_level is None
+        assert config.thinking_config.include_thoughts is expected_include_thoughts
+
+    def test_gemma_4_rejects_thinking_budget(self):
+        llm_ = LLM(
+            model="gemma-4-31b-it",
+            api_key="test",
+            thinking_config={"thinking_budget": 0},
+        )
+
+        with pytest.raises(ValueError, match="does not support thinking_budget"):
+            llm_.chat(chat_ctx=llm.ChatContext.empty())
+
+    @pytest.mark.parametrize("level", ["low", "medium"])
+    def test_gemma_4_rejects_unsupported_thinking_levels(self, level: str):
+        llm_ = LLM(
+            model="gemma-4-31b-it",
+            api_key="test",
+            thinking_config={"thinking_level": level},
+        )
+
+        with pytest.raises(ValueError, match="only supports thinking_level 'minimal' or 'high'"):
+            llm_.chat(chat_ctx=llm.ChatContext.empty())
+
+
 class TestMixedToolsRequestConstruction:
     """Combining built-in (provider) tools with function tools is only supported on the
     Gemini 3 Developer API (not Vertex). These tests drive ``chat()`` against a stubbed


### PR DESCRIPTION
## Summary

- route Gemma 4 through the thinking-level configuration path without enabling Gemini-3-only behavior
- preserve include_thoughts and reject unsupported budget-only configurations with an actionable error
- validate the Gemma 4 minimal/high levels and cover the final generated request configuration

## Verification

- uv run pytest -q tests/test_google_thought_signatures.py tests/test_plugin_google_llm.py (76 passed)
- uv run ruff format --check on changed files
- uv run ruff check on changed files
- uv run --group typing mypy --platform linux -p livekit.plugins.google

Fixes #7071