### PR TITLE
feat(assemblyai): add universal-3-6-pro streaming model

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -59,6 +59,7 @@ class STTOptions:
         "u3-rt-pro-beta-1",
         "u3-pro",
         "universal-3-5-pro",
+        "universal-3-6-pro",
     ] = "universal-3-5-pro"
     language_detection: NotGivenOr[bool] = NOT_GIVEN
     language_codes: NotGivenOr[list[str]] = NOT_GIVEN
@@ -85,7 +86,7 @@ class STTOptions:
 # (prompt, agent_context, previous_context_n_turns, continuous_partials,
 # interruption_delay, voice_focus, voice_focus_threshold) and connect-time
 # defaults. Mirrors the server-side `SpeechModel.is_u3_pro`.
-_U3_PRO_MODELS = ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro")
+_U3_PRO_MODELS = ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro", "universal-3-6-pro")
 
 # Server-side cap on the number of steering codes, mirrored client-side so bad
 # input fails at construction/update time instead of as a websocket error.
@@ -147,6 +148,7 @@ class STT(stt.STT):
             "u3-rt-pro-beta-1",
             "u3-pro",
             "universal-3-5-pro",
+            "universal-3-6-pro",
         ] = "universal-3-5-pro",
         language_detection: NotGivenOr[bool] = NOT_GIVEN,
         language_code: NotGivenOr[str] = NOT_GIVEN,

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -562,6 +562,75 @@ async def test_universal_3_5_pro_leaves_continuous_partials_unset():
 
 
 # ---------------------------------------------------------------------------
+# universal-3-6-pro: u3-rt-pro parameter family
+#
+# universal-3-6-pro is the next U3 Pro release: server-side it has the same
+# parameter support as universal-3-5-pro and differs only in which ASR
+# deployment serves the session. So it accepts the u3-pro-gated params and
+# inherits the family's connect-time defaults.
+# ---------------------------------------------------------------------------
+
+
+async def test_universal_3_6_pro_is_accepted():
+    """universal-3-6-pro is a valid model selection."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(api_key="test-key", model="universal-3-6-pro")
+    assert stt.model == "universal-3-6-pro"
+    assert stt._opts.speech_model == "universal-3-6-pro"
+
+
+async def test_universal_3_6_pro_accepts_u3_pro_params():
+    """universal-3-6-pro shares the u3-rt-pro parameter family."""
+    from livekit.plugins.assemblyai import STT
+
+    stt = STT(
+        api_key="test-key",
+        model="universal-3-6-pro",
+        prompt="medical dictation",
+        agent_context="The agent asked for the patient's name.",
+        previous_context_n_turns=10,
+        interruption_delay=300,
+        voice_focus="near-field",
+        mode="max_accuracy",
+        language_codes=["en", "es"],
+    )
+    assert stt._opts.speech_model == "universal-3-6-pro"
+    assert stt._opts.prompt == "medical dictation"
+    assert stt._opts.agent_context == "The agent asked for the patient's name."
+    assert stt._opts.previous_context_n_turns == 10
+    assert stt._opts.interruption_delay == 300
+    assert stt._opts.voice_focus == "near-field"
+    assert stt._opts.mode == "max_accuracy"
+    assert stt._opts.language_codes == ["en", "es"]
+
+
+async def test_universal_3_6_pro_connect_config_uses_u3_pro_defaults():
+    """The connect query names universal-3-6-pro and applies the U3 Pro family's
+    connect-time defaults (100ms min/max turn silence, language detection on)."""
+    from urllib.parse import parse_qs, urlparse
+
+    from livekit.plugins.assemblyai import STT
+
+    captured: dict = {}
+
+    async def _fake_ws_connect(url, **kwargs):
+        captured["url"] = url
+        return MagicMock()
+
+    stt = STT(api_key="test-key", model="universal-3-6-pro")
+    stream = _make_stream_for_unit_test(stt)
+    stream._session.ws_connect = _fake_ws_connect
+    await stream._connect_ws()
+
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert query["speech_model"] == ["universal-3-6-pro"]
+    assert query["min_turn_silence"] == ["100"]
+    assert query["max_turn_silence"] == ["100"]
+    assert query["language_detection"] == ["true"]
+
+
+# ---------------------------------------------------------------------------
 # voice_focus / voice_focus_threshold
 #
 # Voice Focus isolates the primary voice and suppresses background noise.
@@ -708,7 +777,7 @@ async def test_voice_focus_allowed_for_all_u3_pro_family_models():
     """voice_focus is accepted for every u3-rt-pro-family model, not just the default."""
     from livekit.plugins.assemblyai import STT
 
-    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro"):
+    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro", "universal-3-6-pro"):
         stt = STT(api_key="test-key", model=model, voice_focus="far-field")
         assert stt._opts.voice_focus == "far-field"
 
@@ -764,7 +833,7 @@ async def test_mode_allowed_for_all_u3_pro_family_models():
     """mode is accepted for every u3-rt-pro-family model, not just the default."""
     from livekit.plugins.assemblyai import STT
 
-    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro"):
+    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro", "universal-3-6-pro"):
         stt = STT(api_key="test-key", model=model, mode="min_latency")
         assert stt._opts.mode == "min_latency"
 
@@ -1049,7 +1118,7 @@ async def test_language_codes_allowed_for_all_u3_pro_family_models():
     """language_codes is accepted for every u3-rt-pro-family model, not just the default."""
     from livekit.plugins.assemblyai import STT
 
-    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro"):
+    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro", "universal-3-6-pro"):
         stt = STT(api_key="test-key", model=model, language_codes=["en", "es"])
         assert stt._opts.language_codes == ["en", "es"]
 
@@ -1441,7 +1510,13 @@ async def test_carryover_on_by_default_for_u3_pro_family():
     """chat_context carryover is on by default on models that support it."""
     from livekit.plugins.assemblyai import STT
 
-    for model in ("u3-rt-pro", "u3-rt-pro-beta-1", "universal-3-5-pro", "u3-pro"):
+    for model in (
+        "u3-rt-pro",
+        "u3-rt-pro-beta-1",
+        "universal-3-5-pro",
+        "universal-3-6-pro",
+        "u3-pro",
+    ):
         stt = STT(api_key="test-key", model=model)
         assert stt.capabilities.chat_context is True
 


### PR DESCRIPTION
## What

Adds `universal-3-6-pro` to the AssemblyAI streaming STT plugin as a supported `model` value.

- Server-side, `universal-3-6-pro` is the next Universal-3 Pro release. It is served by its own ASR deployment and shares all Universal-3 Pro behavior: `prompt`, `agent_context`, `previous_context_n_turns`, `continuous_partials`, `interruption_delay`, `voice_focus` / `voice_focus_threshold`, `mode`, `language_codes`, and formatted output. It introduces no new connection or `UpdateConfiguration` parameters.
- The plugin change is accordingly small: the new string is added to the `speech_model` / `model` Literals and to `_U3_PRO_MODELS`, so the model gets the Pro-family parameter gating, the family's connect-time defaults (100 ms min/max turn silence unless `mode` is set, language detection on), and chat-context carryover.
- `universal-3-5-pro` remains the default, and the deprecated `u3-pro` alias is unchanged.

## Testing

- `tests/test_plugin_assemblyai_stt.py`: new `universal-3-6-pro` block (accepted as a model, accepts the Pro-only params, connect query names the model and applies the family defaults), and the family-loop tests (`voice_focus`, `mode`, `language_codes`, carryover default) now include it. Full file: 111 passed; ruff and strict mypy clean.
- Verified against the production AssemblyAI streaming API: a `speech_model=universal-3-6-pro` connection returns a `Begin` session message, identical to `universal-3-5-pro`.
