### PR TITLE
fix: keep the forkserver preload shared with job processes (gc.freeze)

### DIFF
--- a/livekit-agents/livekit/agents/ipc/_preload_freeze.py
+++ b/livekit-agents/livekit/agents/ipc/_preload_freeze.py
@@ -1,0 +1,17 @@
+"""Side-effect module: imported **last** in the forkserver preload list.
+
+A forked job process shares the forkserver's pages copy-on-write, but the first
+gen2 collection in the child traverses every tracked object and rewrites its GC
+header, dirtying (and so un-sharing) nearly every page holding preloaded
+objects. ``gc.freeze()`` moves them to the permanent generation, which the
+collector never visits, so those pages stay shared for the life of the job.
+
+Kept free of imports on purpose: the forkserver swallows ``ImportError`` from
+preload modules, so anything importable that can fail would silently skip the
+freeze.
+"""
+
+import gc
+
+gc.collect()  # don't make import-time cycle garbage permanent
+gc.freeze()

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -752,6 +752,9 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 plugin_packages = [p.package for p in Plugin.registered_plugins] + [
                     "av",
                     "livekit.agents.inference._warmup",
+                    # keep last: freezes everything preloaded above so the job
+                    # processes' GC doesn't un-share those pages (see module docstring)
+                    "livekit.agents.ipc._preload_freeze",
                 ]
                 logger.info("preloading plugins", extra={"packages": plugin_packages})
                 self._mp_ctx.set_forkserver_preload(plugin_packages)


### PR DESCRIPTION
### Problem

On Linux the worker preloads the registered plugin packages plus
`livekit.agents.inference._warmup` into the forkserver process so job processes
inherit the imported modules and the warmed native models copy-on-write.

The sharing does not last. Every job process runs its own cyclic GC, and a full
collection rewrites the `PyGC_Head` (two pointers stored immediately before each
tracked object) of every object in the oldest generation — a write, even when
nothing is collectable. Preloaded modules, classes, functions and their dicts
are long-lived, so they all live there: the first full collection in a forked
child dirties nearly every page holding a preloaded object and the kernel copies
it. Measured on a Linux worker at ~96MB moving from shared to private per job
process, and it happens with no job traffic at all — an idle prewarmed process
already crosses a full collection during prewarm.

The native weights from `init_vad()` / `init_eot()` are allocated outside the
Python heap and stay shared; it is the Python object graph that is lost.

### Fix

`gc.freeze()` in the forkserver, once everything is preloaded. Frozen objects go
to the permanent generation, which the collector never scans, so their headers
are never rewritten and the pages stay shared for the life of the job process.
They are still freed by refcounting if they die, and module-level state lives for
the whole process anyway, so nothing is retained that would not have been.

It has to run inside the forkserver — job processes fork from there, so freezing
in the worker would not affect them. This reuses the mechanism already in the
tree for that: a side-effect module in the preload list, like
`livekit.agents.inference._warmup`. The new module is listed last so everything
above it is resident by the time it runs.

The module deliberately imports nothing but `gc`. The forkserver's preload loop
swallows `ImportError`, so putting the call at the end of `_warmup.py` would
silently skip the freeze on any host where `livekit-local-inference` fails to
import, even though the plugin preload — and the problem — is still there.

Also drops ~230k objects from every full collection in the job process, removing
a recurring GC pause from the audio path.

### Verification

A child forked from a forkserver that preloads the new module reports
`gc.get_freeze_count() == 233838`, i.e. the freeze survives the fork and covers
the whole preloaded graph.

To see the memory effect on a Linux worker, sample a job process right after it
is forked and again after a full collection:

```bash
grep -E '^(Shared_Clean|Private_Dirty)' /proc/<job-pid>/smaps_rollup
```

`Shared_Clean` drops and `Private_Dirty` rises by the same amount without this
change; with it, both hold.

### Notes

- No behaviour change on `spawn` (macOS/Windows) — there is no preload there.
- Alternatives rejected: `gc.freeze()` in the worker (wrong process), and
  `gc.disable()` / raised thresholds in the job process (leaks real cycles for
  the lifetime of a long session).

Fixes #7117
