### PR TITLE
fix: preserve forkserver copy-on-write sharing

### DIFF
--- a/livekit-agents/livekit/agents/ipc/_preload_freeze.py
+++ b/livekit-agents/livekit/agents/ipc/_preload_freeze.py
@@ -1,12 +1,11 @@
-"""Freeze forkserver preloads to preserve copy-on-write sharing.
+"""Preserve copy-on-write sharing for forkserver-preloaded objects.
 
-A full cyclic collection in a forked job process would otherwise write to GC
-metadata on inherited objects and make those memory pages private. This module
-must remain last in the AgentServer forkserver preload list.
+Cyclic GC in a job process writes inherited object metadata and makes those
+pages private.
 """
 
 import gc
 
-# Collect unreachable cycles before they become permanent in the forkserver.
+# Do not freeze unreachable cycles for the forkserver lifetime.
 gc.collect()
 gc.freeze()

--- a/livekit-agents/livekit/agents/ipc/_preload_freeze.py
+++ b/livekit-agents/livekit/agents/ipc/_preload_freeze.py
@@ -1,0 +1,12 @@
+"""Freeze forkserver preloads to preserve copy-on-write sharing.
+
+A full cyclic collection in a forked job process would otherwise write to GC
+metadata on inherited objects and make those memory pages private. This module
+must remain last in the AgentServer forkserver preload list.
+"""
+
+import gc
+
+# Collect unreachable cycles before they become permanent in the forkserver.
+gc.collect()
+gc.freeze()

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -752,6 +752,8 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 plugin_packages = [p.package for p in Plugin.registered_plugins] + [
                     "av",
                     "livekit.agents.inference._warmup",
+                    # Keep last so it freezes objects imported by every other preload.
+                    "livekit.agents.ipc._preload_freeze",
                 ]
                 logger.info("preloading plugins", extra={"packages": plugin_packages})
                 self._mp_ctx.set_forkserver_preload(plugin_packages)

--- a/livekit-agents/livekit/agents/worker.py
+++ b/livekit-agents/livekit/agents/worker.py
@@ -752,7 +752,7 @@ class AgentServer(utils.EventEmitter[EventTypes]):
                 plugin_packages = [p.package for p in Plugin.registered_plugins] + [
                     "av",
                     "livekit.agents.inference._warmup",
-                    # Keep last so it freezes objects imported by every other preload.
+                    # Must remain last; it freezes objects imported by earlier preloads.
                     "livekit.agents.ipc._preload_freeze",
                 ]
                 logger.info("preloading plugins", extra={"packages": plugin_packages})

--- a/tests/test_forkserver_preload.py
+++ b/tests/test_forkserver_preload.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import multiprocessing as mp
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from livekit.agents.job import JobContext
+from livekit.agents.worker import AgentServer
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.skipif(
+    "forkserver" not in mp.get_all_start_methods(),
+    reason="forkserver is not available on this platform",
+)
+async def test_agent_server_runs_freeze_preload_last() -> None:
+    server = AgentServer(multiprocessing_context="forkserver", num_idle_processes=0)
+
+    @server.rtc_session()
+    async def entrypoint(_: JobContext) -> None:
+        pass
+
+    server._simulation = True
+    server._mp_ctx = mp_context = MagicMock()
+
+    pool_started = asyncio.Event()
+    process_pool = MagicMock()
+    process_pool.start = AsyncMock(side_effect=lambda: pool_started.set())
+    process_pool.aclose = AsyncMock()
+
+    with patch("livekit.agents.ipc.proc_pool.ProcPool", return_value=process_pool):
+        run_task = asyncio.create_task(server.run(unregistered=True))
+        try:
+            await asyncio.wait_for(pool_started.wait(), timeout=5)
+            preloads = mp_context.set_forkserver_preload.call_args.args[0]
+
+            assert preloads[-1] == "livekit.agents.ipc._preload_freeze"
+        finally:
+            await server.aclose()
+            await run_task
+
+
+@pytest.mark.skipif(
+    "forkserver" not in mp.get_all_start_methods(),
+    reason="forkserver is not available on this platform",
+)
+def test_forkserver_preload_preserves_child_gc() -> None:
+    helper = Path(__file__).parent / "utils" / "forkserver_preload.py"
+    result = subprocess.run(
+        [sys.executable, str(helper)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    outcome = json.loads(result.stdout)
+
+    assert outcome["freeze_count"] > 0
+    assert outcome["child_cycle_collected"] is True

--- a/tests/utils/forkserver_preload.py
+++ b/tests/utils/forkserver_preload.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import gc
+import json
+import multiprocessing as mp
+import weakref
+from multiprocessing.connection import Connection
+
+
+class _Cycle:
+    reference: _Cycle
+
+
+def _inspect_gc(connection: Connection) -> None:
+    freeze_count = gc.get_freeze_count()
+
+    cycle = _Cycle()
+    cycle.reference = cycle
+    cycle_reference = weakref.ref(cycle)
+    del cycle
+    gc.collect()
+
+    connection.send(
+        {
+            "freeze_count": freeze_count,
+            "child_cycle_collected": cycle_reference() is None,
+        }
+    )
+    connection.close()
+
+
+if __name__ == "__main__":
+    context = mp.get_context("forkserver")
+    context.set_forkserver_preload(["livekit.agents.ipc._preload_freeze"])
+    parent_connection, child_connection = context.Pipe(duplex=False)
+    process = context.Process(target=_inspect_gc, args=(child_connection,))
+
+    process.start()
+    child_connection.close()
+    outcome = parent_connection.recv()
+    parent_connection.close()
+    process.join()
+
+    if process.exitcode != 0:
+        raise SystemExit(process.exitcode)
+
+    print(json.dumps(outcome))


### PR DESCRIPTION
**Why:** Full cyclic GC in a job process writes to inherited GC metadata and turns forkserver-shared heap pages private.

**Behavior:** Freeze completed preloads before forking. Tests protect ordering and child cycle collection.

**Clarification:** Use `Shared_Dirty` and PSS, not `Shared_Clean`; the cost varies with preloaded plugins.

**Credit:** Supersedes #7118 by @Darshak03, credited as a commit co-author.

Fixes #7117
Addresses AGT-3441

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> can you investigate issue 7117?
>
> we don't have similar issue in Node js, right?
>
> Okay, let's create a new PR for this with the original PR author credited as co-author so that we can bring in the regression tests and clarification.
>
> run a subagent with $thermo-nuclear-code-quality-review and $code-taste-review before commit or PR.

</details>
