### PR TITLE
fix(xai): match id-less delete acks to the oldest pending delete

### DIFF
--- a/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-xai/livekit/plugins/xai/realtime/realtime_model.py
@@ -424,8 +424,13 @@ class RealtimeSession(openai.realtime.RealtimeSession):
         super()._handle_conversion_item_added(event)
 
     def _handle_conversion_item_deleted(self, event: ConversationItemDeletedEvent) -> None:
-        if event.item_id == "" and self._item_delete_future:
-            event.item_id = list(self._item_delete_future.keys())[0]
+        if event.item_id == "":
+            # xAI omits the id, so the ack answers the oldest delete still waiting; one the
+            # server already rejected by event id is settled and cannot be the one acked
+            for item_id, fut in self._item_delete_future.items():
+                if not fut.done():
+                    event.item_id = item_id
+                    break
         super()._handle_conversion_item_deleted(event)
 
     def _handle_conversion_item_input_audio_transcription_completed(

--- a/scripts/xai-realtime-repro/README.md
+++ b/scripts/xai-realtime-repro/README.md
@@ -32,7 +32,7 @@ Hermetic coverage for the id-less delete-ack fix:
 ```bash
 ./scripts/xai-realtime-repro/run.sh unit
 # same as:
-uv run pytest tests/test_realtime/test_xai_realtime_model.py -q
+uv run pytest tests/test_realtime/test_xai_realtime_model.py --unit -q
 ```
 
 Expect every test to pass (including

--- a/scripts/xai-realtime-repro/README.md
+++ b/scripts/xai-realtime-repro/README.md
@@ -1,0 +1,107 @@
+# xAI realtime local repro harness
+
+Local probes for three xAI realtime situations that show up next to the
+id-less delete-ack hang fix. Run them from the monorepo root after
+`make install`.
+
+## Setup
+
+```bash
+make install
+export XAI_API_KEY=...          # required for live probes
+# optional:
+# export XAI_REALTIME_MODEL=grok-voice-latest
+# export XAI_RECYCLE_SECONDS=45
+```
+
+Live probes talk to `wss://api.x.ai/v1/realtime`. They do not need LiveKit
+room credentials for the default path.
+
+## Commands
+
+Entrypoint:
+
+```bash
+./scripts/xai-realtime-repro/run.sh <unit|ref-probe|recycle|context|all>
+```
+
+### 1. Mid-session hang / delete-ack (unit) + `$ref` probe
+
+Hermetic coverage for the id-less delete-ack fix:
+
+```bash
+./scripts/xai-realtime-repro/run.sh unit
+# same as:
+uv run pytest tests/test_realtime/test_xai_realtime_model.py -q
+```
+
+Expect every test to pass (including
+`test_delete_ack_without_id_answers_the_oldest_pending_delete`).
+
+Live mid-session nested `$ref` tools update:
+
+```bash
+./scripts/xai-realtime-repro/run.sh ref-probe
+```
+
+Sends a tools `session.update` whose schema is named `NESTED_REF_RAW_SCHEMA`
+(nested `$ref` / `$defs`), then `response.create`.
+
+- **PASS:** tools update accepted and a response completes without a schema error
+- **FAIL:** connection error, timeout, or server `error` after the tools update
+
+### 2. Websocket recycle / long-lived session
+
+```bash
+# print construction notes only (no network)
+./scripts/xai-realtime-repro/run.sh recycle --dry-log
+
+# live demo with a short recycle window (default 45s)
+./scripts/xai-realtime-repro/run.sh recycle
+```
+
+The plugin default is `max_session_duration=None` (no recycle). OpenAI
+realtime defaults to 20 minutes. Callers can opt in today:
+
+```python
+from livekit.plugins.xai.realtime import RealtimeModel
+
+RealtimeModel()  # no recycle
+RealtimeModel(max_session_duration=20 * 60)  # production-like
+RealtimeModel(max_session_duration=45)  # local demo
+```
+
+What to watch on a live run:
+
+- log lines about reconnecting / reconnected
+- the `session_reconnected` event (this script treats that as **PASS**)
+
+### 3. Context loss across turns
+
+```bash
+./scripts/xai-realtime-repro/run.sh context
+```
+
+Seeds a secret code, runs a few filler turns, then asks for the code again.
+Only `XAI_API_KEY` is required. If `LIVEKIT_*` is set, the script notes that
+and still uses the websocket path.
+
+- **PASS:** the recall reply contains `BLUE-ORBIT-7`
+- **FAIL:** the code is missing from the recall reply, or the socket errors
+
+The probe also prints `WARNING` lines and a final count when conversation
+item events omit `item_id` / `previous_item_id` (or empty `item.id`).
+
+## All
+
+```bash
+./scripts/xai-realtime-repro/run.sh all
+```
+
+Runs `unit`, then the three live probes. Live steps fail fast if
+`XAI_API_KEY` is unset.
+
+## Notes
+
+- No API keys belong in this directory.
+- These scripts are for local diagnosis. They are not part of the pytest gate.

--- a/scripts/xai-realtime-repro/common.py
+++ b/scripts/xai-realtime-repro/common.py
@@ -1,0 +1,118 @@
+"""Shared helpers for local xAI realtime repro probes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import aiohttp
+
+XAI_REALTIME_URL = "wss://api.x.ai/v1/realtime"
+DEFAULT_MODEL = os.environ.get("XAI_REALTIME_MODEL", "grok-voice-latest")
+
+
+def require_xai_api_key() -> str:
+    key = os.environ.get("XAI_API_KEY")
+    if not key:
+        print("FAIL: set XAI_API_KEY in the environment", file=sys.stderr)
+        raise SystemExit(1)
+    return key
+
+
+def pass_fail(ok: bool, message: str) -> int:
+    label = "PASS" if ok else "FAIL"
+    print(f"{label}: {message}")
+    return 0 if ok else 1
+
+
+async def open_realtime_ws(
+    api_key: str,
+) -> tuple[aiohttp.ClientSession, aiohttp.ClientWebSocketResponse]:
+    session = aiohttp.ClientSession()
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "User-Agent": "LiveKit Agents xAI repro",
+    }
+    try:
+        ws = await session.ws_connect(XAI_REALTIME_URL, headers=headers)
+    except Exception:
+        await session.close()
+        raise
+    return session, ws
+
+
+async def send_event(ws: aiohttp.ClientWebSocketResponse, event: dict[str, Any]) -> None:
+    await ws.send_str(json.dumps(event))
+
+
+async def recv_json(
+    ws: aiohttp.ClientWebSocketResponse,
+    *,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    msg = await asyncio.wait_for(ws.receive(), timeout=timeout)
+    if msg.type == aiohttp.WSMsgType.TEXT:
+        data = json.loads(msg.data)
+        if not isinstance(data, dict):
+            raise TypeError(f"expected JSON object, got {type(data).__name__}")
+        return data
+    if msg.type == aiohttp.WSMsgType.ERROR:
+        raise RuntimeError(f"websocket error: {ws.exception()}")
+    if msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED):
+        raise RuntimeError("websocket closed")
+    raise RuntimeError(f"unexpected websocket message type: {msg.type}")
+
+
+async def wait_for_event(
+    ws: aiohttp.ClientWebSocketResponse,
+    predicate: Callable[[dict[str, Any]], bool],
+    *,
+    timeout: float = 45.0,
+    on_event: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise TimeoutError("timed out waiting for matching event")
+        event = await recv_json(ws, timeout=remaining)
+        if on_event is not None:
+            on_event(event)
+        if predicate(event):
+            return event
+
+
+async def drain_until(
+    ws: aiohttp.ClientWebSocketResponse,
+    predicate: Callable[[dict[str, Any]], bool],
+    *,
+    timeout: float = 45.0,
+    on_event: Callable[[dict[str, Any]], None] | None = None,
+) -> list[dict[str, Any]]:
+    seen: list[dict[str, Any]] = []
+
+    def _capture(event: dict[str, Any]) -> None:
+        seen.append(event)
+        if on_event is not None:
+            on_event(event)
+
+    await wait_for_event(ws, predicate, timeout=timeout, on_event=_capture)
+    return seen
+
+
+def event_error_message(event: dict[str, Any]) -> str | None:
+    if event.get("type") != "error":
+        return None
+    err = event.get("error") or {}
+    if isinstance(err, dict):
+        return str(err.get("message") or err.get("code") or err)
+    return str(err)
+
+
+def run_async(main: Callable[[], Awaitable[int]]) -> None:
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/xai-realtime-repro/context_probe.py
+++ b/scripts/xai-realtime-repro/context_probe.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Multi-turn context probe: seed a fact, filler turns, ask for the fact back."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from common import (  # noqa: E402
+    DEFAULT_MODEL,
+    drain_until,
+    event_error_message,
+    open_realtime_ws,
+    pass_fail,
+    require_xai_api_key,
+    run_async,
+    send_event,
+)
+
+SECRET = "BLUE-ORBIT-7"
+
+
+def _missing_id_fields(event: dict[str, Any]) -> list[str]:
+    etype = str(event.get("type") or "")
+    if not etype.startswith("conversation.item"):
+        return []
+    missing: list[str] = []
+    if "item_id" in event and not event.get("item_id"):
+        missing.append("item_id")
+    if "previous_item_id" in event and event.get("previous_item_id") in (None, ""):
+        missing.append("previous_item_id")
+    item = event.get("item")
+    if isinstance(item, dict) and "id" in item and not item.get("id"):
+        missing.append("item.id")
+    return missing
+
+
+def _collect_text(events: list[dict[str, Any]]) -> str:
+    chunks: list[str] = []
+    for event in events:
+        etype = event.get("type")
+        if etype in {"response.text.delta", "response.output_text.delta"}:
+            delta = event.get("delta")
+            if isinstance(delta, str):
+                chunks.append(delta)
+        elif etype in {"response.audio_transcript.delta"}:
+            delta = event.get("delta")
+            if isinstance(delta, str):
+                chunks.append(delta)
+        elif etype == "response.done":
+            resp = event.get("response") or {}
+            for output in resp.get("output") or []:
+                if not isinstance(output, dict):
+                    continue
+                for content in output.get("content") or []:
+                    if not isinstance(content, dict):
+                        continue
+                    for key in ("text", "transcript"):
+                        val = content.get(key)
+                        if isinstance(val, str):
+                            chunks.append(val)
+    return "".join(chunks)
+
+
+async def _user_turn(
+    ws: Any,
+    text: str,
+    *,
+    missing_counts: dict[str, int],
+) -> str:
+    errors: list[str] = []
+
+    def on_event(event: dict[str, Any]) -> None:
+        msg = event_error_message(event)
+        if msg:
+            errors.append(msg)
+            print(f"server error: {msg}", file=sys.stderr)
+        for field in _missing_id_fields(event):
+            missing_counts[field] = missing_counts.get(field, 0) + 1
+            print(f"WARNING: missing {field} on {event.get('type')}")
+
+    await send_event(
+        ws,
+        {
+            "type": "conversation.item.create",
+            "item": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}],
+            },
+        },
+    )
+    await send_event(
+        ws,
+        {
+            "type": "response.create",
+            "response": {"modalities": ["text"]},
+        },
+    )
+    events = await drain_until(
+        ws,
+        lambda e: e.get("type") in {"response.done", "response.completed"}
+        or event_error_message(e) is not None,
+        timeout=60.0,
+        on_event=on_event,
+    )
+    if errors:
+        raise RuntimeError(errors[0])
+    return _collect_text(events)
+
+
+async def main() -> int:
+    api_key = require_xai_api_key()
+    missing_counts: dict[str, int] = {}
+
+    livekit_ready = all(
+        os.environ.get(name)
+        for name in ("LIVEKIT_URL", "LIVEKIT_API_KEY", "LIVEKIT_API_SECRET")
+    )
+    if livekit_ready:
+        print(
+            "note: LIVEKIT_* is set; this default path still uses the raw websocket "
+            "so you can repro without a room."
+        )
+    else:
+        print("note: default path needs only XAI_API_KEY (no LiveKit room).")
+
+    http, ws = await open_realtime_ws(api_key)
+    try:
+        await drain_until(
+            ws,
+            lambda e: e.get("type") in {"session.created", "session.updated"},
+            timeout=30.0,
+        )
+        await send_event(
+            ws,
+            {
+                "type": "session.update",
+                "session": {
+                    "type": "realtime",
+                    "model": DEFAULT_MODEL,
+                    "instructions": (
+                        "You are a concise text assistant. Remember facts the user states. "
+                        "Answer in one short sentence."
+                    ),
+                },
+            },
+        )
+        await drain_until(ws, lambda e: e.get("type") == "session.updated", timeout=30.0)
+
+        await _user_turn(
+            ws,
+            f"Remember that the secret code is {SECRET}. Confirm with the word remembered.",
+            missing_counts=missing_counts,
+        )
+        for i, filler in enumerate(
+            (
+                "What is 2+2? Reply with just the number.",
+                "Name a primary color in one word.",
+                "Reply with the word ready.",
+            ),
+            start=1,
+        ):
+            reply = await _user_turn(ws, filler, missing_counts=missing_counts)
+            print(f"filler turn {i} reply: {reply!r}")
+
+        final = await _user_turn(
+            ws,
+            "What is the secret code? Reply with only the code.",
+            missing_counts=missing_counts,
+        )
+        print(f"recall reply: {final!r}")
+        print(f"missing id field counts: {missing_counts or '{}'}")
+
+        ok = SECRET in final
+        return pass_fail(
+            ok,
+            f"context held ({SECRET} in reply)" if ok else f"context lost; reply={final!r}",
+        )
+    except Exception as exc:
+        return pass_fail(False, f"context-probe error: {exc}")
+    finally:
+        await ws.close()
+        await http.close()
+
+
+if __name__ == "__main__":
+    run_async(main)

--- a/scripts/xai-realtime-repro/recycle_demo.py
+++ b/scripts/xai-realtime-repro/recycle_demo.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Demonstrate xAI RealtimeModel websocket recycle via max_session_duration."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from common import pass_fail, require_xai_api_key, run_async  # noqa: E402
+
+
+def _print_construction_notes(seconds: float) -> None:
+    print("Construction without recycle (plugin default):")
+    print("  from livekit.plugins.xai.realtime import RealtimeModel")
+    print("  model = RealtimeModel()  # max_session_duration=None")
+    print()
+    print("Construction with production-like 20m recycle:")
+    print("  model = RealtimeModel(max_session_duration=20 * 60)")
+    print()
+    print(f"This demo uses max_session_duration={seconds} so reconnect is observable locally.")
+    print("Watch for: reconnecting / reconnected log lines, and session_reconnected.")
+
+
+async def _run_live(seconds: float) -> int:
+    require_xai_api_key()
+
+    from livekit.plugins.xai.realtime import RealtimeModel
+
+    _print_construction_notes(seconds)
+
+    model = RealtimeModel(max_session_duration=seconds)
+    session = model.session()
+    reconnected = asyncio.Event()
+
+    def _on_reconnected(_: object) -> None:
+        print("event: session_reconnected")
+        reconnected.set()
+
+    session.on("session_reconnected", _on_reconnected)
+
+    print(f"recycle timer armed for {seconds}s; watching for session_reconnected")
+    try:
+        # give the websocket a moment to come up before the recycle sleep starts counting
+        await asyncio.sleep(2.0)
+        try:
+            await asyncio.wait_for(reconnected.wait(), timeout=seconds + 30.0)
+        except TimeoutError:
+            return pass_fail(
+                False,
+                f"session_reconnected did not fire within {seconds + 30:.0f}s",
+            )
+        return pass_fail(True, f"session_reconnected after ~{seconds}s max_session_duration")
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-log",
+        action="store_true",
+        help="Print construction notes only; do not connect",
+    )
+    args, _unknown = parser.parse_known_args()
+    seconds = float(os.environ.get("XAI_RECYCLE_SECONDS", "45"))
+    dry = args.dry_log or os.environ.get("XAI_RECYCLE_DRY", "") == "1"
+
+    if dry:
+        _print_construction_notes(seconds)
+        return pass_fail(True, "dry-log only; no websocket opened")
+
+    return await _run_live(seconds)
+
+
+if __name__ == "__main__":
+    run_async(main)

--- a/scripts/xai-realtime-repro/ref_probe.py
+++ b/scripts/xai-realtime-repro/ref_probe.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Mid-session nested $ref tools update + response.create probe against xAI realtime."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from common import (  # noqa: E402
+    DEFAULT_MODEL,
+    drain_until,
+    event_error_message,
+    open_realtime_ws,
+    pass_fail,
+    require_xai_api_key,
+    run_async,
+    send_event,
+)
+
+NESTED_REF_RAW_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "name": "NESTED_REF_RAW_SCHEMA",
+    "description": "Lookup a catalog item by nested reference fields.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "item": {"$ref": "#/$defs/catalog_item"},
+        },
+        "required": ["item"],
+        "$defs": {
+            "catalog_item": {
+                "type": "object",
+                "properties": {
+                    "sku": {"type": "string"},
+                    "location": {"$ref": "#/$defs/warehouse_bin"},
+                },
+                "required": ["sku", "location"],
+            },
+            "warehouse_bin": {
+                "type": "object",
+                "properties": {
+                    "aisle": {"type": "string"},
+                    "shelf": {"type": "string"},
+                },
+                "required": ["aisle", "shelf"],
+            },
+        },
+    },
+}
+
+
+async def main() -> int:
+    api_key = require_xai_api_key()
+    http, ws = await open_realtime_ws(api_key)
+    try:
+        await drain_until(
+            ws,
+            lambda e: e.get("type") in {"session.created", "session.updated"},
+            timeout=30.0,
+        )
+
+        await send_event(
+            ws,
+            {
+                "type": "session.update",
+                "session": {
+                    "type": "realtime",
+                    "model": DEFAULT_MODEL,
+                    "instructions": (
+                        "You are a concise text assistant. "
+                        "If tools are available, acknowledge them briefly."
+                    ),
+                    "tools": [NESTED_REF_RAW_SCHEMA],
+                    "tool_choice": "auto",
+                },
+            },
+        )
+
+        tool_errors: list[str] = []
+
+        def note_errors(event: dict[str, Any]) -> None:
+            msg = event_error_message(event)
+            if msg:
+                tool_errors.append(msg)
+                print(f"server error: {msg}", file=sys.stderr)
+
+        await drain_until(
+            ws,
+            lambda e: e.get("type") == "session.updated" or event_error_message(e) is not None,
+            timeout=30.0,
+            on_event=note_errors,
+        )
+        if tool_errors:
+            return pass_fail(False, f"session.update rejected tools: {tool_errors[0]}")
+
+        await send_event(
+            ws,
+            {
+                "type": "response.create",
+                "response": {
+                    "modalities": ["text"],
+                    "instructions": "Reply with exactly: tools_ok",
+                },
+            },
+        )
+
+        events = await drain_until(
+            ws,
+            lambda e: e.get("type") in {"response.done", "response.completed"}
+            or event_error_message(e) is not None,
+            timeout=45.0,
+            on_event=note_errors,
+        )
+        if tool_errors:
+            return pass_fail(False, f"response path failed after $ref tools: {tool_errors[0]}")
+
+        types = {e.get("type") for e in events}
+        if "response.created" not in types and not any(
+            t and str(t).startswith("response.") for t in types
+        ):
+            return pass_fail(False, "no response.* events after response.create")
+
+        return pass_fail(
+            True,
+            "mid-session nested $ref tools update accepted; response completed",
+        )
+    except Exception as exc:
+        return pass_fail(False, f"ref-probe error: {exc}")
+    finally:
+        await ws.close()
+        await http.close()
+
+
+if __name__ == "__main__":
+    run_async(main)

--- a/scripts/xai-realtime-repro/run.sh
+++ b/scripts/xai-realtime-repro/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$DIR/../.." && pwd)"
+export PATH="${HOME}/.local/bin:${PATH}"
+
+usage() {
+  cat <<EOF
+Usage: $0 <command>
+
+Commands:
+  unit        Run hermetic xAI realtime unit tests (delete-ack coverage)
+  ref-probe   Live mid-session nested \$ref tools + response.create probe
+  recycle     Websocket recycle demo (max_session_duration); pass --dry-log offline
+  context     Multi-turn context retention probe
+  all         unit, then live probes (live steps need XAI_API_KEY)
+
+Env:
+  XAI_API_KEY            required for ref-probe, recycle (live), context
+  XAI_REALTIME_MODEL     default grok-voice-latest
+  XAI_RECYCLE_SECONDS    default 45
+  XAI_RECYCLE_DRY=1      same as recycle --dry-log
+EOF
+}
+
+run_unit() {
+  cd "$ROOT"
+  uv run pytest tests/test_realtime/test_xai_realtime_model.py -q
+}
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+  unit)
+    run_unit
+    ;;
+  ref-probe)
+    cd "$ROOT"
+    uv run python "$DIR/ref_probe.py"
+    ;;
+  recycle)
+    cd "$ROOT"
+    uv run python "$DIR/recycle_demo.py" "$@"
+    ;;
+  context)
+    cd "$ROOT"
+    uv run python "$DIR/context_probe.py"
+    ;;
+  all)
+    run_unit
+    cd "$ROOT"
+    uv run python "$DIR/ref_probe.py"
+    uv run python "$DIR/recycle_demo.py" "$@"
+    uv run python "$DIR/context_probe.py"
+    ;;
+  ""|-h|--help|help)
+    usage
+    ;;
+  *)
+    echo "unknown command: $cmd" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/xai-realtime-repro/run.sh
+++ b/scripts/xai-realtime-repro/run.sh
@@ -26,7 +26,7 @@ EOF
 
 run_unit() {
   cd "$ROOT"
-  uv run pytest tests/test_realtime/test_xai_realtime_model.py -q
+  uv run pytest tests/test_realtime/test_xai_realtime_model.py --unit -q
 }
 
 cmd="${1:-}"

--- a/tests/test_realtime/test_xai_realtime_model.py
+++ b/tests/test_realtime/test_xai_realtime_model.py
@@ -7,12 +7,14 @@ import pytest
 from openai.types.realtime import (
     ConversationItemAdded,
     ConversationItemCreateEvent,
+    ConversationItemDeletedEvent,
     ConversationItemDeleteEvent,
     ConversationItemInputAudioTranscriptionCompletedEvent,
     InputAudioBufferSpeechStartedEvent,
     RealtimeAudioConfig,
     RealtimeAudioConfigInput,
     RealtimeAudioConfigOutput,
+    RealtimeErrorEvent,
     RealtimeSessionCreateRequest,
     ResponseAudioDeltaEvent,
     ResponseCreatedEvent,
@@ -489,6 +491,64 @@ def test_held_turn_keeps_the_reply_anchored_behind_it() -> None:
         if isinstance(ev, ConversationItemCreateEvent)
     }
     assert created == {"reply": "item_1"}, "the truncated reply must stay behind the user turn"
+
+
+def _reject_by_event_id(session: RealtimeSession, event_id: str) -> None:
+    session._handle_error(
+        RealtimeErrorEvent.construct(
+            type="error",
+            event_id="evt",
+            error={
+                "type": "invalid_request_error",
+                "code": "item_delete_invalid_item_id",
+                "message": "no such item",
+                "event_id": event_id,
+            },
+        )
+    )
+
+
+def _deleted_without_id(session: RealtimeSession) -> None:
+    session._handle_conversion_item_deleted(
+        ConversationItemDeletedEvent.construct(
+            type="conversation.item.deleted", event_id="evt", item_id=""
+        )
+    )
+
+
+def test_delete_ack_without_id_answers_the_oldest_pending_delete() -> None:
+    # xAI acks a delete with item_id "", so the ack is matched to the deletes update_chat_ctx
+    # still waits on. one the server already rejected by event id is settled and must be skipped,
+    # or the ack removes the wrong item from the mirror and the real one waits out the timeout
+    session, _ = _make_session()
+    session._response_created_futures = {}  # type: ignore[attr-defined]
+    _mirror(session, ("phantom", "assistant", "dropped server-side"), ("stale", "user", "old"))
+
+    phantom_fut: asyncio.Future[None] = asyncio.Future()
+    stale_fut: asyncio.Future[None] = asyncio.Future()
+    session._item_delete_future = {"phantom": phantom_fut, "stale": stale_fut}  # type: ignore[attr-defined]
+    session._chat_ctx_event_futures = {"chat_ctx_delete_phantom": phantom_fut}  # type: ignore[attr-defined]
+
+    _reject_by_event_id(session, "chat_ctx_delete_phantom")
+    assert isinstance(phantom_fut.exception(), llm.RealtimeError)
+
+    _deleted_without_id(session)
+
+    assert stale_fut.done() and stale_fut.exception() is None
+    assert [item.id for item in session._remote_chat_ctx.to_chat_ctx().items] == ["phantom"]
+
+
+def test_delete_acks_without_id_are_matched_in_order() -> None:
+    session, _ = _make_session()
+    _mirror(session, ("first", "user", "one"), ("second", "user", "two"))
+    futs = {"first": asyncio.Future(), "second": asyncio.Future()}
+    session._item_delete_future = dict(futs)  # type: ignore[attr-defined]
+
+    _deleted_without_id(session)
+    assert futs["first"].done() and not futs["second"].done()
+    _deleted_without_id(session)
+    assert futs["second"].done()
+    assert session._remote_chat_ctx.to_chat_ctx().items == []
 
 
 def test_an_item_anchored_to_an_unannounced_one_is_appended() -> None:


### PR DESCRIPTION
## Summary

xAI's realtime API acknowledges `conversation.item.delete` with an empty `item_id`. The plugin mapped that ack to the **first** pending delete future, which can already be a settled (rejected) one. The real delete then sat until `update_chat_ctx`'s 5s timeout, which looks like a mid-session hang.

This PR matches an id-less delete ack to the **oldest unsettled** pending delete instead.

## Changes

- Skip settled futures when pairing an empty-`item_id` delete ack
- Unit test covering the rejected-then-real-delete ordering
- Notes below on related xAI realtime behavior (not fixed here)

## Test plan

- [x] Unit test in `tests/test_realtime/test_xai_realtime_model.py`
- [ ] Live: mid-session tools/`update_chat_ctx` under load with xAI realtime

## Related findings (no code change)

These came up while digging the hang. Separate from the delete-ack bug:

1. **`$ref` in tool schemas** — Both OpenAI and xAI plugins forward `$ref`/`$defs` as-is. A live probe against xAI accepted a mid-session tools update with nested `$ref` and still produced a response. Field reports that stripping `$ref` helps may be conflating this with the `update_chat_ctx` timeout above.

2. **Long-lived sessions** — OpenAI realtime defaults `max_session_duration` to 20 minutes (websocket recycle). xAI defaults it to `None`. Callers can set `max_session_duration=20*60` today; changing the xAI default is a possible follow-up.

3. **Context / item IDs** — xAI often omits `item_id` / `previous_item_id` on conversation item events, so the plugin has to guess. Wrong guesses desync the mirror. Needs better IDs from xAI (see also livekit/agents#6391). This PR only fixes one wrong-guess path on delete acks.
