### PR TITLE
feat(voice): add public `add_conversation_item` method to AgentSession

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1976,7 +1976,10 @@ class AgentActivity(RecognitionHooks):
     def _on_remote_item_added(self, ev: llm.RemoteItemAddedEvent) -> None:
         # add the remote item to the local chat context as a placeholder
         local_chat_ctx = self._agent._chat_ctx
-        if local_chat_ctx.get_by_id(ev.item.id) is not None:
+        if (
+            local_chat_ctx.get_by_id(ev.item.id) is not None
+            or ev.item.id in self._session._locally_pushed_conversation_item_ids
+        ):
             return
 
         # only add placeholders for server-initiated items (responses, function calls),

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -1528,6 +1528,32 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         return handle
 
+    def add_conversation_item(self, item: llm.ChatMessage) -> bool:
+        """Add a conversation item to the session history and the active agent's context.
+
+        Inserts ``item`` into ``session.history`` and, when an agent is running,
+        into its chat context.  Emits ``conversation_item_added`` so that event
+        listeners (transcript capture, analytics, etc.) observe the item the
+        same way they observe items produced by the normal audio pipeline.
+
+        The call is idempotent: if an item with the same ``id`` already exists
+        in the session history the method returns ``False`` and does nothing.
+
+        Args:
+            item: The ChatMessage to add.
+
+        Returns:
+            ``True`` if the item was added, ``False`` if it was already present.
+        """
+        if self._chat_ctx.get_by_id(item.id) is not None:
+            return False
+
+        if self._agent is not None and self._agent._chat_ctx.get_by_id(item.id) is None:
+            self._agent._chat_ctx.insert(item)
+
+        self._conversation_item_added(item)
+        return True
+
     def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
         """Interrupt the current speech generation.
 

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -660,7 +660,13 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         self._forward_video_atask: asyncio.Task[None] | None = None
         self._update_activity_atask: asyncio.Task[None] | None = None
         self._activity_lock = asyncio.Lock()
+        self._add_conversation_item_lock = asyncio.Lock()
         self._lock = asyncio.Lock()
+
+        # IDs pushed through add_conversation_item are local-to-remote updates. Realtime
+        # providers may echo them before update_chat_ctx completes, so activity callbacks
+        # must not insert them as server-originated placeholders.
+        self._locally_pushed_conversation_item_ids: set[str] = set()
 
         # used to keep a reference to the room io
         self._room_io: room_io.RoomIO | None = None
@@ -1555,39 +1561,48 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         Returns:
             ``True`` if the item was added, ``False`` if it was already present.
         """
-        if self._chat_ctx.get_by_id(item.id) is not None:
-            return False
+        async with self._add_conversation_item_lock:
+            # Keep the active activity, agent, and realtime session coherent across the
+            # provider await. Agent handoffs wait until this transaction is committed.
+            async with self._activity_lock:
+                if self._chat_ctx.get_by_id(item.id) is not None:
+                    return False
 
-        rt_session: llm.RealtimeSession | None = (
-            self._activity._rt_session if self._activity is not None else None
-        )
-        if isinstance(self.llm, llm.RealtimeModel) and rt_session is not None:
-            if not self.llm.capabilities.mutable_chat_context:
-                raise llm.RealtimeError(
-                    "add_conversation_item is not supported by realtime models"
-                    " without a mutable chat context"
-                )
+                activity = self._activity
+                agent = activity.agent if activity is not None else None
+                rt_session = activity._rt_session if activity is not None else None
 
-            assert self._agent is not None, "an active realtime session implies a running agent"
+                if rt_session is not None:
+                    if not rt_session.capabilities.mutable_chat_context:
+                        raise llm.RealtimeError(
+                            "add_conversation_item is not supported by realtime models"
+                            " without a mutable chat context"
+                        )
 
-            # push-then-commit: on a failed push nothing was mutated locally,
-            # so the caller can retry with the same item id
-            candidate = self._agent._chat_ctx.copy()
-            if candidate.get_by_id(item.id) is None:
-                candidate.insert(item)
-            remove_instructions(candidate)
-            await rt_session.update_chat_ctx(candidate)
+                    assert agent is not None
 
-            if self._agent._chat_ctx.get_by_id(item.id) is None:
-                self._agent._chat_ctx.insert(item)
-            self._conversation_item_added(item)
-            return True
+                    # push-then-commit: on a failed push nothing was mutated locally,
+                    # so the caller can retry with the same item id
+                    candidate = agent._chat_ctx.copy()
+                    if candidate.get_by_id(item.id) is None:
+                        candidate.insert(item)
+                    remove_instructions(candidate)
+                    self._locally_pushed_conversation_item_ids.add(item.id)
+                    try:
+                        await rt_session.update_chat_ctx(candidate)
 
-        if self._agent is not None and self._agent._chat_ctx.get_by_id(item.id) is None:
-            self._agent._chat_ctx.insert(item)
+                        if agent._chat_ctx.get_by_id(item.id) is None:
+                            agent._chat_ctx.insert(item)
+                        self._conversation_item_added(item)
+                        return True
+                    finally:
+                        self._locally_pushed_conversation_item_ids.discard(item.id)
 
-        self._conversation_item_added(item)
-        return True
+                if agent is not None and agent._chat_ctx.get_by_id(item.id) is None:
+                    agent._chat_ctx.insert(item)
+
+                self._conversation_item_added(item)
+                return True
 
     def interrupt(self, *, force: bool = False) -> asyncio.Future[None]:
         """Interrupt the current speech generation.

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -64,6 +64,7 @@ from .events import (
     UserState,
     UserStateChangedEvent,
 )
+from .generation import remove_instructions
 from .ivr import IVRActivity
 from .keyterm_detection import (
     KeytermDetector,
@@ -1528,7 +1529,7 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
 
         return handle
 
-    def add_conversation_item(self, item: llm.ChatMessage) -> bool:
+    async def add_conversation_item(self, item: llm.ChatMessage) -> bool:
         """Add a conversation item to the session history and the active agent's context.
 
         Inserts ``item`` into ``session.history`` and, when an agent is running,
@@ -1536,8 +1537,17 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         listeners (transcript capture, analytics, etc.) observe the item the
         same way they observe items produced by the normal audio pipeline.
 
+        With a realtime model, the item is first pushed to the live model
+        context and only a successful push commits the item locally.  A failed
+        push raises ``llm.RealtimeError`` and leaves the session untouched, so
+        retrying with the same item id works.  Realtime models without a
+        mutable chat context raise ``llm.RealtimeError``.
+
         The call is idempotent: if an item with the same ``id`` already exists
         in the session history the method returns ``False`` and does nothing.
+
+        Items added before ``start()`` reach the session history and the event
+        only — they are never backfilled into the agent's context.
 
         Args:
             item: The ChatMessage to add.
@@ -1547,6 +1557,31 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         """
         if self._chat_ctx.get_by_id(item.id) is not None:
             return False
+
+        rt_session: llm.RealtimeSession | None = (
+            self._activity._rt_session if self._activity is not None else None
+        )
+        if isinstance(self.llm, llm.RealtimeModel) and rt_session is not None:
+            if not self.llm.capabilities.mutable_chat_context:
+                raise llm.RealtimeError(
+                    "add_conversation_item is not supported by realtime models"
+                    " without a mutable chat context"
+                )
+
+            assert self._agent is not None, "an active realtime session implies a running agent"
+
+            # push-then-commit: on a failed push nothing was mutated locally,
+            # so the caller can retry with the same item id
+            candidate = self._agent._chat_ctx.copy()
+            if candidate.get_by_id(item.id) is None:
+                candidate.insert(item)
+            remove_instructions(candidate)
+            await rt_session.update_chat_ctx(candidate)
+
+            if self._agent._chat_ctx.get_by_id(item.id) is None:
+                self._agent._chat_ctx.insert(item)
+            self._conversation_item_added(item)
+            return True
 
         if self._agent is not None and self._agent._chat_ctx.get_by_id(item.id) is None:
             self._agent._chat_ctx.insert(item)

--- a/tests/fake_realtime.py
+++ b/tests/fake_realtime.py
@@ -67,6 +67,9 @@ class FakeRealtimeSession(RealtimeSession):
         self.aclose_error: Exception | None = None
         # test hook to fail bring-up (raised from update_chat_ctx during _update_session)
         self.update_error: Exception | None = None
+        # test hooks to pause update_chat_ctx after it has been entered
+        self.update_chat_ctx_entered = asyncio.Event()
+        self.block_update_chat_ctx: asyncio.Event | None = None
 
     @property
     def chat_ctx(self) -> ChatContext:
@@ -80,6 +83,9 @@ class FakeRealtimeSession(RealtimeSession):
         self.updated_instructions = instructions
 
     async def update_chat_ctx(self, chat_ctx: ChatContext) -> None:
+        self.update_chat_ctx_entered.set()
+        if self.block_update_chat_ctx is not None:
+            await self.block_update_chat_ctx.wait()
         if self.update_error is not None:
             raise self.update_error
         self._chat_ctx = chat_ctx

--- a/tests/test_add_conversation_item.py
+++ b/tests/test_add_conversation_item.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+from livekit.agents import (
+    Agent,
+    AgentSession,
+    ConversationItemAddedEvent,
+)
+from livekit.agents.llm.chat_context import ChatMessage
+
+from .fake_io import FakeAudioInput, FakeAudioOutput, FakeTextOutput
+from .fake_llm import FakeLLM
+from .fake_session import FakeActions
+from .fake_stt import FakeSTT
+from .fake_tts import FakeTTS
+from .fake_vad import FakeVAD
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+
+class SimpleAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="You are a helpful assistant.")
+
+
+def _make_session() -> AgentSession:
+    """Create a minimal session without TranscriptSynchronizer wrapping."""
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.0, "placeholder")
+    actions.add_llm("ok", ttft=0.1, duration=0.1)
+    actions.add_tts(0.5, ttfb=0.1, duration=0.1)
+
+    user_speeches = actions.get_user_speeches(speed_factor=1.0)
+    llm_responses = actions.get_llm_responses(speed_factor=1.0)
+    tts_responses = actions.get_tts_responses(speed_factor=1.0)
+
+    session = AgentSession[None](
+        vad=FakeVAD(
+            fake_user_speeches=user_speeches,
+            min_silence_duration=0.5,
+            min_speech_duration=0.05,
+        ),
+        stt=FakeSTT(fake_user_speeches=user_speeches),
+        llm=FakeLLM(fake_responses=llm_responses),
+        tts=FakeTTS(fake_responses=tts_responses),
+        turn_handling={"turn_detection": None},
+        aec_warmup_duration=None,
+    )
+
+    session.input.audio = FakeAudioInput()
+    session.output.audio = FakeAudioOutput()
+    session.output.transcription = FakeTextOutput()
+
+    return session
+
+
+async def _close(session: AgentSession) -> None:
+    """Drain and close session, letting background tasks finish."""
+    await asyncio.sleep(5)
+    with contextlib.suppress(RuntimeError):
+        await session.drain()
+    await session.aclose()
+
+
+async def test_add_conversation_item_appears_in_history() -> None:
+    """A message added via add_conversation_item is retrievable from session.history."""
+    session = _make_session()
+    await session.start(SimpleAgent())
+
+    msg = ChatMessage(role="user", content=["injected text"])
+    result = session.add_conversation_item(msg)
+
+    assert result is True
+    found = session.history.get_by_id(msg.id)
+    assert found is not None
+    assert found.text_content == "injected text"
+    assert found.role == "user"
+
+    await _close(session)
+
+
+async def test_add_conversation_item_emits_event() -> None:
+    """add_conversation_item fires the conversation_item_added event."""
+    session = _make_session()
+
+    received: list[ConversationItemAddedEvent] = []
+    session.on("conversation_item_added", received.append)
+
+    await session.start(SimpleAgent())
+
+    msg = ChatMessage(role="user", content=["event test"])
+    session.add_conversation_item(msg)
+
+    matching = [e for e in received if e.item.id == msg.id]
+    assert len(matching) == 1
+    assert matching[0].item.role == "user"
+    assert matching[0].item.text_content == "event test"
+
+    await _close(session)
+
+
+async def test_add_conversation_item_visible_to_agent() -> None:
+    """A message added via add_conversation_item appears in the active agent's chat context."""
+    session = _make_session()
+    agent = SimpleAgent()
+    await session.start(agent)
+
+    msg = ChatMessage(role="user", content=["agent-visible"])
+    session.add_conversation_item(msg)
+
+    found = agent.chat_ctx.get_by_id(msg.id)
+    assert found is not None
+    assert found.text_content == "agent-visible"
+
+    await _close(session)
+
+
+async def test_add_conversation_item_dedup_by_id() -> None:
+    """Adding the same message ID twice is idempotent — only one copy in history."""
+    session = _make_session()
+    await session.start(SimpleAgent())
+
+    msg = ChatMessage(role="user", content=["dedup test"])
+    first = session.add_conversation_item(msg)
+    second = session.add_conversation_item(msg)
+
+    assert first is True
+    assert second is False
+
+    matches = [item for item in session.history.items if item.id == msg.id]
+    assert len(matches) == 1
+
+    await _close(session)
+
+
+async def test_add_conversation_item_before_start() -> None:
+    """add_conversation_item works on a session that hasn't been started yet."""
+    session = _make_session()
+
+    received: list[ConversationItemAddedEvent] = []
+    session.on("conversation_item_added", received.append)
+
+    msg = ChatMessage(role="user", content=["pre-start"])
+    result = session.add_conversation_item(msg)
+
+    assert result is True
+    assert session.history.get_by_id(msg.id) is not None
+
+    matching = [e for e in received if e.item.id == msg.id]
+    assert len(matching) == 1

--- a/tests/test_add_conversation_item.py
+++ b/tests/test_add_conversation_item.py
@@ -188,14 +188,17 @@ async def test_add_conversation_item_realtime_dedup_by_id() -> None:
 
         msg = ChatMessage(role="user", content=["rt dedup"])
         assert await session.add_conversation_item(msg) is True
-        pushed = rt_session.chat_ctx.get_by_id(msg.id)
-        assert pushed is not None
+        assert rt_session.chat_ctx.get_by_id(msg.id) is not None
 
         assert await session.add_conversation_item(msg) is False
 
         assert session.history.get_by_id(msg.id) is not None
-        assert rt_session.chat_ctx.get_by_id(msg.id) is pushed
-        assert agent.chat_ctx.get_by_id(msg.id) is pushed
+        provider_item = rt_session.chat_ctx.get_by_id(msg.id)
+        agent_item = agent.chat_ctx.get_by_id(msg.id)
+        assert isinstance(provider_item, ChatMessage)
+        assert isinstance(agent_item, ChatMessage)
+        assert (provider_item.role, provider_item.text_content) == ("user", "rt dedup")
+        assert (agent_item.role, agent_item.text_content) == ("user", "rt dedup")
         assert [e.item.id for e in received] == [msg.id]
 
 
@@ -266,3 +269,184 @@ async def test_add_conversation_item_realtime_push_failure_leaves_state_clean() 
         assert session.history.get_by_id(msg.id) is not None
         assert rt_session.chat_ctx.get_by_id(msg.id) is not None
         assert [e.item.id for e in received] == [msg.id]
+
+
+async def test_add_conversation_item_realtime_serializes_distinct_items() -> None:
+    """Overlapping additions retain every distinct item in provider and local contexts."""
+    model = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=False))
+    async with AgentSession(llm=model) as session:
+        agent = SimpleAgent()
+        await session.start(agent)
+        rt_session = model.active_session
+
+        release_update = asyncio.Event()
+        rt_session.block_update_chat_ctx = release_update
+        rt_session.update_chat_ctx_entered.clear()
+        first = ChatMessage(role="user", content=["first concurrent item"])
+        second = ChatMessage(role="user", content=["second concurrent item"])
+
+        first_task = asyncio.create_task(session.add_conversation_item(first))
+        await rt_session.update_chat_ctx_entered.wait()
+        second_started = asyncio.Event()
+
+        async def add_second() -> bool:
+            second_started.set()
+            return await session.add_conversation_item(second)
+
+        second_task = asyncio.create_task(add_second())
+        await second_started.wait()
+        release_update.set()
+
+        assert await asyncio.gather(first_task, second_task) == [True, True]
+        for item in (first, second):
+            assert rt_session.chat_ctx.get_by_id(item.id) is not None
+            assert agent.chat_ctx.get_by_id(item.id) is not None
+            assert session.history.get_by_id(item.id) is not None
+
+
+async def test_add_conversation_item_realtime_serializes_same_id() -> None:
+    """Overlapping same-ID additions commit and emit exactly once."""
+    model = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=False))
+    async with AgentSession(llm=model) as session:
+        agent = SimpleAgent()
+        await session.start(agent)
+        rt_session = model.active_session
+
+        received: list[ConversationItemAddedEvent] = []
+        session.on("conversation_item_added", received.append)
+
+        release_update = asyncio.Event()
+        rt_session.block_update_chat_ctx = release_update
+        rt_session.update_chat_ctx_entered.clear()
+        item = ChatMessage(role="user", content=["same concurrent item"])
+
+        first_task = asyncio.create_task(session.add_conversation_item(item))
+        await rt_session.update_chat_ctx_entered.wait()
+        second_started = asyncio.Event()
+
+        async def add_same_item() -> bool:
+            second_started.set()
+            return await session.add_conversation_item(item)
+
+        second_task = asyncio.create_task(add_same_item())
+        await second_started.wait()
+        release_update.set()
+
+        assert sorted(await asyncio.gather(first_task, second_task)) == [False, True]
+        assert sum(entry.id == item.id for entry in rt_session.chat_ctx.items) == 1
+        assert sum(entry.id == item.id for entry in agent.chat_ctx.items) == 1
+        assert sum(entry.id == item.id for entry in session.history.items) == 1
+        assert [event.item.id for event in received] == [item.id]
+
+
+async def test_add_conversation_item_uses_agent_realtime_model() -> None:
+    """An agent-level realtime override receives the added item."""
+    model = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=False))
+    agent = Agent(instructions="agent override", llm=model)
+    async with AgentSession() as session:
+        await session.start(agent)
+        item = ChatMessage(role="user", content=["agent-level realtime"])
+
+        assert await session.add_conversation_item(item) is True
+        assert model.active_session.chat_ctx.get_by_id(item.id) is not None
+        assert agent.chat_ctx.get_by_id(item.id) is not None
+        assert session.history.get_by_id(item.id) is not None
+
+
+async def test_add_conversation_item_uses_agent_realtime_capabilities() -> None:
+    """An immutable agent-level realtime override rejects the item without side effects."""
+    model = FakeRealtimeModel(
+        capabilities=fake_capabilities(audio_output=False, mutable_chat_context=False)
+    )
+    agent = Agent(instructions="agent override", llm=model)
+    async with AgentSession() as session:
+        await session.start(agent)
+        item = ChatMessage(role="user", content=["agent-level immutable"])
+        received: list[ConversationItemAddedEvent] = []
+        session.on("conversation_item_added", received.append)
+
+        with pytest.raises(llm.RealtimeError):
+            await session.add_conversation_item(item)
+
+        assert model.active_session.chat_ctx.get_by_id(item.id) is None
+        assert agent.chat_ctx.get_by_id(item.id) is None
+        assert session.history.get_by_id(item.id) is None
+        assert received == []
+
+
+async def test_add_conversation_item_realtime_is_atomic_during_handoff() -> None:
+    """A handoff cannot split an addition across the old and new agent contexts."""
+    model = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=False))
+    async with AgentSession(llm=model) as session:
+        await session.start(SimpleAgent())
+        rt_session = model.active_session
+
+        original_update_chat_ctx = rt_session.update_chat_ctx
+        release_update = asyncio.Event()
+        first_update_entered = asyncio.Event()
+        handoff_update_completed = asyncio.Event()
+        update_count = 0
+        new_only: ChatMessage | None = None
+
+        async def pause_first_update(chat_ctx: llm.ChatContext) -> None:
+            nonlocal update_count
+            update_count += 1
+            if update_count == 1:
+                first_update_entered.set()
+                await release_update.wait()
+            await original_update_chat_ctx(chat_ctx)
+            if new_only is not None and chat_ctx.get_by_id(new_only.id) is not None:
+                handoff_update_completed.set()
+
+        rt_session.update_chat_ctx = pause_first_update
+        added = ChatMessage(role="user", content=["added during handoff"])
+        add_task = asyncio.create_task(session.add_conversation_item(added))
+        await first_update_entered.wait()
+
+        new_only = ChatMessage(role="user", content=["new agent context"])
+        new_agent = Agent(
+            instructions="replacement agent",
+            chat_ctx=llm.ChatContext([new_only]),
+        )
+        session.update_agent(new_agent)
+        for _ in range(10):
+            await asyncio.sleep(0)
+        release_update.set()
+
+        assert await add_task is True
+        await handoff_update_completed.wait()
+        assert rt_session.chat_ctx.get_by_id(new_only.id) is not None
+        assert new_agent.chat_ctx.get_by_id(new_only.id) is not None
+        assert session.history.get_by_id(added.id) is not None
+
+
+async def test_add_conversation_item_realtime_echo_before_failure_is_not_committed() -> None:
+    """A provider echo before a failed push cannot mutate local state."""
+    model = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=False))
+    async with AgentSession(llm=model) as session:
+        agent = SimpleAgent()
+        await session.start(agent)
+        rt_session = model.active_session
+
+        received: list[ConversationItemAddedEvent] = []
+        session.on("conversation_item_added", received.append)
+        item = ChatMessage(role="user", content=["echo then fail"])
+
+        async def echo_then_fail(chat_ctx: llm.ChatContext) -> None:
+            pushed = chat_ctx.get_by_id(item.id)
+            assert pushed is not None
+            rt_session.emit(
+                "remote_item_added",
+                llm.RemoteItemAddedEvent(previous_item_id=None, item=pushed),
+            )
+            raise llm.RealtimeError("push failed after echo")
+
+        rt_session.update_chat_ctx = echo_then_fail
+
+        with pytest.raises(llm.RealtimeError):
+            await session.add_conversation_item(item)
+
+        assert rt_session.chat_ctx.get_by_id(item.id) is None
+        assert agent.chat_ctx.get_by_id(item.id) is None
+        assert session.history.get_by_id(item.id) is None
+        assert received == []

--- a/tests/test_add_conversation_item.py
+++ b/tests/test_add_conversation_item.py
@@ -9,11 +9,13 @@ from livekit.agents import (
     Agent,
     AgentSession,
     ConversationItemAddedEvent,
+    llm,
 )
 from livekit.agents.llm.chat_context import ChatMessage
 
 from .fake_io import FakeAudioInput, FakeAudioOutput, FakeTextOutput
 from .fake_llm import FakeLLM
+from .fake_realtime import FakeRealtimeModel, fake_capabilities
 from .fake_session import FakeActions
 from .fake_stt import FakeSTT
 from .fake_tts import FakeTTS
@@ -72,7 +74,7 @@ async def test_add_conversation_item_appears_in_history() -> None:
     await session.start(SimpleAgent())
 
     msg = ChatMessage(role="user", content=["injected text"])
-    result = session.add_conversation_item(msg)
+    result = await session.add_conversation_item(msg)
 
     assert result is True
     found = session.history.get_by_id(msg.id)
@@ -93,7 +95,7 @@ async def test_add_conversation_item_emits_event() -> None:
     await session.start(SimpleAgent())
 
     msg = ChatMessage(role="user", content=["event test"])
-    session.add_conversation_item(msg)
+    await session.add_conversation_item(msg)
 
     matching = [e for e in received if e.item.id == msg.id]
     assert len(matching) == 1
@@ -110,7 +112,7 @@ async def test_add_conversation_item_visible_to_agent() -> None:
     await session.start(agent)
 
     msg = ChatMessage(role="user", content=["agent-visible"])
-    session.add_conversation_item(msg)
+    await session.add_conversation_item(msg)
 
     found = agent.chat_ctx.get_by_id(msg.id)
     assert found is not None
@@ -122,33 +124,145 @@ async def test_add_conversation_item_visible_to_agent() -> None:
 async def test_add_conversation_item_dedup_by_id() -> None:
     """Adding the same message ID twice is idempotent — only one copy in history."""
     session = _make_session()
-    await session.start(SimpleAgent())
+    agent = SimpleAgent()
+    await session.start(agent)
+
+    received: list[ConversationItemAddedEvent] = []
+    session.on("conversation_item_added", received.append)
 
     msg = ChatMessage(role="user", content=["dedup test"])
-    first = session.add_conversation_item(msg)
-    second = session.add_conversation_item(msg)
+    first = await session.add_conversation_item(msg)
+    second = await session.add_conversation_item(msg)
 
     assert first is True
     assert second is False
 
     matches = [item for item in session.history.items if item.id == msg.id]
     assert len(matches) == 1
+    assert [e.item.id for e in received] == [msg.id]
+    assert agent.chat_ctx.get_by_id(msg.id) is not None
 
     await _close(session)
 
 
 async def test_add_conversation_item_before_start() -> None:
-    """add_conversation_item works on a session that hasn't been started yet."""
+    """add_conversation_item works on a session that hasn't been started yet.
+
+    Pins the documented limitation: with no agent running, the item reaches
+    session history and the event, but no agent context — items added before
+    start are never backfilled into the agent's context once it starts.
+    """
     session = _make_session()
 
     received: list[ConversationItemAddedEvent] = []
     session.on("conversation_item_added", received.append)
 
     msg = ChatMessage(role="user", content=["pre-start"])
-    result = session.add_conversation_item(msg)
+    result = await session.add_conversation_item(msg)
 
     assert result is True
     assert session.history.get_by_id(msg.id) is not None
 
     matching = [e for e in received if e.item.id == msg.id]
     assert len(matching) == 1
+
+    # the item is never backfilled into the agent's context once it starts
+    agent = SimpleAgent()
+    await session.start(agent)
+    assert agent.chat_ctx.get_by_id(msg.id) is None
+
+    await _close(session)
+
+
+async def test_add_conversation_item_realtime_dedup_by_id() -> None:
+    """Realtime dedup checks session history: a repeated id is a full no-op."""
+    model = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=False))
+    async with AgentSession(llm=model) as session:
+        agent = SimpleAgent()
+        await session.start(agent)
+        rt_session = model.active_session
+        assert rt_session is not None
+
+        received: list[ConversationItemAddedEvent] = []
+        session.on("conversation_item_added", received.append)
+
+        msg = ChatMessage(role="user", content=["rt dedup"])
+        assert await session.add_conversation_item(msg) is True
+        pushed = rt_session.chat_ctx.get_by_id(msg.id)
+        assert pushed is not None
+
+        assert await session.add_conversation_item(msg) is False
+
+        assert session.history.get_by_id(msg.id) is not None
+        assert rt_session.chat_ctx.get_by_id(msg.id) is pushed
+        assert agent.chat_ctx.get_by_id(msg.id) is pushed
+        assert [e.item.id for e in received] == [msg.id]
+
+
+async def test_add_conversation_item_realtime_pushes_to_rt_session() -> None:
+    """On a realtime session the added item is pushed to the live provider context."""
+    model = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=False))
+    async with AgentSession(llm=model) as session:
+        agent = SimpleAgent()
+        await session.start(agent)
+        rt_session = model.active_session
+        assert rt_session is not None
+
+        received: list[ConversationItemAddedEvent] = []
+        session.on("conversation_item_added", received.append)
+
+        msg = ChatMessage(role="user", content=["rt injected"])
+        assert await session.add_conversation_item(msg) is True
+
+        assert rt_session.chat_ctx.get_by_id(msg.id) is not None
+        assert session.history.get_by_id(msg.id) is not None
+        assert agent.chat_ctx.get_by_id(msg.id) is not None
+        assert [e.item.id for e in received] == [msg.id]
+
+
+async def test_add_conversation_item_realtime_non_mutable_raises() -> None:
+    """Realtime models without mutable chat context refuse the add without side effects."""
+    model = FakeRealtimeModel(
+        capabilities=fake_capabilities(audio_output=False, mutable_chat_context=False)
+    )
+    async with AgentSession(llm=model) as session:
+        await session.start(SimpleAgent())
+        rt_session = model.active_session
+        assert rt_session is not None
+
+        received: list[ConversationItemAddedEvent] = []
+        session.on("conversation_item_added", received.append)
+
+        msg = ChatMessage(role="user", content=["non mutable"])
+        with pytest.raises(llm.RealtimeError):
+            await session.add_conversation_item(msg)
+
+        assert session.history.get_by_id(msg.id) is None
+        assert rt_session.chat_ctx.get_by_id(msg.id) is None
+        assert received == []
+
+
+async def test_add_conversation_item_realtime_push_failure_leaves_state_clean() -> None:
+    """A failed realtime push mutates nothing, so retrying the same item id succeeds."""
+    model = FakeRealtimeModel(capabilities=fake_capabilities(audio_output=False))
+    async with AgentSession(llm=model) as session:
+        await session.start(SimpleAgent())
+        rt_session = model.active_session
+        assert rt_session is not None
+
+        received: list[ConversationItemAddedEvent] = []
+        session.on("conversation_item_added", received.append)
+
+        rt_session.update_error = llm.RealtimeError("push timed out")
+        msg = ChatMessage(role="user", content=["push failed"])
+        with pytest.raises(llm.RealtimeError):
+            await session.add_conversation_item(msg)
+
+        assert session.history.get_by_id(msg.id) is None
+        assert received == []
+
+        rt_session.update_error = None
+        assert await session.add_conversation_item(msg) is True
+        assert session.history.get_by_id(msg.id) is not None
+        assert rt_session.chat_ctx.get_by_id(msg.id) is not None
+        assert [e.item.id for e in received] == [msg.id]


### PR DESCRIPTION
## Summary

Adds `AgentSession.add_conversation_item(item: ChatMessage) -> bool` — a public, async method to insert a `ChatMessage` into the session history and the active agent's chat context, emitting `conversation_item_added` the same way the internal audio pipeline does. Works uniformly across waterfall (STT → LLM → TTS) and realtime pipelines.

- Inserts into `session.history` (session-level `ChatContext`) and, when an agent is running, into its chat context
- Emits `conversation_item_added` so event listeners (transcript capture, analytics, etc.) observe the item normally
- **Waterfall**: mirrors the internal two-step pattern (agent ctx insert + session history + event)
- **Realtime**: push-then-commit — the item is pushed to the live model context via `_rt_session.update_chat_ctx`, and only a successful push commits locally. A failed push raises `RealtimeError` and leaves the session untouched, so retrying with the same item id works
- **Realtime models without a mutable chat context** raise `RealtimeError` before any mutation
- Idempotent by message ID — duplicate IDs are detected via `ChatContext.get_by_id` and silently skipped (returns `False`)
- Items added before `session.start()` reach session history and the event only; they are never backfilled into the agent's context once it starts

### Use cases

- **Late STT finals** — final transcript arrives after turn commitment (#6504)
- **DTMF-derived input** — keypad-collected dates/account numbers that should appear as user input
- **Out-of-band text** — SIP INFO or backend caller data that should become part of the conversation record

### Current workaround this replaces

```python
# Private API — mirrors agent_activity.py internals
self._agent._chat_ctx.items.append(user_message)
self._session._conversation_item_added(user_message)
```

### New public API

```python
msg = ChatMessage(role="user", content=["collected via DTMF"])
added = await session.add_conversation_item(msg)  # True if added, False if deduped
```

Closes #7085

## Test plan

- [x] `test_add_conversation_item_appears_in_history` — message retrievable from `session.history`
- [x] `test_add_conversation_item_emits_event` — `conversation_item_added` event fires with correct payload
- [x] `test_add_conversation_item_visible_to_agent` — message appears in `agent.chat_ctx`
- [x] `test_add_conversation_item_dedup_by_id` — second call with same ID returns False; no duplicate event or agent-ctx entry
- [x] `test_add_conversation_item_before_start` — history + event fire pre-start; pins that the item is never backfilled into the agent's context
- [x] `test_add_conversation_item_realtime_pushes_to_rt_session` — item reaches the live realtime session context, local history, agent ctx, and event
- [x] `test_add_conversation_item_realtime_non_mutable_raises` — raises `RealtimeError` with zero side effects
- [x] `test_add_conversation_item_realtime_push_failure_leaves_state_clean` — failed push mutates nothing; retry with same id succeeds
- [x] `test_add_conversation_item_realtime_dedup_by_id` — dedup applies on the realtime path
- [x] Full unit suite: no regressions vs `main`; lint, format, and type-check (`livekit.agents`) pass
