### PR TITLE
fix(aws): restore Transcribe STT on transcribe-streaming 0.11

### DIFF
--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -36,13 +36,10 @@ from .log import logger
 from .utils import DEFAULT_REGION
 
 try:
-    from aws_sdk_transcribe_streaming.client import TranscribeStreamingClient
-
-    try:
-        from aws_sdk_transcribe_streaming.config import Config
-    except ImportError:
-        # aws-sdk-transcribe-streaming 0.10 renamed the exported class to lowercase.
-        from aws_sdk_transcribe_streaming.config import config as Config
+    from aws_sdk_transcribe_streaming.client import (
+        AsyncTranscribeStreamingClient as TranscribeStreamingClient,
+    )
+    from aws_sdk_transcribe_streaming.config import AsyncTranscribeStreamingConfig as Config
     from aws_sdk_transcribe_streaming.models import (
         AudioEvent,
         AudioStream,
@@ -233,6 +230,10 @@ class SpeechStream(stt.SpeechStream):
         self._audio_duration = 0.0
         self._last_audio_duration_report_time = time.monotonic()
 
+    async def aclose(self) -> None:
+        await super().aclose()
+        await self._http_client.close()
+
     async def _run(self) -> None:
         while True:
             config_kwargs: dict[str, Any] = {"region": self._opts.region}
@@ -264,7 +265,7 @@ class SpeechStream(stt.SpeechStream):
                 )
 
             client: TranscribeStreamingClient = TranscribeStreamingClient(
-                config=Config(**config_kwargs)
+                config=await Config.resolve(transport=self._http_client, **config_kwargs)
             )
 
             live_config = {

--- a/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
+++ b/livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/stt.py
@@ -226,16 +226,23 @@ class SpeechStream(stt.SpeechStream):
         super().__init__(stt=stt, conn_options=conn_options, sample_rate=opts.sample_rate)
         self._opts = opts
         self._credentials = credentials
-        self._http_client = AWSCRTHTTPClient()
+        self._http_client: AWSCRTHTTPClient | None = None
         self._audio_duration = 0.0
         self._last_audio_duration_report_time = time.monotonic()
 
     async def aclose(self) -> None:
         await super().aclose()
-        await self._http_client.close()
+        if self._http_client is not None:
+            await self._http_client.close()
 
     async def _run(self) -> None:
         while True:
+            # a restarted attempt needs its own transport: the pooled HTTP/2 connection
+            # of the finished stream cannot carry a second StartStreamTranscription
+            if self._http_client is not None:
+                await self._http_client.close()
+            self._http_client = AWSCRTHTTPClient()
+
             config_kwargs: dict[str, Any] = {"region": self._opts.region}
             if self._credentials:
                 # Use a credentials resolver for explicit credentials

--- a/livekit-plugins/livekit-plugins-aws/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-aws/pyproject.toml
@@ -25,7 +25,10 @@ classifiers = [
 dependencies = [
     "livekit-agents>=1.7.1",
     "aiobotocore>=3.0.0",
-    "aws_sdk_transcribe_streaming>=0.2.0; python_version >= '3.12'",
+    # StartStreamTranscription is bidirectional, which only the CRT transport provides;
+    # transcribe-streaming 0.11 dropped it from its own base dependencies.
+    "aws_sdk_transcribe_streaming>=0.11.0; python_version >= '3.12'",
+    "smithy-http[awscrt]; python_version >= '3.12'",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_plugin_aws_stt.py
+++ b/tests/test_plugin_aws_stt.py
@@ -36,21 +36,31 @@ class _FakeAudioStream:
 
 
 class _FakeOutputStream:
+    def __init__(self, error: Exception | None = None) -> None:
+        self._error = error
+
     def __aiter__(self) -> _FakeOutputStream:
         return self
 
     async def __anext__(self) -> Any:
+        if self._error is not None:
+            error, self._error = self._error, None
+            raise error
         await asyncio.Event().wait()
         raise StopAsyncIteration
 
 
 class _FakeTranscribeStream:
-    def __init__(self) -> None:
+    def __init__(self, output_error: Exception | None = None) -> None:
         self.input_stream = _FakeAudioStream()
-        self.config: Any = None
+        self.configs: list[Any] = []
+        self.restarted = asyncio.Event()
+        self._output_error = output_error
 
     async def await_output(self) -> tuple[None, _FakeOutputStream]:
-        return None, _FakeOutputStream()
+        # the error is one-shot, so only the first attempt fails
+        error, self._output_error = self._output_error, None
+        return None, _FakeOutputStream(error)
 
 
 def _frame(duration_ms: int, sample_rate: int = 16000) -> rtc.AudioFrame:
@@ -65,12 +75,16 @@ def _frame(duration_ms: int, sample_rate: int = 16000) -> rtc.AudioFrame:
 
 def _make_stream(
     monkeypatch: pytest.MonkeyPatch,
+    *,
+    output_error: Exception | None = None,
 ) -> tuple[aws_stt.STT, aws_stt.SpeechStream, _FakeTranscribeStream]:
-    transcribe_stream = _FakeTranscribeStream()
+    transcribe_stream = _FakeTranscribeStream(output_error)
 
     class _FakeTranscribeClient:
         def __init__(self, *, config: Any) -> None:
-            transcribe_stream.config = config
+            transcribe_stream.configs.append(config)
+            if len(transcribe_stream.configs) > 1:
+                transcribe_stream.restarted.set()
 
         async def start_stream_transcription(self, *, input: Any) -> _FakeTranscribeStream:
             return transcribe_stream
@@ -193,27 +207,39 @@ async def test_aws_stream_cleanup_survives_closed_event_channel(
         await provider.aclose()
 
 
-async def test_aws_stream_pins_the_crt_transport(monkeypatch: pytest.MonkeyPatch):
-    provider, stream, transcribe_stream = _make_stream(monkeypatch)
-    closes = 0
-    crt_close = stream._http_client.close
+async def test_aws_stream_gives_each_attempt_its_own_crt_transport(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    closed: list[Any] = []
+    crt_close = aws_stt.AWSCRTHTTPClient.close
 
-    async def counting_close() -> None:
-        nonlocal closes
-        closes += 1
-        await crt_close()
+    async def tracking_close(self: Any) -> None:
+        closed.append(self)
+        await crt_close(self)
 
-    monkeypatch.setattr(stream._http_client, "close", counting_close)
+    monkeypatch.setattr(aws_stt.AWSCRTHTTPClient, "close", tracking_close)
+
+    provider, stream, transcribe_stream = _make_stream(
+        monkeypatch,
+        output_error=aws_stt.BadRequestException(
+            "Your request timed out because no new audio was received for 15 seconds."
+        ),
+    )
 
     try:
         stream.push_frame(_frame(100))
-        await asyncio.wait_for(transcribe_stream.input_stream.event_sent.wait(), timeout=1.0)
+        await asyncio.wait_for(transcribe_stream.restarted.wait(), timeout=1.0)
 
+        first, second = transcribe_stream.configs
         # StartStreamTranscription is bidirectional, which only the CRT transport carries
-        assert transcribe_stream.config.transport is stream._http_client
-        assert closes == 0
+        assert isinstance(first.transport, aws_stt.AWSCRTHTTPClient)
+        # AWS finishes the stream on its idle timeout, and the pooled connection dies with
+        # it, so the restarted attempt needs a transport of its own
+        assert second.transport is not first.transport
+        assert second.transport is stream._http_client
+        assert closed == [first.transport]
     finally:
         await stream.aclose()
         await provider.aclose()
 
-    assert closes == 1
+    assert closed == [first.transport, second.transport]

--- a/tests/test_plugin_aws_stt.py
+++ b/tests/test_plugin_aws_stt.py
@@ -47,6 +47,7 @@ class _FakeOutputStream:
 class _FakeTranscribeStream:
     def __init__(self) -> None:
         self.input_stream = _FakeAudioStream()
+        self.config: Any = None
 
     async def await_output(self) -> tuple[None, _FakeOutputStream]:
         return None, _FakeOutputStream()
@@ -69,7 +70,7 @@ def _make_stream(
 
     class _FakeTranscribeClient:
         def __init__(self, *, config: Any) -> None:
-            self.config = config
+            transcribe_stream.config = config
 
         async def start_stream_transcription(self, *, input: Any) -> _FakeTranscribeStream:
             return transcribe_stream
@@ -190,3 +191,29 @@ async def test_aws_stream_cleanup_survives_closed_event_channel(
         if not stream._task.done():
             await stream.aclose()
         await provider.aclose()
+
+
+async def test_aws_stream_pins_the_crt_transport(monkeypatch: pytest.MonkeyPatch):
+    provider, stream, transcribe_stream = _make_stream(monkeypatch)
+    closes = 0
+    crt_close = stream._http_client.close
+
+    async def counting_close() -> None:
+        nonlocal closes
+        closes += 1
+        await crt_close()
+
+    monkeypatch.setattr(stream._http_client, "close", counting_close)
+
+    try:
+        stream.push_frame(_frame(100))
+        await asyncio.wait_for(transcribe_stream.input_stream.event_sent.wait(), timeout=1.0)
+
+        # StartStreamTranscription is bidirectional, which only the CRT transport carries
+        assert transcribe_stream.config.transport is stream._http_client
+        assert closes == 0
+    finally:
+        await stream.aclose()
+        await provider.aclose()
+
+    assert closes == 1

--- a/uv.lock
+++ b/uv.lock
@@ -552,16 +552,16 @@ wheels = [
 
 [[package]]
 name = "aws-sdk-bedrock-runtime"
-version = "0.7.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "smithy-aws-core", extra = ["eventstream", "json"] },
     { name = "smithy-core" },
-    { name = "smithy-http", extra = ["awscrt"] },
+    { name = "smithy-http", extra = ["aiohttp"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/8a/ed3fd98775273b0b7f6006b4970aa876d506668b7fe29145f54fcb941c3b/aws_sdk_bedrock_runtime-0.7.0.tar.gz", hash = "sha256:0cb172cbc03ff060e5c1d6f9cfa9a8ac5e71d9e0d58d3117006ebf614cbb4677", size = 170304, upload-time = "2026-06-23T04:04:52.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/b3/9c225cbfe9f17ea2e3d75a0fdd0b325ef79839b9c09a376bda63a7bf3bb3/aws_sdk_bedrock_runtime-0.11.0.tar.gz", hash = "sha256:f2c45d34625bf6a7b56375e29a53a16b376880bda771e4bbf7d84491622eb193", size = 173854, upload-time = "2026-08-24T21:17:16.304Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/e1/f86d50f0ad9c8200645f315c524d285e86b30b94bb65118e1108597714e6/aws_sdk_bedrock_runtime-0.7.0-py3-none-any.whl", hash = "sha256:de67ede6f441bbb77ef61c237945d559513843fc827abe1af12535c2519650c5", size = 94948, upload-time = "2026-06-23T04:04:51.281Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0c/9512304ed017ce49992df6661eac2b914550247e13bccb55be6ca594170d/aws_sdk_bedrock_runtime-0.11.0-py3-none-any.whl", hash = "sha256:ef01c26ddfd83a5d3e438ab72ebb3c13b41fc0ef11d81095b22c8016f97e9795", size = 97112, upload-time = "2026-08-24T21:17:17.396Z" },
 ]
 
 [[package]]
@@ -575,16 +575,16 @@ wheels = [
 
 [[package]]
 name = "aws-sdk-transcribe-streaming"
-version = "0.7.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "smithy-aws-core", extra = ["eventstream", "json"] },
     { name = "smithy-core" },
-    { name = "smithy-http", extra = ["awscrt"] },
+    { name = "smithy-http", extra = ["aiohttp"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/0c/f37b2acea16dd4ddce3da27302b2ff72cf774bc4593cacf87821fd01129f/aws_sdk_transcribe_streaming-0.7.0.tar.gz", hash = "sha256:63f55209af4c48339c1dec076dff77f7d5780cf50eb7a0851b1411cffeaad7f2", size = 459974, upload-time = "2026-06-23T04:05:04.48Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/8a/f4556fed694b0f4e5e6bcf1105fe5d0b6a95a7633308242dd10e53bd6492/aws_sdk_transcribe_streaming-0.11.0.tar.gz", hash = "sha256:ec9fa7d635aed09df6be51a55ad9e39018b0a1451428916fcdf2b412714b00b3", size = 463385, upload-time = "2026-08-24T21:17:15.188Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/be/6cfbc24c8b9264c8201e38868b335c95b24070092100fd2505b53254bc26/aws_sdk_transcribe_streaming-0.7.0-py3-none-any.whl", hash = "sha256:0d39759d1bf3c4acad60dd39ae613f3795a7fdd25d51aaa5227de736225f5f34", size = 62674, upload-time = "2026-06-23T04:05:03.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c4/4a4e48769e98542e5709c8e168dd5971d3c152d972bc0e60636a55498725/aws_sdk_transcribe_streaming-0.11.0-py3-none-any.whl", hash = "sha256:3a5fdad60b08ae8c2fa45831775ccf6978bc2a28a2d5fd29e3d3820f77b58ba3", size = 64556, upload-time = "2026-08-24T21:17:14.01Z" },
 ]
 
 [[package]]
@@ -2654,6 +2654,7 @@ dependencies = [
     { name = "aiobotocore" },
     { name = "aws-sdk-transcribe-streaming" },
     { name = "livekit-agents" },
+    { name = "smithy-http", extra = ["awscrt"] },
 ]
 
 [package.optional-dependencies]
@@ -2669,9 +2670,10 @@ requires-dist = [
     { name = "aiobotocore", specifier = ">=3.0.0" },
     { name = "aws-sdk-bedrock-runtime", marker = "python_full_version >= '3.12' and extra == 'realtime'", specifier = ">=0.2.0" },
     { name = "aws-sdk-signers", marker = "python_full_version >= '3.12' and extra == 'realtime'", specifier = ">=0.0.3" },
-    { name = "aws-sdk-transcribe-streaming", marker = "python_full_version >= '3.12'", specifier = ">=0.2.0" },
+    { name = "aws-sdk-transcribe-streaming", marker = "python_full_version >= '3.12'", specifier = ">=0.11.0" },
     { name = "boto3", marker = "extra == 'realtime'", specifier = ">1.35.10" },
     { name = "livekit-agents", editable = "livekit-agents" },
+    { name = "smithy-http", extras = ["awscrt"], marker = "python_full_version >= '3.12'" },
     { name = "smithy-http", extras = ["awscrt"], marker = "python_full_version >= '3.12' and extra == 'realtime'" },
 ]
 provides-extras = ["realtime"]
@@ -5634,16 +5636,16 @@ wheels = [
 
 [[package]]
 name = "smithy-aws-core"
-version = "0.7.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aws-sdk-signers" },
     { name = "smithy-core" },
     { name = "smithy-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/a8/37bfde59519f45d2047d0033b791aca6574d867aaf57bb56a6de42ab5c26/smithy_aws_core-0.7.0.tar.gz", hash = "sha256:34e82d09fc808acd5ffc80f03828d0609c6a211f49f0884dc6ee7ca095a1b6af", size = 15670, upload-time = "2026-06-23T04:04:50.365Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/d3/501c0023548173416109ac42298ca33b708469dc922005770811a597949f/smithy_aws_core-0.11.0.tar.gz", hash = "sha256:29ee89976a520a87e3db557e03e115fdc21a0a60b81161e95174395a1b064da1", size = 38791, upload-time = "2026-08-24T21:16:59.631Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/54/2d06dd9a3972a380d71bb8c3312e317aa8f1ea68dd28cffc06955ccf0220/smithy_aws_core-0.7.0-py3-none-any.whl", hash = "sha256:6c60c8fbb9431c60e80ea7f2d37e7ae48409cc1541f587fe073f202eca067e92", size = 24894, upload-time = "2026-06-23T04:04:49.349Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f6/fefda9aab809fa1a62bf7073bd6d8ab427bd9989f39b13c0d6e29d4d1045/smithy_aws_core-0.11.0-py3-none-any.whl", hash = "sha256:77cf130c22deac14a8cbeb8ccc4bcfe5a91798f4b38cb53a987080ec58c89f23", size = 58855, upload-time = "2026-08-24T21:16:58.657Z" },
 ]
 
 [package.optional-dependencies]
@@ -5668,41 +5670,45 @@ wheels = [
 
 [[package]]
 name = "smithy-core"
-version = "0.6.0"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e9/45/688d52c61cd4d843bb230694259e91d4c7d6954eeecbadf452a168001d45/smithy_core-0.6.0.tar.gz", hash = "sha256:ba2e5d860d716aff75004a23f53e09dfaca3e2b94f8a00c1f76dcb355b769ce0", size = 52095, upload-time = "2026-06-23T04:04:44.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/c6/93e9eea3c6163228dfe972c3e989e0553047858805ab7aa4a59f074ba129/smithy_core-0.8.1.tar.gz", hash = "sha256:3d2f8fca5960d74bd7ef380f70901c7bcdebe53f929d2d3d2fa6cb790b3f5214", size = 54259, upload-time = "2026-08-20T17:55:30.354Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/b6/06795faa9844b9667ae492e6293370393e19e7f0c2df8da1b4bf7e5f6ed9/smithy_core-0.6.0-py3-none-any.whl", hash = "sha256:51e347ed309d60ab9d36b783dbf88de614c460d51bec79d39cd403956b00f063", size = 66879, upload-time = "2026-06-23T04:04:43.596Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/23/c6430bbf406477fc7d16254b9908a723b299a4a21a94c99db9d12c84a8bf/smithy_core-0.8.1-py3-none-any.whl", hash = "sha256:44bd9bdf702f76919af58e44a6a1bb3dc136a745b2f955281743022ce767e347", size = 68805, upload-time = "2026-08-20T17:55:29.366Z" },
 ]
 
 [[package]]
 name = "smithy-http"
-version = "0.4.2"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "smithy-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/58/5a772d212e066d6fc1398946c4aae19bcdaa75209879d776f641b6a06b5b/smithy_http-0.4.2.tar.gz", hash = "sha256:50d11b6a55e42448450a01e3d0f605ccee65a72abf52d02eed82862a15be5937", size = 29616, upload-time = "2026-06-23T04:04:45.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/78/b5f3113d6c8f0bc1f9777a7f5ca84b892d29efac05850e14f7d4f7e645b5/smithy_http-0.5.0.tar.gz", hash = "sha256:bb4a19672f7c7eeb872a308f777eb505281a5bafb1ee3d1ea9c760c06c352510", size = 31122, upload-time = "2026-08-24T21:16:56.488Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/3e/7b2464d40893bec0b5d1f479d25116d4aa09f9f66536b4c4b3126202215d/smithy_http-0.4.2-py3-none-any.whl", hash = "sha256:a158f107e9fab925289d20772c2e38b0bba94e55c05d0edc9290310f22a60454", size = 41025, upload-time = "2026-06-23T04:04:46.764Z" },
+    { url = "https://files.pythonhosted.org/packages/27/27/e414082643028846b73afa52a1a8f934548196ee12b187a06803f02a3e66/smithy_http-0.5.0-py3-none-any.whl", hash = "sha256:af273d5f42e7733ce7a6e9bd6fdd6a59ef1b61f6cd1f4a89dd53dfce99da7bef", size = 42198, upload-time = "2026-08-24T21:16:57.52Z" },
 ]
 
 [package.optional-dependencies]
+aiohttp = [
+    { name = "aiohttp" },
+    { name = "yarl" },
+]
 awscrt = [
     { name = "awscrt" },
 ]
 
 [[package]]
 name = "smithy-json"
-version = "0.2.3"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ijson" },
     { name = "smithy-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/6c/418b5687d8933b7a135d5e1a98c61fe814b98f72517dbae0e666860cb876/smithy_json-0.2.3.tar.gz", hash = "sha256:686e9b55a36dacb08e472732b358573ef78009055e05e9fce2e806d61490b2b3", size = 7805, upload-time = "2026-06-23T04:04:47.71Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/ac/04164eefb3da7479f52f6535b4b39cc8384c292cb2bb74279f2acc4f4b4d/smithy_json-0.3.0.tar.gz", hash = "sha256:c81c7034587e01bc64767cbbecb05a7d65ca9070612fd94e8a03e80540290a22", size = 7956, upload-time = "2026-08-20T17:55:32.177Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/14/eabb26b355415bcd9feef27fb5b18f1dad3fabd4208cfcbaf152025fa9ae/smithy_json-0.2.3-py3-none-any.whl", hash = "sha256:594e1bbe3d480963237f8fd0fc648dbd4e988b4503fea90157b5f07706796327", size = 10252, upload-time = "2026-06-23T04:04:48.46Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/cf/0104c40a0e18fa307ea3da4310eba949f474a5bc1df3cc2b5851a72e8486/smithy_json-0.3.0-py3-none-any.whl", hash = "sha256:ffb73d2e60cf5e616e5d0a1019e7b9f518edba076cb423f10981457725dcddc4", size = 10252, upload-time = "2026-08-20T17:55:31.204Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Problem:** AWS Transcribe STT cannot start on `aws-sdk-transcribe-streaming` 0.10.0 or later. 0.10.0 dropped the `Config` export and 0.11.0 dropped the `TranscribeStreamingClient` alias, so the module import fails and `STT()` raises a misleading `ImportError: The 'aws_sdk_transcribe_streaming' package is not installed`.

**Fix:** Raise the floor to 0.11.0, import `AsyncTranscribeStreamingClient` and `AsyncTranscribeStreamingConfig` directly, and build the config with `await Config.resolve(...)`. 0.11.0 makes `AIOHTTPClient` the default transport, which cannot carry a bidirectional stream, so `StartStreamTranscription` now gets the SpeechStream's `AWSCRTHTTPClient` through `transport=`, closed once in `aclose()`.

Replaces #7074, whose transport diagnosis this keeps. Close #7072.

<details>
<summary>Context for reviewing and coding agents</summary>

> **How to see the failure**
>
> Install `aws-sdk-transcribe-streaming` 0.11.0, then run the module. On main all five tests fail, because `livekit.plugins.aws.stt` sets `_AWS_SDK_AVAILABLE = False` and every test constructs an `STT`.
>
> ```
> uv run pytest tests/test_plugin_aws_stt.py --unit
> ```
>
> The new test asserts the resolved config carries the SpeechStream's own `AWSCRTHTTPClient`, and that the client is closed exactly once, after `aclose()`. The close count guards the restart path: AWS ends a stream after 15 seconds of silence and `_run` loops, so a close inside the loop leaves the next attempt with a dead HTTP client.
>
> **What else the lock bump moves**
>
> transcribe-streaming 0.11.0 needs `smithy-core~=0.8.0`, while the locked 0.7.0 needed `~=0.6.0`. uv therefore also lifts `aws-sdk-bedrock-runtime` 0.7.0 to 0.11.0, plus smithy-aws-core, smithy-http, and smithy-json. The only other consumer of bedrock-runtime is `livekit-plugins/livekit-plugins-aws/livekit/plugins/aws/experimental/realtime/realtime_model.py`, which #7076 already made work on 0.11.
>
> **Why the floor moved instead of a version ladder**
>
> The client name, the config name, and the config constructor all differ across 0.9.0, 0.10.0, and 0.11.0. A ladder that keeps `>=0.2.0` needs nested import fallbacks and a `hasattr(Config, "resolve")` check at runtime. One floor makes the imports direct and leaves the config path with no branch.
>
> **What the raise costs**
>
> A Python 3.12+ install that holds transcribe-streaming below 0.11.0 must upgrade. STT is already dead on 0.10.0 and 0.11.0, so only pins at 0.9.0 and earlier lose a working version. The dependency added is `smithy-http[awscrt]`, not `awscrt`, because 0.11.0 moved the CRT transport behind an extra and smithy-http owns the `awscrt~=0.32.0` bound.

</details>
