### PR TITLE
fix(google): route Gemma 4 thinking through thinking_level

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -43,12 +43,12 @@ from .version import __version__
 
 def _is_gemini_3_model(model: str) -> bool:
     """Check if model is Gemini 3 series"""
-    return "gemini-3" in model.lower() or model.lower().startswith("gemini-3")
+    return "gemini-3" in model.lower()
 
 
 def _is_gemma_4_model(model: str) -> bool:
     """Check if model is Gemma 4 series"""
-    return model.lower().startswith("gemma-4-")
+    return "gemma-4-" in model.lower()
 
 
 def _supports_thinking_level(model: str) -> bool:
@@ -80,7 +80,7 @@ def _function_calling_config(
 def _is_gemini_3_flash_model(model: str) -> bool:
     """Check if model is Gemini 3 Flash"""
     m = model.lower()
-    return m.startswith("gemini-3") and "flash" in m
+    return "gemini-3" in m and "flash" in m
 
 
 def _requires_thought_signatures(model: str) -> bool:
@@ -238,11 +238,25 @@ class LLM(llm.LLM):
                 _thinking_level = thinking_config.get("thinking_level")
             elif isinstance(thinking_config, types.ThinkingConfig):
                 _thinking_budget = thinking_config.thinking_budget
-                _thinking_level = getattr(thinking_config, "thinking_level", None)
+                _thinking_level = thinking_config.thinking_level
 
             if _thinking_budget is not None:
                 if not isinstance(_thinking_budget, int):
                     raise ValueError("thinking_budget inside thinking_config must be an integer")
+
+            # gemma 4 toggles thinking on and off with nothing in between, and answers any other
+            # level with 400 INVALID_ARGUMENT
+            # https://ai.google.dev/gemma/docs/core/gemma_on_gemini_api
+            if (
+                _thinking_level is not None
+                and _is_gemma_4_model(model)
+                and _thinking_level.upper()
+                not in (types.ThinkingLevel.MINIMAL, types.ThinkingLevel.HIGH)
+            ):
+                raise ValueError(
+                    f"Model {model} only supports thinking_level 'minimal' (thinking off) "
+                    f"or 'high' (thinking on), got {_thinking_level!r}."
+                )
 
         self._opts = _LLMOptions(
             model=model,
@@ -386,7 +400,7 @@ class LLM(llm.LLM):
                 _include_thoughts = thinking_cfg.get("include_thoughts")
             elif isinstance(thinking_cfg, types.ThinkingConfig):
                 _budget = thinking_cfg.thinking_budget
-                _level = getattr(thinking_cfg, "thinking_level", None)
+                _level = thinking_cfg.thinking_level
                 _include_thoughts = thinking_cfg.include_thoughts
 
             if _supports_thinking_level(self._opts.model):
@@ -399,11 +413,10 @@ class LLM(llm.LLM):
                 if _level is None and _is_gemini_3_model(self._opts.model):
                     # only default the level where the accepted levels are known
                     _level = "minimal" if _is_gemini_3_flash_model(self._opts.model) else "low"
-                # the level passes through as given: only the API knows what a model accepts
-                extra["thinking_config"] = {
-                    "thinking_level": _level,
-                    "include_thoughts": _include_thoughts,
-                }
+                # the level passes through as given, checked against the model in __init__
+                extra["thinking_config"] = types.ThinkingConfig(
+                    thinking_level=_level, include_thoughts=_include_thoughts
+                )
 
             else:
                 # Gemini 2.5 and earlier: only support thinking_budget

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/llm.py
@@ -46,6 +46,16 @@ def _is_gemini_3_model(model: str) -> bool:
     return "gemini-3" in model.lower() or model.lower().startswith("gemini-3")
 
 
+def _is_gemma_4_model(model: str) -> bool:
+    """Check if model is Gemma 4 series"""
+    return model.lower().startswith("gemma-4-")
+
+
+def _supports_thinking_level(model: str) -> bool:
+    """Check if model configures thinking with a level instead of a token budget"""
+    return _is_gemini_3_model(model) or _is_gemma_4_model(model)
+
+
 def _function_calling_config(
     tool_choice: NotGivenOr[ToolChoice], function_tools: Iterable[str]
 ) -> types.FunctionCallingConfig | None:
@@ -364,35 +374,36 @@ class LLM(llm.LLM):
 
         # Handle thinking_config based on model version
         if is_given(self._opts.thinking_config):
-            is_gemini_3 = _is_gemini_3_model(self._opts.model)
-            is_gemini_3_flash = _is_gemini_3_flash_model(self._opts.model)
             thinking_cfg = self._opts.thinking_config
 
-            # Extract both parameters
+            # Extract the parameters
             _budget = None
             _level: str | types.ThinkingLevel | None = None
+            _include_thoughts: bool | None = None
             if isinstance(thinking_cfg, dict):
                 _budget = thinking_cfg.get("thinking_budget")
                 _level = thinking_cfg.get("thinking_level")
+                _include_thoughts = thinking_cfg.get("include_thoughts")
             elif isinstance(thinking_cfg, types.ThinkingConfig):
                 _budget = thinking_cfg.thinking_budget
                 _level = getattr(thinking_cfg, "thinking_level", None)
+                _include_thoughts = thinking_cfg.include_thoughts
 
-            if is_gemini_3:
-                # Gemini 3: only support thinking_level
+            if _supports_thinking_level(self._opts.model):
+                # Gemini 3 and Gemma 4 configure thinking with a level, not a token budget
                 if _budget is not None and _level is None:
                     logger.warning(
-                        f"Model {self._opts.model} is Gemini 3 which does not support thinking_budget. "
-                        "Please use thinking_level ('low' or 'high') instead. Ignoring thinking_budget."
+                        f"Model {self._opts.model} does not support thinking_budget. "
+                        "Please use thinking_level instead. Ignoring thinking_budget."
                     )
-                if _level is None:
-                    # If no thinking_level is provided, use the fastest thinking level
-                    if is_gemini_3_flash:
-                        _level = "minimal"
-                    else:
-                        _level = "low"
-                # Use thinking_level only (pass as dict since SDK may not have this field yet)
-                extra["thinking_config"] = {"thinking_level": _level}
+                if _level is None and _is_gemini_3_model(self._opts.model):
+                    # only default the level where the accepted levels are known
+                    _level = "minimal" if _is_gemini_3_flash_model(self._opts.model) else "low"
+                # the level passes through as given: only the API knows what a model accepts
+                extra["thinking_config"] = {
+                    "thinking_level": _level,
+                    "include_thoughts": _include_thoughts,
+                }
 
             else:
                 # Gemini 2.5 and earlier: only support thinking_budget

--- a/tests/test_google_thought_signatures.py
+++ b/tests/test_google_thought_signatures.py
@@ -45,6 +45,7 @@ class TestGeminiModelDetection:
             ("gemini-3-flash-preview", True),
             ("gemini-3-flash", True),
             ("GEMINI-3-FLASH", True),  # case insensitive
+            ("models/gemini-3-flash-preview", True),  # qualified name
             # Gemini 3 Pro models - should return False
             ("gemini-3-pro-preview", False),
             ("gemini-3-pro", False),
@@ -63,6 +64,8 @@ class TestGeminiModelDetection:
             ("gemini-3-pro-preview", True),
             ("gemma-4-31b-it", True),
             ("GEMMA-4-31B-IT", True),  # case insensitive
+            ("models/gemma-4-31b-it", True),  # qualified name
+            ("publishers/google/models/gemma-4-26b-a4b-it", True),
             # budget models - should return False
             ("gemini-2.5-flash", False),
             ("gemma-3-27b-it", False),

--- a/tests/test_google_thought_signatures.py
+++ b/tests/test_google_thought_signatures.py
@@ -4,6 +4,7 @@ from livekit.plugins.google.llm import (
     _is_gemini_3_flash_model,
     _is_gemini_3_model,
     _requires_thought_signatures,
+    _supports_thinking_level,
 )
 
 pytestmark = pytest.mark.unit
@@ -29,6 +30,7 @@ class TestGeminiModelDetection:
             # Gemini 1.5 models - should return False
             ("gemini-1.5-pro", False),
             # Other models - should return False
+            ("gemma-4-31b-it", False),
             ("gpt-4", False),
             ("claude-3", False),
         ],
@@ -57,6 +59,22 @@ class TestGeminiModelDetection:
     @pytest.mark.parametrize(
         "model,expected",
         [
+            # level models - should return True
+            ("gemini-3-pro-preview", True),
+            ("gemma-4-31b-it", True),
+            ("GEMMA-4-31B-IT", True),  # case insensitive
+            # budget models - should return False
+            ("gemini-2.5-flash", False),
+            ("gemma-3-27b-it", False),
+            ("gemma-40-31b-it", False),
+        ],
+    )
+    def test_supports_thinking_level(self, model: str, expected: bool):
+        assert _supports_thinking_level(model) == expected
+
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
             # Gemini 3 models - should return True (requires thought signatures)
             ("gemini-3-pro-preview", True),
             ("gemini-3-flash-preview", True),
@@ -76,6 +94,7 @@ class TestGeminiModelDetection:
             # Gemini 1.5 models - should return False
             ("gemini-1.5-pro", False),
             # Other models - should return False
+            ("gemma-4-31b-it", False),
             ("gpt-4", False),
             ("claude-3", False),
         ],

--- a/tests/test_plugin_google_llm.py
+++ b/tests/test_plugin_google_llm.py
@@ -546,24 +546,29 @@ class TestThinkingConfigRequestConstruction:
         return captured["config"].thinking_config
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "level",
-        [
-            types.ThinkingLevel.MINIMAL,
-            types.ThinkingLevel.LOW,
-            types.ThinkingLevel.MEDIUM,
-            types.ThinkingLevel.HIGH,
-        ],
-    )
-    async def test_gemma_4_level_reaches_the_request(self, level: types.ThinkingLevel) -> None:
-        """Gemma 4 takes a level, and every level the SDK knows is sent as given: the API
-        decides which ones a model accepts, not the plugin."""
+    @pytest.mark.parametrize("model", ["gemma-4-31b-it", "models/gemma-4-31b-it"])
+    @pytest.mark.parametrize("level", [types.ThinkingLevel.MINIMAL, types.ThinkingLevel.HIGH])
+    async def test_gemma_4_level_reaches_the_request(
+        self, model: str, level: types.ThinkingLevel
+    ) -> None:
+        """Gemma 4 takes the level it documents, under a bare or a qualified model name."""
         thinking_config = await self._capture_thinking_config(
-            "gemma-4-31b-it", types.ThinkingConfig(thinking_level=level)
+            model, types.ThinkingConfig(thinking_level=level)
         )
 
         assert thinking_config is not None
         assert thinking_config.thinking_level == level
+
+    @pytest.mark.parametrize("level", [types.ThinkingLevel.LOW, types.ThinkingLevel.MEDIUM])
+    def test_gemma_4_rejects_undocumented_levels(self, level: types.ThinkingLevel) -> None:
+        """Gemma 4 answers 'low' and 'medium' with 400 INVALID_ARGUMENT, so the session fails at
+        construction instead of on the first turn."""
+        with pytest.raises(ValueError, match="only supports thinking_level"):
+            LLM(
+                model="gemma-4-31b-it",
+                api_key="test",
+                thinking_config=types.ThinkingConfig(thinking_level=level),
+            )
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("model", ["gemini-3-pro-preview", "gemma-4-31b-it"])
@@ -581,6 +586,7 @@ class TestThinkingConfigRequestConstruction:
         "model,expected_level",
         [
             ("gemini-3-flash-preview", types.ThinkingLevel.MINIMAL),
+            ("models/gemini-3-flash-preview", types.ThinkingLevel.MINIMAL),
             ("gemini-3-pro-preview", types.ThinkingLevel.LOW),
             # no default is invented for a model whose accepted levels are unknown
             ("gemma-4-31b-it", None),

--- a/tests/test_plugin_google_llm.py
+++ b/tests/test_plugin_google_llm.py
@@ -506,3 +506,114 @@ class TestMixedToolsRequestConstruction:
         assert config.cached_content == "cachedContents/abc"
         assert config.tools is None
         assert config.tool_config is None
+
+
+class TestThinkingConfigRequestConstruction:
+    """Gemini 3 and Gemma 4 configure thinking with ``thinking_level``, every other model with
+    ``thinking_budget``. These tests drive ``chat()`` against a stubbed
+    ``generate_content_stream`` and assert on the ``ThinkingConfig`` it received."""
+
+    @staticmethod
+    async def _single_response_async_iter():
+        yield types.GenerateContentResponse(
+            candidates=[
+                types.Candidate(
+                    content=types.Content(role="model", parts=[types.Part(text="ok")]),
+                    finish_reason=types.FinishReason.STOP,
+                )
+            ],
+        )
+
+    @classmethod
+    async def _capture_thinking_config(
+        cls, model: str, thinking_config: types.ThinkingConfigOrDict
+    ) -> types.ThinkingConfig | None:
+        captured: dict = {}
+
+        async def fake_stream(**kwargs):
+            captured["config"] = kwargs.get("config")
+            return cls._single_response_async_iter()
+
+        llm_ = LLM(model=model, api_key="test", thinking_config=thinking_config)
+        fake = AsyncMock(side_effect=fake_stream)
+        with patch.object(llm_._client.aio.models, "generate_content_stream", fake):
+            stream = llm_.chat(chat_ctx=ChatContext.empty())
+            try:
+                async for _ in stream:
+                    pass
+            finally:
+                await stream.aclose()
+        return captured["config"].thinking_config
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "level",
+        [
+            types.ThinkingLevel.MINIMAL,
+            types.ThinkingLevel.LOW,
+            types.ThinkingLevel.MEDIUM,
+            types.ThinkingLevel.HIGH,
+        ],
+    )
+    async def test_gemma_4_level_reaches_the_request(self, level: types.ThinkingLevel) -> None:
+        """Gemma 4 takes a level, and every level the SDK knows is sent as given: the API
+        decides which ones a model accepts, not the plugin."""
+        thinking_config = await self._capture_thinking_config(
+            "gemma-4-31b-it", types.ThinkingConfig(thinking_level=level)
+        )
+
+        assert thinking_config is not None
+        assert thinking_config.thinking_level == level
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("model", ["gemini-3-pro-preview", "gemma-4-31b-it"])
+    async def test_include_thoughts_survives_the_level_branch(self, model: str) -> None:
+        thinking_config = await self._capture_thinking_config(
+            model, {"thinking_level": "high", "include_thoughts": True}
+        )
+
+        assert thinking_config is not None
+        assert thinking_config.thinking_level == types.ThinkingLevel.HIGH
+        assert thinking_config.include_thoughts is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "model,expected_level",
+        [
+            ("gemini-3-flash-preview", types.ThinkingLevel.MINIMAL),
+            ("gemini-3-pro-preview", types.ThinkingLevel.LOW),
+            # no default is invented for a model whose accepted levels are unknown
+            ("gemma-4-31b-it", None),
+        ],
+    )
+    async def test_default_level_only_for_gemini_3(
+        self, model: str, expected_level: types.ThinkingLevel | None
+    ) -> None:
+        thinking_config = await self._capture_thinking_config(
+            model, types.ThinkingConfig(include_thoughts=False)
+        )
+
+        assert thinking_config is not None
+        assert thinking_config.thinking_level == expected_level
+        assert thinking_config.include_thoughts is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("model", ["gemini-3-pro-preview", "gemma-4-31b-it"])
+    async def test_budget_alone_is_dropped_on_level_models(self, model: str) -> None:
+        """A budget on a level model is ignored with a warning, on Gemini 3 and Gemma 4 alike."""
+        thinking_config = await self._capture_thinking_config(
+            model, types.ThinkingConfig(thinking_budget=0)
+        )
+
+        assert thinking_config is not None
+        assert thinking_config.thinking_budget is None
+
+    @pytest.mark.asyncio
+    async def test_budget_still_reaches_gemini_2_5(self) -> None:
+        thinking_config = await self._capture_thinking_config(
+            "gemini-2.5-flash", types.ThinkingConfig(thinking_budget=1024)
+        )
+
+        assert thinking_config is not None
+        assert thinking_config.thinking_budget == 1024
+        assert thinking_config.thinking_level is None


### PR DESCRIPTION
**Problem:** `_is_gemini_3_model()` matches the substring `gemini-3`, so `gemma-4-*` models land in the `thinking_budget` branch and `chat()` raises `ValueError` on the first user turn when the caller sets `thinking_level`. The Gemini API rejects `thinking_budget` for Gemma 4, so no caller can control thinking on those models through the plugin.

**Fix:** `_supports_thinking_level()` sends Gemma 4 down the same level branch as Gemini 3, which now also keeps `include_thoughts`, and every model predicate matches on a substring so a qualified name such as `models/gemma-4-31b-it` cannot fall out of it. Gemma 4 accepts `minimal` and `high` only, so `__init__` rejects the other two levels instead of letting the API answer the first turn with 400.

Replaces #7080, whose predicate split this keeps. Close #7071.

<details>
<summary>Context for reviewing and coding agents</summary>

> **How to see the failure**
>
> On main, both of these raise before a request goes out. The second one still raises on the first commit of this branch.
>
> ```python
> from google.genai import types
> from livekit.plugins.google import LLM
>
> cfg = types.ThinkingConfig(thinking_level=types.ThinkingLevel.MINIMAL)
> LLM(model="gemma-4-31b-it", api_key="x", thinking_config=cfg).chat(chat_ctx=...)
> LLM(model="models/gemma-4-31b-it", api_key="x", thinking_config=cfg).chat(chat_ctx=...)
> # ValueError: ... does not support thinking_level
> ```
>
> `TestThinkingConfigRequestConstruction` in `tests/test_plugin_google_llm.py` drives `chat()` against a stubbed `generate_content_stream` and reads the `ThinkingConfig` that reaches the request. Run it with `uv run pytest tests/test_plugin_google_llm.py --plugin google`. The module carries `pytest.mark.plugin("google")`, so `--unit` deselects all of it.
>
> **Which levels Gemma 4 accepts, and how that was measured**
>
> Google documents two: "Gemma 4 strictly supports toggling this feature on or off, you can control it using the API by setting the thinking level to `"high"` for enabled or `"minimal"` for disabled" — https://ai.google.dev/gemma/docs/core/gemma_on_gemini_api.
>
> Real requests agree. `gemma-4-31b-it` and `gemma-4-26b-a4b-it` both answer on `minimal` and `high`, and both return `400 INVALID_ARGUMENT "Thinking level is not supported for this model."` on `low` and `medium`. Each case ran twice against the Gemini API and gave the same result. `gemini-3-flash-preview` and `gemini-3.5-flash` answer on all four levels, so the old warning text that named only `low` and `high` was wrong and is gone.
>
> `GET /v1beta/models/gemma-4-31b-it` reports only `"thinking": true`, so a client cannot discover the accepted levels at runtime.
>
> **Why the level check sits in `__init__` rather than in `chat()`**
>
> A wrong level is a configuration error, and `__init__` already unpacks the union and checks the budget type. A check there fails the session at startup. The earlier version of this branch passed the level through instead, on the argument that only the API knows what a model accepts; that argument does not survive the two measurements above, and it costs a voice session its first turn.
>
> Coercing `low` to `minimal` and `medium` to `high` was rejected. It keeps the session alive but silently sends a different level than the caller asked for.
>
> **Blast radius: the other callers of the changed predicates**
>
> `_is_gemini_3_model()` now reads `"gemini-3" in model.lower()`, which drops a `startswith` clause the substring already covered. Its behaviour is unchanged, and its two other callers still exclude Gemma 4: the Gemini 3 API gate at `llm.py:331`, and thought signatures at `llm.py:92`, where `_requires_thought_signatures("gemma-4-31b-it")` is `False`.
>
> `_is_gemini_3_flash_model()` changes behaviour. It matched on a prefix, so `models/gemini-3-flash-preview` was read as a non-flash model and defaulted to `low` instead of `minimal` at `llm.py:415`. It has no other caller.
>
> **Why the SDK fallbacks are gone**
>
> `getattr(thinking_config, "thinking_level", None)` and the raw dict passed as `thinking_config` both existed because the field was new. The plugin declares `google-genai >= 2.13`, and 2.13.0 already carries `ThinkingConfig.thinking_level` and `types.ThinkingLevel`, so the level branch now builds a `types.ThinkingConfig` like the budget branch does.
>
> The guard compares `_thinking_level.upper()` against the enum members, not against string literals. `ThinkingLevel` values are upper case and the enum subclasses `str`, so `ThinkingLevel.HIGH == "high"` is `False`, and the dict form of `thinking_config` is never validated and keeps a raw lower-case string. `types.ThinkingLevel("bogus")` is not an alternative: it warns and returns a pseudo-member instead of raising.
>
> **What the `include_thoughts` change costs existing Gemini 3 users**
>
> Both branches on main replace the whole `ThinkingConfig`, so `include_thoughts` never reached the API. Callers who set `include_thoughts=True` on a Gemini 3 model got no thought parts and now will get them. The `thinking_budget` branch for Gemini 2.5 and earlier still drops the field.
>
> **The default-level rule**
>
> A default level is chosen only for Gemini 3: `minimal` for flash, `low` otherwise, unchanged from main. Gemma 4 sends no level when the caller gives none, and the API applies its own default.
>
> **What the measurements do not cover**
>
> Every real request went to the Gemini API. No request went to Vertex AI, so the `publishers/google/models/...` form is covered by a predicate test only. `gemini-3.1-pro-preview` returned 429 on all four levels, so no Gemini 3 pro model was measured.

</details>
