### PR TITLE
fix(worker): discard impossible cgroup v2 cpu samples

### DIFF
--- a/livekit-agents/livekit/agents/utils/hw/cpu.py
+++ b/livekit-agents/livekit/agents/utils/hw/cpu.py
@@ -39,6 +39,9 @@ class DefaultCPUMonitor(CPUMonitor):
 
 
 class CGroupV2CPUMonitor(CPUMonitor):
+    def __init__(self) -> None:
+        self._last_cpu_percent = 0.0
+
     def cpu_count(self) -> float:
         # quota: The maximum CPU time in microseconds that the cgroup can use within a given period.
         # period: The period of time in microseconds over which the quota applies.
@@ -53,18 +56,28 @@ class CGroupV2CPUMonitor(CPUMonitor):
         return 1.0 * int(quota) / period
 
     def cpu_percent(self, interval: float = 0.5) -> float:
+        start = time.monotonic()
         cpu_usage_start = self._read_cpu_usage()
         time.sleep(interval)
         cpu_usage_end = self._read_cpu_usage()
-        cpu_usage_diff = cpu_usage_end - cpu_usage_start
+        elapsed = time.monotonic() - start
 
         # microseconds to seconds
-        cpu_usage_seconds = cpu_usage_diff / 1_000_000
+        cpu_usage_seconds = (cpu_usage_end - cpu_usage_start) / 1_000_000
 
-        num_cpus = self.cpu_count()
-        cpu_usage_percent = cpu_usage_seconds / (interval * num_cpus)
+        # some hypervisors serve a torn per-cpu sum, so discard a delta the host cannot have produced
+        max_cpu_usage_seconds = elapsed * (psutil.cpu_count() or 1)
+        if not 0 <= cpu_usage_seconds <= max_cpu_usage_seconds:
+            logger.warning(
+                "discarding impossible cgroup cpu usage delta of %.3fs (ceiling %.3fs)",
+                cpu_usage_seconds,
+                max_cpu_usage_seconds,
+            )
+            return self._last_cpu_percent
 
-        return min(cpu_usage_percent, 1)
+        cpu_usage_percent = cpu_usage_seconds / (elapsed * self.cpu_count())
+        self._last_cpu_percent = min(cpu_usage_percent, 1.0)
+        return self._last_cpu_percent
 
     def _read_cpu_max(self) -> tuple[str, int]:
         try:

--- a/tests/test_cpu_monitor.py
+++ b/tests/test_cpu_monitor.py
@@ -1,0 +1,121 @@
+import logging
+import time
+
+import psutil
+import pytest
+
+from livekit.agents import utils
+from livekit.agents.utils.hw.cpu import CGroupV2CPUMonitor
+
+pytestmark = pytest.mark.unit
+
+HOST_CPUS = 8
+INTERVAL = 0.5
+# one idle 0.5 s sample on the reporter's host, about 0.5 % of 8 CPUs
+IDLE_USAGE_USEC = 21_600
+
+# raw (start, end) usage_usec pairs logged on the affected Xen HVM guest
+TORN_READS = [
+    (5260817467, 2548880500),
+    (5268770613, 5860175581),
+    (5889766280, 5270782758),
+    (1210759425, 5271033390),
+    (5271381786, 5798443673),
+    (5288672329, 1215868554),
+]
+
+
+@pytest.fixture
+def monitor(monkeypatch: pytest.MonkeyPatch) -> CGroupV2CPUMonitor:
+    monkeypatch.delenv("NUM_CPUS", raising=False)
+    monkeypatch.setattr(psutil, "cpu_count", lambda: HOST_CPUS)
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    monitor = CGroupV2CPUMonitor()
+    monkeypatch.setattr(monitor, "_read_cpu_max", lambda: ("max", 100000))
+    return monitor
+
+
+def sample(
+    monitor: CGroupV2CPUMonitor,
+    monkeypatch: pytest.MonkeyPatch,
+    usage_start: int,
+    usage_end: int,
+    *,
+    elapsed: float = INTERVAL,
+) -> float:
+    reads = iter([usage_start, usage_end])
+    clock = iter([0.0, elapsed])
+    monkeypatch.setattr(monitor, "_read_cpu_usage", lambda: next(reads))
+    monkeypatch.setattr(time, "monotonic", lambda: next(clock))
+    return monitor.cpu_percent(INTERVAL)
+
+
+@pytest.mark.parametrize("elapsed", [0.5, 0.6])
+def test_normal_delta_uses_measured_elapsed(
+    monitor: CGroupV2CPUMonitor, monkeypatch: pytest.MonkeyPatch, elapsed: float
+) -> None:
+    # one cpu-second of usage over the measured interval on 8 CPUs
+    pct = sample(monitor, monkeypatch, 5_000_000_000, 5_001_000_000, elapsed=elapsed)
+    assert pct == pytest.approx(1.0 / (elapsed * HOST_CPUS))
+
+
+def test_negative_delta_holds_previous_sample(
+    monitor: CGroupV2CPUMonitor, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    good = sample(monitor, monkeypatch, 5_000_000_000, 5_001_000_000)
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        pct = sample(monitor, monkeypatch, *TORN_READS[0])
+    assert pct == good
+    assert "impossible" in caplog.text
+
+
+def test_over_ceiling_delta_holds_previous_sample(
+    monitor: CGroupV2CPUMonitor, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    good = sample(monitor, monkeypatch, 5_000_000_000, 5_001_000_000)
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        pct = sample(monitor, monkeypatch, *TORN_READS[1])
+    assert pct == good
+    assert pct != 1.0
+    assert "impossible" in caplog.text
+
+
+def test_first_discarded_sample_reads_idle(
+    monitor: CGroupV2CPUMonitor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert sample(monitor, monkeypatch, *TORN_READS[0]) == 0.0
+
+
+def test_reporter_pattern_stays_below_threshold(
+    monitor: CGroupV2CPUMonitor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    idle = 5_270_000_000
+    reads: list[tuple[int, int]] = []
+    for torn in [None, None, *TORN_READS[:3], None, *TORN_READS[3:], None, None]:
+        reads.append(torn or (idle, idle + IDLE_USAGE_USEC))
+        idle += IDLE_USAGE_USEC
+
+    avg = utils.MovingAverage(5)
+    idle_pct = IDLE_USAGE_USEC / 1_000_000 / (INTERVAL * HOST_CPUS)
+    for usage_start, usage_end in reads:
+        avg.add_sample(sample(monitor, monkeypatch, usage_start, usage_end))
+        assert avg.get_avg() == pytest.approx(idle_pct)
+
+
+def test_delta_at_ceiling_is_full_load(
+    monitor: CGroupV2CPUMonitor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    full = int(INTERVAL * HOST_CPUS * 1_000_000)
+    assert sample(monitor, monkeypatch, 5_000_000_000, 5_000_000_000 + full) == 1.0
+
+
+def test_burst_above_quota_clamps_instead_of_discarding(
+    monitor: CGroupV2CPUMonitor, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # a 2-CPU cpu.max quota on an 8-CPU host, bursting to 4 CPUs for the interval
+    monkeypatch.setattr(monitor, "_read_cpu_max", lambda: ("200000", 100000))
+    assert monitor.cpu_count() == 2.0
+    with caplog.at_level(logging.WARNING, logger="livekit.agents"):
+        pct = sample(monitor, monkeypatch, 5_000_000_000, 5_002_000_000)
+    assert pct == 1.0
+    assert "impossible" not in caplog.text


### PR DESCRIPTION
**Problem:** On some hypervisors the root cgroup `usage_usec` counter returns a torn per-cpu sum, and `CGroupV2CPUMonitor.cpu_percent` turns that one read into a 1.0 or a large negative sample. Four such samples in the five-slot load average mark an idle worker FULL for 2.5 s, and a call that lands in that window gets no server.

**Fix:** The monitor measures elapsed time around the two reads and discards a delta that is negative or above `elapsed x host cpus`, since no host can produce either. A discarded sample returns the last good value instead of a fresh number, so the average is unchanged on idle and busy hosts alike.

Fixes #7102. Supersedes #7103.

<details>
<summary>Context for reviewing and coding agents</summary>

> **How to see it**
>
> `tests/test_cpu_monitor.py` replays the six raw `(start, end)` counter pairs from the issue log through a scripted `_read_cpu_usage`, a no-op `time.sleep` and a scripted `time.monotonic` on an 8-cpu host. `test_reporter_pattern_stays_below_threshold` pushes the reporter's sample sequence through `utils.MovingAverage(5)` and asserts the average stays at the idle fraction on every step; on main the same sequence averages 0.80, the value in the report.
>
> **Blast radius**
>
> The only caller is `_DefaultLoadCalc` in `worker.py:98`, which feeds `cpu_percent(interval=0.5)` into `utils.MovingAverage(5)` at `worker.py:88`. `cpu_count`, `_read_cpu_max`, `_read_cpu_usage`, `CGroupV1CPUMonitor` and `DefaultCPUMonitor` are unchanged, so the `num_idle_processes` defaults at `worker.py:208` and `worker.py:299` keep their values.
>
> **Why the ceiling uses host cpus and not the quota**
>
> `cpu.max` is an average limit and a container can burst above it for one interval, so a quota-based ceiling would discard real samples. `psutil.cpu_count()` is the physical bound; the quota still divides the accepted sample, so a burst clamps to 1.0 rather than being thrown away.
>
> **Alternatives rejected**
>
> Clamping to `[0, 1]` removes the negative case only; an inflated delta still clamps to 1.0 and four of them still average to 0.80. Falling back to `psutil.cpu_percent` is not safer, because `/proc/stat` is summed by the kernel from the same per-cpu kcpustat counters as the root cgroup's `cpu.stat`. Returning 0.0 on a discard, as #7103 does, is the same defect mirrored: on a saturated worker each glitch drops the average by 0.2 and the worker keeps accepting jobs. #7103 also reads the process's own cgroup and walks `cpu.max` up the ancestor chain, which changes what load means for a systemd-managed worker and belongs in its own discussion.
>
> **Where the numbers come from**
>
> The reporter's log shows deltas of +5.9e8 and -2.7e9 microseconds over 0.5 s on 8 cpus, against a physical ceiling of 4e6. Four 1.0 samples in a five-slot average give 0.8011 (4.0054 / 5), which matches the `load` value in the reported log line.

</details>
