### PR TITLE
fix: restore speaking state when releasing playout pause

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -4451,8 +4451,18 @@ class AgentActivity(RecognitionHooks):
 
     def _disallow_interruptions(self, speech_handle: SpeechHandle) -> None:
         speech_handle.allow_interruptions = False
-        if self._paused_speech is not None and self._paused_speech.handle is speech_handle:
-            self._reconcile_playout_pause(speech_handle)
+        paused_speech = self._paused_speech
+        if paused_speech is None or paused_speech.handle is not speech_handle:
+            return
+
+        if (
+            not speech_handle.done()
+            and self._session.output.audio_enabled
+            and self._session.output.audio is not None
+        ):
+            self._restore_paused_speech_state(paused_speech)
+
+        self._reconcile_playout_pause(speech_handle)
 
     def _update_paused_speech(self, speech_handle: SpeechHandle, timeout: float) -> None:
         """Record that ``speech_handle`` is paused.
@@ -4523,6 +4533,16 @@ class AgentActivity(RecognitionHooks):
             self._false_interruption_timer = None
         self._false_interruption_pending = False
 
+    def _restore_paused_speech_state(self, paused_speech: _PausedSpeechInfo) -> None:
+        self._session._update_agent_state(
+            paused_speech.agent_state,
+            otel_context=paused_speech.handle._agent_turn_context,
+        )
+        if self._audio_recognition and paused_speech.agent_state == "speaking":
+            self._audio_recognition._on_start_of_agent_speech(started_at=time.time())
+        if self.interruption_enabled:
+            self._disable_vad_interruption_soon()
+
     def _start_false_interruption_timer(self, timeout: float) -> None:
         self._cancel_false_interruption_timer()
 
@@ -4541,14 +4561,7 @@ class AgentActivity(RecognitionHooks):
                 and audio_output.can_pause
                 and not self._paused_speech.handle.done()
             ):
-                self._session._update_agent_state(
-                    self._paused_speech.agent_state,
-                    otel_context=self._paused_speech.handle._agent_turn_context,
-                )
-                if self._audio_recognition and self._paused_speech.agent_state == "speaking":
-                    self._audio_recognition._on_start_of_agent_speech(started_at=time.time())
-                if self.interruption_enabled:
-                    self._disable_vad_interruption_soon()
+                self._restore_paused_speech_state(self._paused_speech)
                 audio_output.resume()
                 resumed = True
                 logger.debug("resumed false interrupted speech", extra={"timeout": timeout})

--- a/tests/test_disallow_interruptions_pause.py
+++ b/tests/test_disallow_interruptions_pause.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterable
 
 import pytest
 
-from livekit.agents import Agent, RunContext, function_tool
-from livekit.agents.llm import FunctionToolCall
+from livekit.agents import Agent, FlushSentinel, ModelSettings, RunContext, function_tool
+from livekit.agents.llm import ChatChunk, ChatContext, ChoiceDelta, FunctionToolCall, Tool
 from livekit.agents.voice.io import PlaybackFinishedEvent
 
 from .fake_session import FakeActions, create_session, run_session
@@ -20,15 +21,52 @@ class TransferAgent(Agent):
         super().__init__(instructions="Transfer callers when requested.")
         self.transfer_started = asyncio.Event()
         self.transfer_completed = asyncio.Event()
+        self.paused_parent_state_before_disallow: str | None = None
+        self.parent_state_after_disallow: str | None = None
+        self.recognition_speaking_after_disallow: bool | None = None
 
     @function_tool
     async def transfer_to_live_agent(self, context: RunContext) -> None:
         """Transfer the caller to a live agent."""
         self.transfer_started.set()
+        activity = context.session._activity
+        assert activity is not None and activity._audio_recognition is not None
+        paused_speech = activity._paused_speech
+        self.paused_parent_state_before_disallow = (
+            paused_speech.agent_state if paused_speech is not None else None
+        )
         context.disallow_interruptions()
+        self.parent_state_after_disallow = context.session.agent_state
+        self.recognition_speaking_after_disallow = activity._audio_recognition._agent_speaking
         context.session.input.set_audio_enabled(False)
         await context.session.say(TRANSFER_MESSAGE, allow_interruptions=False)
         self.transfer_completed.set()
+
+
+class DelayedTransferAgent(TransferAgent):
+    async def llm_node(
+        self,
+        chat_ctx: ChatContext,
+        tools: list[Tool],
+        model_settings: ModelSettings,
+    ) -> AsyncIterable[ChatChunk | str | FlushSentinel]:
+        del chat_ctx, tools, model_settings
+        yield "Happy to connect you."
+        yield FlushSentinel()
+        await asyncio.sleep(3.0)
+        yield ChatChunk(
+            id="transfer-response",
+            delta=ChoiceDelta(
+                role="assistant",
+                tool_calls=[
+                    FunctionToolCall(
+                        name="transfer_to_live_agent",
+                        arguments="{}",
+                        call_id="transfer-1",
+                    )
+                ],
+            ),
+        )
 
 
 async def test_uninterruptible_tool_speech_plays_after_paused_parent() -> None:
@@ -68,3 +106,49 @@ async def test_uninterruptible_tool_speech_plays_after_paused_parent() -> None:
     assert [event.playback_position for event in playback_finished_events] == pytest.approx(
         [2.0, 1.0], abs=0.02
     )
+
+
+async def test_uninterruptible_tool_restores_paused_parent_speaking_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Connect me to an agent.")
+    # The first LLM segment reaches TTS immediately. Its playout is active when
+    # VAD pauses the parent, before DelayedTransferAgent emits the tool call.
+    actions.add_tts(5.0, input="Happy to connect you.", ttfb=0.1, duration=0.2)
+    # VAD pauses the parent after playback has started but before the tool runs.
+    actions.add_user_speech(4.0, 8.0, "")
+    actions.add_tts(1.0, input=TRANSFER_MESSAGE)
+
+    session = create_session(actions, can_pause_audio=True)
+    agent = DelayedTransferAgent()
+    audio_output = session.output.audio
+    assert audio_output is not None
+    original_resume = audio_output.resume
+    restored_state_observed_during_resume = False
+
+    def resume_with_state_assertion() -> None:
+        nonlocal restored_state_observed_during_resume
+        if agent.transfer_started.is_set() and agent.parent_state_after_disallow is None:
+            activity = session._activity
+            assert activity is not None and activity._audio_recognition is not None
+            assert session.agent_state == "speaking"
+            assert activity._audio_recognition._agent_speaking
+            restored_state_observed_during_resume = True
+        original_resume()
+
+    monkeypatch.setattr(audio_output, "resume", resume_with_state_assertion)
+
+    run_task = asyncio.create_task(run_session(session, agent))
+    try:
+        await asyncio.wait_for(agent.transfer_started.wait(), timeout=7.0)
+        await asyncio.wait_for(agent.transfer_completed.wait(), timeout=8.0)
+    finally:
+        if not run_task.done():
+            await session.aclose()
+        await run_task
+
+    assert agent.paused_parent_state_before_disallow == "speaking"
+    assert restored_state_observed_during_resume
+    assert agent.parent_state_after_disallow == "speaking"
+    assert agent.recognition_speaking_after_disallow is True


### PR DESCRIPTION
**Stacked on #7083.**

A false-interruption pause can start just before a parent response invokes a transfer tool. #7083 releases the pause when the tool calls `disallow_interruptions()`, but audio resumed while the session still reported `listening` and recognition reported no agent speech.

**State sequence:**

`H1` is the parent response that includes the tool call. `H2` is the transfer message produced by `session.say()`.

| Event | Before #7083 | #7083 only | #7083 + #7087 |
| --- | --- | --- | --- |
| `H1` starts playing | Session: `speaking`<br>`_agent_speaking=True` | Same | Same |
| False-interruption pause starts | `H1` pauses<br>Session: `listening`<br>`_agent_speaking=False`<br>Saved state: `speaking` | Same | Same |
| `disallow_interruptions()` | `H1` stays paused<br>State stays `listening` / `False` | `H1` resumes<br>State incorrectly stays `listening` / `False` | State returns to `speaking` / `True`<br>Then `H1` resumes |
| Remaining `H1` audio | Blocked in this path | Audible while state is `listening` / `False` | Audible while state is `speaking` / `True` |
| `H2` starts | Blocked behind `H1` | Starts after `H1`<br>First frame corrects the state | Starts after `H1`<br>No state correction needed |

**Affected application pattern:**

```python
@function_tool
async def transfer_to_live_agent_tool(run_context: RunContext[SessionData]) -> None:
    run_context.disallow_interruptions()
    run_context.session.input.set_audio_enabled(False)
    await run_context.session.say(
        text=_TRANSFER_MSG,
        allow_interruptions=False,
    )
    await transfer_to_live_agent_and_shutdown(...)
```

<details>
<summary>Deterministic reproduction</summary>

The committed test delays the transfer tool until a parent response is playing, then starts a false-interruption pause before the tool runs:

```python
actions = FakeActions()
actions.add_user_speech(0.5, 2.5, "Connect me to an agent.")
actions.add_tts(5.0, input="Happy to connect you.", ttfb=0.1, duration=0.2)
actions.add_user_speech(4.0, 8.0, "")
actions.add_tts(1.0, input=TRANSFER_MESSAGE)

session = create_session(actions, can_pause_audio=True)
await run_session(session, DelayedTransferAgent())
```

Run it from the repository root:

```bash
uv run pytest tests/test_disallow_interruptions_pause.py \
  -k restores_paused_parent_speaking_state --unit
```

Without the fix, the callback at `audio_output.resume()` observes `("listening", False)`. With the fix, it observes `("speaking", True)`.

</details>

Addresses AGT-3421

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> wait, did you make the change in 7083? Can you separate the change into another PR that targets 7083?
>
> Low: #7087’s test checks state after `disallow_interruptions()` returns. It does not prove that state restoration occurs before `audio_output.resume()`. A resume callback assertion would preserve this ordering invariant. See [test_disallow_interruptions_pause.py](/Users/chenghao/.t3/worktrees/agents/t3code-e3729c55/tests/test_disallow_interruptions_pause.py:133).
>
> also you should update the pr description because it was not clear enough. Maybe some event sequence + example function code and script (folded) for reproduction.
>
> > False SOS pauses playout
>
> vad speech might not be false.
>
> VAD SOS itself does not pause, it is min interruption duration that pauses or min words.
>
> you can just say false interruption pause starts

</details>
