### PR TITLE
plugins/phonic: add enable_watermarking realtime config option

### DIFF
--- a/livekit-plugins/livekit-plugins-phonic/README.md
+++ b/livekit-plugins/livekit-plugins-phonic/README.md
@@ -126,6 +126,7 @@ Set the `PHONIC_API_KEY` environment variable, or pass `api_key` directly to `Re
 | `pronunciation_dictionary` | `list[PronunciationEntry]` | `{ word, pronunciation }` entries; words must be unique |
 | `template_variables` | `dict[str, str]` | Variables substituted into the system prompt and welcome message |
 | `enable_redaction` | `bool` | Redact PII/PHI from transcripts and bleep it from audio after the conversation |
+| `enable_watermarking` | `bool` | Embed an inaudible provenance watermark in generated audio. Adds a very small amount of latency |
 | `mcp_servers` | `list[str]` | Names of pre-configured MCP servers to make available (must be unique) |
 | `observability_integrations` | `list["braintrust"]` | Observability integrations to forward traces to |
 | `configuration_endpoint` | `ConfigurationEndpoint` \| `None` | Endpoint the agent calls to fetch per-conversation configuration |

--- a/livekit-plugins/livekit-plugins-phonic/README.md
+++ b/livekit-plugins/livekit-plugins-phonic/README.md
@@ -99,7 +99,7 @@ Set the `PHONIC_API_KEY` environment variable, or pass `api_key` directly to `Re
 | --- | --- | --- |
 | `api_key` | `str` | Phonic API key. Falls back to `PHONIC_API_KEY` environment variable |
 | `phonic_agent` | `str` | Phonic agent name. Options set explicitly here override agent settings |
-| `voice` | `str` | Voice ID — `sabrina`, `grant`, `virginia`, `landon`, `eleanor`, `shelby`, `nolan` |
+| `voice` | `str` | Voice ID — see [available voices](https://docs.phonic.ai/docs/build/agents/voices) |
 | `welcome_message` | `str` | Message the agent says when the conversation starts. Ignored when `generate_welcome_message` is True |
 | `generate_welcome_message` | `bool` | Auto-generate the welcome message (ignores `welcome_message`) |
 | `project` | `str` | Project name (default: `main`) |

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -157,6 +157,7 @@ class _RealtimeOptions:
     pronunciation_dictionary: NotGivenOr[list[PronunciationEntry]]
     template_variables: NotGivenOr[dict[str, str]]
     enable_redaction: NotGivenOr[bool]
+    enable_watermarking: NotGivenOr[bool]
     mcp_servers: NotGivenOr[list[str]]
     observability_integrations: NotGivenOr[list[ObservabilityIntegration]]
     configuration_endpoint: NotGivenOr[ConfigurationEndpoint | None]
@@ -230,6 +231,7 @@ class RealtimeModel(llm.RealtimeModel):
         pronunciation_dictionary: NotGivenOr[list[PronunciationEntry]] = NOT_GIVEN,
         template_variables: NotGivenOr[dict[str, str]] = NOT_GIVEN,
         enable_redaction: NotGivenOr[bool] = NOT_GIVEN,
+        enable_watermarking: NotGivenOr[bool] = NOT_GIVEN,
         mcp_servers: NotGivenOr[list[str]] = NOT_GIVEN,
         observability_integrations: NotGivenOr[list[ObservabilityIntegration]] = NOT_GIVEN,
         configuration_endpoint: NotGivenOr[ConfigurationEndpoint | None] = NOT_GIVEN,
@@ -284,6 +286,8 @@ class RealtimeModel(llm.RealtimeModel):
             template_variables: Variables substituted into the system prompt and welcome message.
             enable_redaction: When True, PII/PHI is redacted from transcripts and bleeped from audio
                 after the conversation ends.
+            enable_watermarking: When True, embeds an inaudible provenance watermark in the agent's
+                generated audio. Adds a very small amount of latency.
             mcp_servers: Names of pre-configured MCP servers to make available to the assistant.
                 Names must be unique.
             observability_integrations: Names of observability integrations to forward traces to
@@ -367,6 +371,7 @@ class RealtimeModel(llm.RealtimeModel):
             pronunciation_dictionary=pronunciation_dictionary,
             template_variables=template_variables,
             enable_redaction=enable_redaction,
+            enable_watermarking=enable_watermarking,
             mcp_servers=mcp_servers,
             observability_integrations=observability_integrations,
             configuration_endpoint=configuration_endpoint,
@@ -430,6 +435,7 @@ class RealtimeModel(llm.RealtimeModel):
         pronunciation_dictionary: NotGivenOr[list[PronunciationEntry]] = NOT_GIVEN,
         template_variables: NotGivenOr[dict[str, str]] = NOT_GIVEN,
         enable_redaction: NotGivenOr[bool] = NOT_GIVEN,
+        enable_watermarking: NotGivenOr[bool] = NOT_GIVEN,
         mcp_servers: NotGivenOr[list[str]] = NOT_GIVEN,
         observability_integrations: NotGivenOr[list[ObservabilityIntegration]] = NOT_GIVEN,
         configuration_endpoint: NotGivenOr[ConfigurationEndpoint | None] = NOT_GIVEN,
@@ -474,6 +480,7 @@ class RealtimeModel(llm.RealtimeModel):
                 pronunciation_dictionary=pronunciation_dictionary,
                 template_variables=template_variables,
                 enable_redaction=enable_redaction,
+                enable_watermarking=enable_watermarking,
                 mcp_servers=mcp_servers,
                 observability_integrations=observability_integrations,
                 configuration_endpoint=configuration_endpoint,
@@ -839,6 +846,7 @@ class RealtimeSession(llm.RealtimeSession):
             "pronunciation_dictionary": self._opts.pronunciation_dictionary,
             "template_variables": self._opts.template_variables,
             "enable_redaction": self._opts.enable_redaction,
+            "enable_watermarking": self._opts.enable_watermarking,
             "mcp_servers": self._opts.mcp_servers,
             "observability_integrations": self._opts.observability_integrations,
             "configuration_endpoint": self._opts.configuration_endpoint,
@@ -879,6 +887,7 @@ class RealtimeSession(llm.RealtimeSession):
         pronunciation_dictionary: NotGivenOr[list[PronunciationEntry]] = NOT_GIVEN,
         template_variables: NotGivenOr[dict[str, str]] = NOT_GIVEN,
         enable_redaction: NotGivenOr[bool] = NOT_GIVEN,
+        enable_watermarking: NotGivenOr[bool] = NOT_GIVEN,
         mcp_servers: NotGivenOr[list[str]] = NOT_GIVEN,
         observability_integrations: NotGivenOr[list[ObservabilityIntegration]] = NOT_GIVEN,
         configuration_endpoint: NotGivenOr[ConfigurationEndpoint | None] = NOT_GIVEN,
@@ -919,6 +928,7 @@ class RealtimeSession(llm.RealtimeSession):
                 ("pronunciation_dictionary", pronunciation_dictionary),
                 ("template_variables", template_variables),
                 ("enable_redaction", enable_redaction),
+                ("enable_watermarking", enable_watermarking),
                 ("mcp_servers", mcp_servers),
                 ("observability_integrations", observability_integrations),
                 ("configuration_endpoint", configuration_endpoint),


### PR DESCRIPTION
Adds an `enable_watermarking` option to the Phonic realtime plugin, gating Phonic's inaudible provenance watermark on the agent's generated audio. Boolean, off by default; adds a very small amount of latency when enabled.

Mirrors the existing `enable_redaction` option across `RealtimeModel.__init__`, `update_options` (model + session), the config message sent to Phonic, and the README.

Draft — depends on Phonic's `enable_watermarking` per-agent config reaching prod (control plane + engine); harmless to send before then (Phonic ignores unknown config fields).