### PR TITLE
fix(cartesia): ignore stale frames from previous contexts on pooled websockets

### DIFF
--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -487,6 +487,10 @@ class SynthesizeStream(tts.SynthesizeStream):
 
                 data = json.loads(msg.data)
                 segment_id = data.get("context_id")
+                # A pooled websocket may still hold audio/done from an interrupted
+                # previous context; ignore messages tagged with another context id.
+                if segment_id is not None and segment_id != cartesia_context_id:
+                    continue
                 if current_segment_id is None:
                     current_segment_id = segment_id
                     output_emitter.start_segment(segment_id=segment_id)

--- a/tests/test_plugin_cartesia_tts.py
+++ b/tests/test_plugin_cartesia_tts.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import asyncio
+import base64
+import json
+from collections import deque
 from unittest.mock import MagicMock
 
+import aiohttp
 import pytest
 from aiohttp import RequestInfo, WSServerHandshakeError
 from multidict import CIMultiDict, CIMultiDictProxy
@@ -73,3 +78,99 @@ async def test_connect_ws_generic_error_does_not_chain_cause():
     assert str(err) == "ConnectionError"
     assert SECRET_API_KEY not in repr(err)
     assert SECRET_API_KEY not in str(err)
+
+
+# --- pooled websocket: stale frames/done from previous contexts must be ignored ---
+
+
+class _FakeMsg:
+    def __init__(self, type: aiohttp.WSMsgType, data=None, extra=None) -> None:
+        self.type = type
+        self.data = data
+        self.extra = extra
+
+    @classmethod
+    def text(cls, payload: dict) -> _FakeMsg:
+        return cls(aiohttp.WSMsgType.TEXT, json.dumps(payload))
+
+
+class _FakeWS:
+    """Yield stale frames/done first, then the current context's frames/done."""
+
+    def __init__(self) -> None:
+        self._sent: list[dict] = []
+        self._context_id: str | None = None
+        self._end_pkt_sent = asyncio.Event()
+        self._built = False
+        self._queue: deque[_FakeMsg] = deque()
+
+    async def send_str(self, data: str) -> None:
+        pkt = json.loads(data)
+        self._sent.append(pkt)
+        if self._context_id is None and pkt.get("context_id"):
+            self._context_id = pkt["context_id"]
+        if pkt.get("continue") is False:
+            self._end_pkt_sent.set()
+
+    async def receive(self, timeout: float | None = None) -> _FakeMsg:
+        if not self._built:
+            self._built = True
+            stale = "stale-context-id"
+            # stale leftovers from the previous context arrive first
+            self._queue.append(_FakeMsg.text({"context_id": stale, "data": _b64(b"\x00" * 160)}))
+            self._queue.append(_FakeMsg.text({"context_id": stale, "done": True}))
+
+        if self._queue:
+            return self._queue.popleft()
+
+        # current frames; delay done until end_pkt so the tokenizer is closed
+        ctx = self._context_id or ""
+        self._queue.append(_FakeMsg.text({"context_id": ctx, "data": _b64(b"\x01" * 160)}))
+        await self._end_pkt_sent.wait()
+        self._queue.append(_FakeMsg.text({"context_id": ctx, "done": True}))
+        return self._queue.popleft()
+
+
+class _FakePool:
+    def __init__(self, ws: _FakeWS) -> None:
+        self._ws = ws
+        self.last_acquire_time = 0.0
+        self.last_connection_reused = False
+
+    def connection(self, timeout: float):  # noqa: ANN201
+        ws = self._ws
+
+        class _Ctx:
+            async def __aenter__(self_):  # noqa: N805
+                return ws
+
+            async def __aexit__(self_, *exc):  # noqa: N805
+                return False
+
+        return _Ctx()
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode()
+
+
+@pytest.mark.asyncio
+async def test_synthesize_skips_stale_frames_from_previous_context():
+    """Only the current context's audio is played when stale frames are pooled."""
+    from livekit.agents import APIConnectOptions
+    from livekit.plugins.cartesia import TTS
+
+    tts = TTS(api_key=SECRET_API_KEY)
+    tts._pool = _FakePool(_FakeWS())  # type: ignore[assignment]
+
+    stream = tts.stream(conn_options=APIConnectOptions(max_retry=0, timeout=5.0))
+    stream.push_text("hello world")
+    stream.end_input()
+
+    frames: list[bytes] = []
+    async for ev in stream:
+        frames.append(bytes(ev.frame.data))
+
+    # stale frame (b"\x00") must be dropped; only current audio (b"\x01") is played
+    assert frames, "no audio frames were synthesized"
+    assert all(f == b"\x01" * 160 for f in frames)


### PR DESCRIPTION
When the ConnectionPool returns a previously-used websocket, the socket buffer may still contain unread audio frames / done from the abandoned context (occurring when a SynthesizeStream was interrupted before the frames were fully consumed). The `_recv_task` did not validate the `context_id` on received messages, so stale audio was pushed into the new output and a stale "done" could prematurely truncate the new synthesis.

### Changes

- **tts.py (`_recv_task`):** skip any message whose `context_id` is present but does not match the current `cartesia_context_id`. Messages without a `context_id` (e.g. server errors) are not affected.
- **test_plugin_cartesia_tts.py:** new test that simulates a reused socket where stale audio + done arrive before the legitimate frames, and asserts they are silently dropped.

### Reproduction

Without the fix, sending a stale-context audio frame + done then current-context audio + done:

```
frames = [stale b"""*160, current b"\x01"*160]   # stale audio played
```

With the fix:

```
frames = [current b"\x01"*160]                     # stale frame silently dropped
```

### Related

Root cause analysis: In the production session, 27 consecutive `say()` calls had `ttfb≈0.002s` (impossible over a fresh connection) and `duration≈0.01s`, confirming the socket was replaying stale frames instead of performing fresh synthesis. The `"..."` SPEAK text that triggered the visible symptom was just the most obvious case — any text sent through a pooled socket after an interrupted stream would exhibit the same corruption.
