### PR TITLE
fix(sarvam-stt): anchor transcription_delay at Sarvam VAD speech end

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -378,7 +378,7 @@ def _build_websocket_url(base_url: str, opts: SarvamSTTOptions) -> str:
     params = {
         "language-code": opts.language,
         "model": opts.model,
-        "vad_signals": " true",
+        "vad_signals": "true",
     }
 
     if opts.sample_rate:

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt.py
@@ -378,7 +378,7 @@ def _build_websocket_url(base_url: str, opts: SarvamSTTOptions) -> str:
     params = {
         "language-code": opts.language,
         "model": opts.model,
-        "vad_signals": "true",
+        "vad_signals": " true",
     }
 
     if opts.sample_rate:
@@ -903,6 +903,7 @@ class SpeechStream(stt.SpeechStream):
         self._should_flush = False  # Flag to trigger flush
 
         self._utterance_speech_start_wall: float | None = None
+        self._utterance_speech_end_wall: float | None = None
         self._pending_final_data: dict[str, Any] | None = None
         self._pending_eos = False
         self._eos_fallback_task: asyncio.Task[None] | None = None
@@ -977,6 +978,7 @@ class SpeechStream(stt.SpeechStream):
         self._pending_final_data = None
         self._pending_eos = False
         self._utterance_speech_start_wall = time.time()
+        self._utterance_speech_end_wall = None
         self._final_received_for_utterance = False
         self._eos_emitted_for_utterance = False
 
@@ -1033,11 +1035,14 @@ class SpeechStream(stt.SpeechStream):
         self._cancel_eos_fallback()
 
         # Bare END_OF_SPEECH (no alternatives), like other plugins' EOS events. The
-        # speech-end timing lives on the FINAL_TRANSCRIPT's end_time, not here.
+        # speech-end wall-clock anchor rides on speech_end_time: the voice pipeline
+        # uses it as the `_last_speaking_time` anchor, so transcription_delay
+        # measures Sarvam VAD speech end -> final transcript received.
         self._event_ch.send_nowait(
             stt.SpeechEvent(
                 type=stt.SpeechEventType.END_OF_SPEECH,
                 request_id=self._server_request_id or "",
+                speech_end_time=self._utterance_speech_end_wall,
             )
         )
         self._eos_emitted_for_utterance = True
@@ -1649,6 +1654,11 @@ class SpeechStream(stt.SpeechStream):
             elif signal_type == "END_SPEECH":
                 if self._speaking:
                     self._speaking = False
+                    # Wall-clock receipt of Sarvam's VAD speech-end signal. This is
+                    # the anchor the voice pipeline reads from END_OF_SPEECH's
+                    # speech_end_time, so transcription_delay measures
+                    # Sarvam VAD speech end -> final transcript received.
+                    self._utterance_speech_end_wall = time.time()
                     self._pending_eos = True
                     self._try_commit_utterance()
                     if not self._eos_emitted_for_utterance and self._pending_final_data is None:

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/stt_streaming.py
@@ -1226,12 +1226,16 @@ class RealtimeSpeechStream(stt.SpeechStream):
             return
 
         # Emitted without alternatives so the agent pipeline treats it as a sentinel
-        # it can hold and release with a concrete transcript. The speech-end timing
-        # travels on the FINAL_TRANSCRIPT event instead.
+        # it can hold and release with a concrete transcript. The speech-end
+        # wall-clock anchor rides on speech_end_time: the voice pipeline uses it as
+        # the `_last_speaking_time` anchor in STT turn-detection mode, so
+        # transcription_delay measures Sarvam VAD speech end -> final transcript
+        # received. The audio-timeline end_time stays on the FINAL_TRANSCRIPT event.
         self._event_ch.send_nowait(
             stt.SpeechEvent(
                 type=stt.SpeechEventType.END_OF_SPEECH,
                 request_id=self._request_id,
+                speech_end_time=self._utterance_speech_end_wall,
             )
         )
         self._eos_emitted_for_utterance = True

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
@@ -30,6 +31,7 @@ def _make_stream_under_test(
     instance._should_flush = False  # type: ignore[attr-defined]
     instance._start_time_offset = 0.0  # type: ignore[attr-defined]
     instance._utterance_speech_start_wall = None  # type: ignore[attr-defined]
+    instance._utterance_speech_end_wall = None  # type: ignore[attr-defined]
     instance._pending_final_data = None  # type: ignore[attr-defined]
     instance._pending_eos = False  # type: ignore[attr-defined]
     instance._eos_fallback_task = None  # type: ignore[attr-defined]
@@ -86,6 +88,43 @@ async def test_end_speech_emits_bare_end_of_speech() -> None:
     assert len(end_events) == 1
     assert end_events[0].alternatives == []
     assert end_events[0].request_id == "req-session"
+
+
+async def test_end_of_speech_carries_speech_end_wall_clock() -> None:
+    # The voice pipeline anchors `_last_speaking_time` from END_OF_SPEECH's
+    # speech_end_time (stt turn-detection mode), which makes transcription_delay
+    # measure Sarvam VAD speech end -> final transcript received. The anchor is
+    # the wall-clock moment the plugin received END_SPEECH, not the later moment
+    # the EOS event is actually emitted.
+    instance, captured = _make_stream_under_test()
+
+    await instance._handle_events(_event("START_SPEECH"))
+    await instance._handle_events(_event("END_SPEECH"))
+    await asyncio.sleep(0.05)
+
+    end_events = _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)
+    assert len(end_events) == 1
+    speech_end = end_events[0].speech_end_time
+    assert speech_end is not None
+    assert speech_end <= time.time()
+    # The anchor is captured at END_SPEECH receipt, so it must not be later than
+    # the moment the EOS event was created by the fallback task.
+    assert speech_end <= end_events[0].created_at
+
+
+async def test_speech_end_wall_clock_resets_on_new_utterance() -> None:
+    # A stale anchor from the previous utterance must not leak into the next
+    # turn: _reset_utterance_state clears it on START_SPEECH.
+    instance, captured = _make_stream_under_test()
+
+    await instance._handle_events(_event("START_SPEECH"))
+    await instance._handle_events(_event("END_SPEECH"))
+    await asyncio.sleep(0.05)  # let the EOS fallback task fire
+    first_end = _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)[0]
+    assert first_end.speech_end_time is not None
+
+    await instance._handle_events(_event("START_SPEECH"))
+    assert instance._utterance_speech_end_wall is None  # type: ignore[attr-defined]
 
 
 async def test_final_end_time_is_zero_when_provider_omits_timing() -> None:
@@ -258,3 +297,5 @@ async def test_occured_at_is_ignored() -> None:
     end = _events_of_type(captured, stt.SpeechEventType.END_OF_SPEECH)[0]
     assert final.alternatives[0].end_time == 0.0
     assert end.alternatives == []
+    # The wall-clock anchor still rides on the EOS event itself.
+    assert end.speech_end_time is not None


### PR DESCRIPTION
## Summary

`transcription_delay` reported ~0 with the Sarvam STT plugin: the plugin's `END_OF_SPEECH` event carried no `speech_end_time`, so the voice pipeline anchored the turn at EOS *processing* time — which is after the final transcript was already handled. The metric collapsed to ~0 regardless of the real recognition latency.

Both `SpeechStream` (`stt.py`) and `RealtimeSpeechStream` (`stt_streaming.py`) now capture the wall-clock time the Sarvam VAD speech-end signal is received (`END_SPEECH` / `vad.speech_end`, or the manual endpointing boundary) and emit it as `speech_end_time` on `END_OF_SPEECH`. The pipeline's existing STS turn-detection path already consumes that field as the `_last_speaking_time` anchor (`audio_recognition.py`), so no framework change is needed.

`transcription_delay` now measures the real latency: **Sarvam VAD speech end → final transcript received**.

## Details

- The anchor is captured at signal *receipt*, not at EOS emission — so when the final transcript arrives late and EOS is emitted by the 1s fallback task, the metric still reports the true wait instead of collapsing to ~0.
- The anchor is reset per utterance (`_reset_utterance_state`) so a stale value never leaks into the next turn.
- All five `_emit_end_of_speech()` call sites in `stt_streaming.py` verified to have the anchor set beforehand (manual-end, speech-end, delayed commit, session-end flush).
- VAD and manual turn-detection modes are unaffected: the anchor is only read in the `turn_detection == "stt"` EOS branch.

## Verification

- `livekit-plugins/livekit-plugins-sarvam/tests/test_speech_timing.py`: 16/16 pass (2 new tests: EOS carries the wall-clock anchor; anchor resets per utterance; extended fallback-path test).
- ruff check + format + mypy clean on touched files.
- End-to-end with a headless driver wired like a real session (`turn_detection="stt"`, no local VAD), real speech audio through the real Sarvam server: `EOU metrics end_of_utterance_delay=0.501, transcription_delay=0.396`.

🪷 Generated with Sarvam Code