### PR TITLE
docs(elevenlabs): clarify ELEVEN_API_KEY vs ELEVENLABS_API_KEY

### DIFF
--- a/livekit-plugins/livekit-plugins-elevenlabs/README.md
+++ b/livekit-plugins/livekit-plugins-elevenlabs/README.md
@@ -13,3 +13,7 @@ pip install livekit-plugins-elevenlabs
 ## Pre-requisites
 
 You'll need an API key from ElevenLabs. It can be set as an environment variable: `ELEVEN_API_KEY`
+
+Note: this plugin reads `ELEVEN_API_KEY`, while the official ElevenLabs Python SDK reads
+`ELEVENLABS_API_KEY`. If you use both in the same project (for example, the plugin in your
+agent and the SDK in a separate script), set both variables to the same key.


### PR DESCRIPTION
Documents the env var difference between this plugin (ELEVEN_API_KEY) and the official ElevenLabs Python SDK (ELEVENLABS_API_KEY). I hit this building an agent that used the plugin for TTS and the SDK separately for a latency benchmark — same key, two names, and nothing in the docs mentions it. One line seemed worth adding.