### PR TITLE
feat(assemblyai): surface end_of_turn_confidence on SpeechData.metadata

### DIFF
--- a/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
+++ b/livekit-plugins/livekit-plugins-assemblyai/livekit/plugins/assemblyai/stt.py
@@ -968,6 +968,20 @@ class SpeechStream(stt.SpeechStream):
         speaker_label = data.get("speaker_label")
         speaker_id = speaker_label if speaker_label and speaker_label != "UNKNOWN" else None
 
+        # Surface the server's end-of-turn confidence on SpeechData.metadata so it's
+        # reachable from SpeechEvent / stt_node / UserInputTranscribedEvent without
+        # subclassing the stream. On Universal-3.5 Pro (and later) this rises from 0
+        # toward 1 across the partials emitted while a turn is held open between
+        # min_turn_silence and max_turn_silence, letting callers threshold it to
+        # trigger preemptive/eager LLM generation before the final arrives; it is 1.0
+        # on the final. Only attached when the message carries it, so models that
+        # don't emit the field are unaffected.
+        eot_confidence_metadata = (
+            {"end_of_turn_confidence": end_of_turn_confidence}
+            if end_of_turn_confidence is not None
+            else None
+        )
+
         # transcript (final) and words (interim) are cumulative
         # utterance (preflight) is chunk based
         start_time: float = 0
@@ -1004,6 +1018,7 @@ class SpeechStream(stt.SpeechStream):
                         words=timed_words,
                         confidence=confidence,
                         speaker_id=speaker_id,
+                        metadata=eot_confidence_metadata,
                     )
                 ],
             )
@@ -1040,6 +1055,7 @@ class SpeechStream(stt.SpeechStream):
                         words=utterance_words,
                         confidence=utterance_confidence,
                         speaker_id=speaker_id,
+                        metadata=eot_confidence_metadata,
                     )
                 ],
             )
@@ -1065,6 +1081,7 @@ class SpeechStream(stt.SpeechStream):
                         words=timed_words,
                         confidence=confidence,
                         speaker_id=speaker_id,
+                        metadata=eot_confidence_metadata,
                     )
                 ],
             )

--- a/tests/test_plugin_assemblyai_stt.py
+++ b/tests/test_plugin_assemblyai_stt.py
@@ -1596,3 +1596,85 @@ async def test_carryover_explicit_true_wins_over_n_turns_zero():
 
     stt = STT(api_key="test-key", previous_context_n_turns=0, agent_context_carryover=True)
     assert stt.capabilities.chat_context is True
+
+
+# ---------------------------------------------------------------------------
+# end_of_turn_confidence surfaced on SpeechData.metadata
+#
+# The server reports a per-Turn `end_of_turn_confidence`. On Universal-3.5 Pro
+# (and later) this rises from 0 toward 1 across the partials emitted while a
+# turn is held open between min_turn_silence and max_turn_silence, and is 1.0 on
+# the final. The plugin surfaces it on SpeechData.metadata so callers can
+# threshold it (e.g. to trigger preemptive/eager LLM generation) from a
+# SpeechEvent / stt_node / UserInputTranscribedEvent without subclassing the
+# stream. It's only attached when the message carries the field, so models that
+# never emit it are unaffected.
+# ---------------------------------------------------------------------------
+
+
+def _drain_events(stream):
+    from livekit.agents.utils.aio.channel import ChanEmpty
+
+    events = []
+    while True:
+        try:
+            events.append(stream._event_ch.recv_nowait())
+        except ChanEmpty:
+            break
+    return events
+
+
+def _turn_message(**overrides):
+    """A minimal server Turn message with a single word (so an interim fires)."""
+    msg = {
+        "type": "Turn",
+        "words": [{"text": "hello", "start": 0, "end": 480, "confidence": 0.9}],
+        "end_of_turn": False,
+        "transcript": "",
+    }
+    msg.update(overrides)
+    return msg
+
+
+async def test_end_of_turn_confidence_surfaced_on_interim_metadata():
+    """A held-turn partial carries its end_of_turn_confidence on interim metadata."""
+    stream = _make_stream_for_unit_test()
+    stream._process_stream_event(_turn_message(end_of_turn_confidence=0.55))
+
+    interim = [e for e in _drain_events(stream) if e.type == SpeechEventType.INTERIM_TRANSCRIPT]
+    assert interim
+    assert interim[0].alternatives[0].metadata == {"end_of_turn_confidence": 0.55}
+
+
+async def test_end_of_turn_confidence_surfaced_on_final_metadata():
+    """The final transcript carries end_of_turn_confidence (1.0) on its metadata."""
+    stream = _make_stream_for_unit_test()
+    stream._process_stream_event(
+        _turn_message(end_of_turn=True, transcript="hello", end_of_turn_confidence=1.0)
+    )
+
+    final = [e for e in _drain_events(stream) if e.type == SpeechEventType.FINAL_TRANSCRIPT]
+    assert final
+    assert final[0].alternatives[0].metadata == {"end_of_turn_confidence": 1.0}
+
+
+async def test_end_of_turn_confidence_zero_is_surfaced():
+    """0.0 on an early partial is a real value (turn just started), not 'absent',
+    so it must still surface — mirrors the value seen before the ramp climbs."""
+    stream = _make_stream_for_unit_test()
+    stream._process_stream_event(_turn_message(end_of_turn_confidence=0.0))
+
+    interim = [e for e in _drain_events(stream) if e.type == SpeechEventType.INTERIM_TRANSCRIPT]
+    assert interim
+    assert interim[0].alternatives[0].metadata == {"end_of_turn_confidence": 0.0}
+
+
+async def test_end_of_turn_confidence_absent_leaves_metadata_none():
+    """A model/message that doesn't include end_of_turn_confidence leaves metadata
+    unset, so existing consumers are unaffected."""
+    stream = _make_stream_for_unit_test()
+    stream._process_stream_event(_turn_message())  # no end_of_turn_confidence key
+
+    interim = [e for e in _drain_events(stream) if e.type == SpeechEventType.INTERIM_TRANSCRIPT]
+    assert interim
+    assert interim[0].alternatives[0].metadata is None


### PR DESCRIPTION
## Summary

Surfaces the AssemblyAI streaming `end_of_turn_confidence` on `SpeechData.metadata` so callers can read it off the `SpeechEvent` (e.g. in an `stt_node` override) and threshold it for preemptive / eager LLM generation. The plugin already parsed the field from each `Turn` message but only logged it, so it never reached `SpeechData`. It's now attached to the interim, preflight, and final events, guarded on `is not None` (an early-partial `0.0` still surfaces; models that don't emit the field are unaffected).

Value semantics are model-defined:
- `universal-3-5-pro` / `universal-3-6-pro` / `u3-rt-pro` — rises from `0` toward `1` across the partials held between `min_turn_silence` and `max_turn_silence`, and is `1.0` on the final.
- `universal-streaming-english` / `universal-streaming-multilingual` — a per-partial end-of-turn probability on every partial, with the model's own score on the final.

## Testing

- `tests/test_plugin_assemblyai_stt.py`: 4 new tests (interim, final, the `0.0`-still-surfaces case, and the absent-field case). Full file: 115 passed; ruff and strict mypy clean.
- Verified against the production AssemblyAI streaming API on an ambiguous-ending clip: `universal-3-5-pro` and `universal-3-6-pro` surface the held-turn ramp (`0.0 → 0.4 → 0.75 → 1.0`), and `universal-streaming-english` / `universal-streaming-multilingual` surface their per-partial EOT probability — all readable off `SpeechData.metadata`.
