### PR TITLE
docs: add Parallel web search MCP example

### DIFF
--- a/examples/voice_agents/README.md
+++ b/examples/voice_agents/README.md
@@ -35,6 +35,7 @@ session = AgentSession(
 - [`mcp/`](./mcp/) - Model Context Protocol (MCP) integration examples
   - [`mcp-agent.py`](./mcp/mcp-agent.py) - Connecting an agent to an MCP server
   - [`server.py`](./mcp/server.py) - MCP server example
+  - [Remote web search with Parallel](./mcp/README.md#add-remote-web-search-with-parallel) - Add anonymous search and page extraction alongside the local tools
 
 ### RAG & Knowledge Management
 

--- a/examples/voice_agents/mcp/README.md
+++ b/examples/voice_agents/mcp/README.md
@@ -1,0 +1,48 @@
+# MCP examples
+
+[`mcp-agent.py`](./mcp-agent.py) connects to the local [`server.py`](./server.py)
+for simulated weather and flight booking tools. The booking tool demonstrates
+progress notifications and cancellation.
+
+## Add remote web search with Parallel
+
+You can add public web search and page extraction to the same agent using
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp).
+The anonymous endpoint needs no Parallel account, API key, or authorization
+header. Free access is rate limited.
+
+The voice examples already include the `livekit-agents[mcp]` dependency. In
+`mcp-agent.py`, add this entry to the existing `AgentSession(tools=[...])` list,
+alongside the local toolset:
+
+```python
+mcp.MCPToolset(
+    id="parallel_search",
+    mcp_server=mcp.MCPServerHTTP(
+        url="https://search.parallel.ai/mcp",
+        transport_type="streamable_http",
+        allowed_tools=["web_search", "web_fetch"],
+        # Web retrieval can take longer than the default five-second tool timeout.
+        client_session_timeout_seconds=30,
+    ),
+)
+```
+
+Keep the local server running for the existing weather and booking tools. The
+session connects to both servers and discovers their tools when it starts.
+There is no separate Parallel plugin or local Parallel server to run.
+
+Add guidance to `MyAgent`'s instructions, such as: "Use web_search for current
+public information and web_fetch to read a public URL. Name the sources you
+used, and say when retrieval fails instead of guessing."
+
+Once this toolset is enabled, the agent can invoke its tools during the
+conversation. Search queries, requested URLs, and any supplied objectives,
+context, or metadata are sent to Parallel. Avoid putting private conversation
+details in retrieval requests. Remove the added toolset and its instruction
+text to disable this integration.
+
+Anonymous search does not replace the voice agent's credentials. The existing
+LiveKit connection and LiveKit Inference still need their normal configuration
+and may incur charges. This addition keeps the agent's speech and inference
+settings, local tools, and booking progress/cancellation behavior unchanged.


### PR DESCRIPTION
This shows how to add public web search and page extraction to the existing MCP voice agent with Parallel. It uses `MCPToolset` and `MCPServerHTTP`, with Streamable HTTP and a 30-second tool timeout. The local travel example stays unchanged.

LiveKit [starts without search tools or MCP servers](https://github.com/livekit/agents/blob/d8607e6711bf9770bfd7e5476f79ab63e6a451a6/livekit-agents/livekit/agents/voice/agent_session.py#L626-L632), so there isn't a default search provider to replace. Of the vendors on Artificial Analysis's Search API leaderboard, Perplexity is the only existing overlap I found. Its [LiveKit plugin](https://github.com/livekit/agents/blob/d8607e6711bf9770bfd7e5476f79ab63e6a451a6/livekit-plugins/livekit-plugins-perplexity/README.md) uses answer APIs, rather than a search MCP.

For separate Search API context, AA compares Parallel with Perplexity Search, a different product from LiveKit's existing Perplexity answer integration. These figures do not establish cost savings or faster responses for that integration. In [Artificial Analysis's August 31 results](https://artificialanalysis.ai/agents/search-api), Parallel Search (fast) averages **19.2 seconds per task**, versus **28.6–37.1 seconds** across Perplexity Search's low, medium, and high configurations. Search cost is **$8.41 per 1,000 benchmark tasks**, versus **$56.93–$77.20**. That's about **33–48% less time and 85–89% lower search cost**. Perplexity does score higher on the overall quality index: 77–80 versus 73 for Parallel fast.

Those are Search API benchmark results, not measurements of this anonymous MCP endpoint or LiveKit's Perplexity plugin. AA's [methodology](https://artificialanalysis.ai/methodology/search-api) includes derived model time in time per task; the search costs above exclude model costs. For a voice agent, this is a reason to test Parallel, not a measured improvement in LiveKit.

The guide explains what goes to Parallel: queries, URLs, and supplied context. Anonymous access needs no Parallel key and is rate limited. LiveKit and inference credentials and charges remain separate.

Checked the exact Markdown snippet against the current LiveKit source using prebuilt dependencies: discovery, anonymous search and fetch, result parsing, and cleanup passed. Ruff, relative links, and diff checks also pass. No repository build, full test suite, or voice session was run.

I work at Parallel, which operates this service.
