### PR TITLE
fix: keep the gateway routing stamp on tool-only turns

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/openai.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/openai.py
@@ -24,7 +24,9 @@ def to_chat_ctx(
             continue
 
         # one message can contain zero or more tool calls
-        msg = _to_chat_item(group.message) if group.message else {"role": "assistant"}
+        msg: dict[str, Any] = (
+            _to_chat_item(group.message) if group.message else {"role": "assistant"}
+        )
         tool_calls = []
         for tool_call in group.tool_calls:
             tc: dict[str, Any] = {
@@ -37,7 +39,15 @@ def to_chat_ctx(
                 tc["extra_content"] = extra_content
             tool_calls.append(tc)
         if tool_calls:
-            msg["tool_calls"] = tool_calls  # type: ignore[assignment]
+            msg["tool_calls"] = tool_calls
+            if not group.message:
+                # the gateway reads its routing stamp from the assistant message
+                livekit = next(
+                    (tc.extra["livekit"] for tc in group.tool_calls if tc.extra.get("livekit")),
+                    None,
+                )
+                if livekit:
+                    msg["extra_content"] = {"livekit": livekit}
         messages.append(msg)
 
         # append tool outputs following the tool calls

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3686,6 +3686,12 @@ class AgentActivity(RecognitionHooks):
                 self._session.update_agent(new_agent_task)
                 draining = True
 
+            if not forwarded_text and llm_gen_data.generated_extra:
+                # a turn with no text stores no assistant message, so the generation's
+                # extra (e.g. the gateway's routing stamp) has to ride on the calls
+                for call in new_calls:
+                    call.extra = {**llm_gen_data.generated_extra, **call.extra}
+
             tool_messages = new_calls + new_fnc_outputs
             # commit now so results survive even if the reply speech never runs (#3702)
             if tool_messages:

--- a/tests/fake_llm.py
+++ b/tests/fake_llm.py
@@ -34,6 +34,7 @@ class FakeLLMResponse(BaseModel):
     ttft: float
     duration: float
     tool_calls: list[FunctionToolCall] = Field(default_factory=list)
+    extra: dict[str, Any] | None = None
 
     def speed_up(self, factor: float) -> FakeLLMResponse:
         obj = copy.deepcopy(self)
@@ -94,14 +95,18 @@ class FakeLLMStream(LLMStream):
         num_chunks = max(1, len(resp.content) // chunk_size + 1)
         for i in range(num_chunks):
             delta = resp.content[i * chunk_size : (i + 1) * chunk_size]
-            self._send_chunk(delta=delta)
+            self._send_chunk(delta=delta, extra=resp.extra if i == 0 else None)
 
         await asyncio.sleep(resp.duration - (time.perf_counter() - start_time))
 
         self._send_chunk(tool_calls=resp.tool_calls)
 
     def _send_chunk(
-        self, *, delta: str | None = None, tool_calls: list[FunctionToolCall] | None = None
+        self,
+        *,
+        delta: str | None = None,
+        tool_calls: list[FunctionToolCall] | None = None,
+        extra: dict[str, Any] | None = None,
     ) -> None:
         self._event_ch.send_nowait(
             ChatChunk(
@@ -110,6 +115,7 @@ class FakeLLMStream(LLMStream):
                     role="assistant",
                     content=delta,
                     tool_calls=tool_calls or [],
+                    extra=extra,
                 ),
             )
         )

--- a/tests/fake_session.py
+++ b/tests/fake_session.py
@@ -160,6 +160,7 @@ class FakeActions:
         input: NotGivenOr[str] = NOT_GIVEN,
         ttft: float = 0.1,
         duration: float = 0.3,
+        extra: dict[str, Any] | None = None,
     ) -> None:
         if (
             not utils.is_given(input)
@@ -179,6 +180,7 @@ class FakeActions:
                 ttft=ttft,
                 duration=duration,
                 tool_calls=tool_calls or [],
+                extra=extra,
             )
         )
 

--- a/tests/test_chat_ctx.py
+++ b/tests/test_chat_ctx.py
@@ -902,3 +902,25 @@ def test_to_provider_format_non_object_tool_arguments(fmt: str, arguments: str):
 
     messages, _ = ctx.to_provider_format(format=fmt)
     assert _tool_call_input(fmt, messages) == {}
+
+
+def test_openai_format_lifts_livekit_extra_onto_a_tool_only_assistant_message():
+    # the inference gateway reads its routing stamp from the assistant message,
+    # so a turn with no text still has to carry it there
+    chat_ctx = ChatContext()
+    chat_ctx.add_message(role="user", content="hi")
+    chat_ctx.items.append(
+        FunctionCall(
+            call_id="c1",
+            name="f",
+            arguments="{}",
+            extra={"livekit": {"inference_deployment": "dep"}},
+        )
+    )
+    chat_ctx.items.append(FunctionCallOutput(call_id="c1", name="f", output="ok", is_error=False))
+
+    messages, _ = chat_ctx.to_provider_format(format="openai")
+
+    assistant = messages[1]
+    assert assistant["role"] == "assistant"
+    assert assistant["extra_content"] == {"livekit": {"inference_deployment": "dep"}}

--- a/tests/test_tool_turn_generation_extra.py
+++ b/tests/test_tool_turn_generation_extra.py
@@ -1,0 +1,47 @@
+"""A generation's provider extra (the inference gateway's deployment stamp) is kept
+on the turn even when the LLM produced only tool calls and no text."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from livekit.agents import Agent, AgentSession, function_tool
+from livekit.agents.llm import FunctionToolCall
+
+from .fake_session import FakeActions, create_session, run_session
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+STAMP = {"livekit": {"inference_deployment": "standard_openai"}}
+
+
+class ToolAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="You are a helpful assistant.")
+
+    @function_tool
+    async def do_the_thing(self) -> str:
+        """Do the thing."""
+        return "ok"
+
+
+async def test_tool_only_turn_keeps_the_generation_extra() -> None:
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "Do the thing.")
+    actions.add_llm(
+        content="",
+        tool_calls=[FunctionToolCall(name="do_the_thing", arguments="{}", call_id="1")],
+        extra=STAMP,
+    )
+    actions.add_llm(content="Done.", input="ok")
+    actions.add_tts(1.0)
+
+    session: AgentSession = create_session(actions)
+    agent = ToolAgent()
+    await asyncio.wait_for(run_session(session, agent), timeout=60.0)
+
+    calls = [i for i in agent.chat_ctx.items if i.type == "function_call"]
+    assert len(calls) == 1
+    assert calls[0].extra["livekit"] == STAMP["livekit"]


### PR DESCRIPTION
## Problem

The inference gateway stamps every streamed chunk with the deployment that served it (`choices[0].delta.extra_content.livekit.inference_deployment`) and, when the stamp comes back on an assistant message, pins the next turn to that deployment so the prompt cache warmed by the previous turn is reused.

The SDK only stored the stamp on the assistant `ChatMessage`, and that message is only created when the turn produced text. A turn that produced tool calls and no text dropped the stamp, so every follow-up turn of a tool-driven agent was re-routed at random across providers.

Measured on the simulation summarizer in production over 7 days: 0 of 28,699 gateway routing decisions for that project carried a preferred deployment, and 36% of consecutive reviewer turns switched deployment, each one missing the prefix it had just cached.

## Fix

- `agent_activity`: when no assistant message is stored, carry the generation's extra on the function calls of that turn.
- OpenAI serializer: for a tool-only group, emit the `livekit` extra on the synthesized assistant message, where the gateway reads it. Tool-level `extra_content` is unchanged.

## Verification

- New unit tests: serializer places the stamp on the tool-only assistant message; a fake-session tool turn with no text keeps the stamp on the recorded function call. Both failed before the change.
- Replayed the summarizer's reviewer path against the production gateway with this branch: the follow-up request now carries `extra_content.livekit.inference_deployment` on the assistant message.
- `make unit-tests`: all pass except `tests/test_room.py`, which fails identically on `main` in my environment (local WebSocket connect error).
- `make type-check`: no new errors.

agents-js has the same gap (`agent_activity.ts` stores `generatedExtra` only under `if (forwardedText)`, and `provider_format/openai.ts` synthesizes a bare `{ role: 'assistant' }` for tool-only groups). Follow-up PR there.