### PR TITLE
fix(telemetry): describe option objects in the session report

### DIFF
--- a/livekit-agents/livekit/agents/inference/eot/detector.py
+++ b/livekit-agents/livekit/agents/inference/eot/detector.py
@@ -130,6 +130,24 @@ class TurnDetector(_BaseStreamingTurnDetector):
     def model(self) -> TurnDetectorModels:
         return self._model
 
+    @property
+    def sample_rate(self) -> int:
+        return self._opts.sample_rate
+
+    @property
+    def local_fallback(self) -> bool:
+        return self._local_fallback
+
+    @property
+    def threshold_overrides(self) -> NotGivenOr[float | dict[str, float]]:
+        """User ``unlikely_threshold`` override(s); NOT_GIVEN when server defaults apply."""
+        return self._opts.thresholds.overrides
+
+    @property
+    def backchannel_threshold_overrides(self) -> NotGivenOr[float | dict[str, float]]:
+        """User ``backchannel_threshold`` override(s); NOT_GIVEN when server defaults apply."""
+        return self._opts.thresholds.backchannel_overrides
+
     def _warn_threshold_override(self) -> None:
         thresholds = self._opts.thresholds
         if is_given(overrides := thresholds.overrides):

--- a/livekit-agents/livekit/agents/inference/eot/detector.py
+++ b/livekit-agents/livekit/agents/inference/eot/detector.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from typing import Any
 
 import aiohttp
 
@@ -130,23 +131,22 @@ class TurnDetector(_BaseStreamingTurnDetector):
     def model(self) -> TurnDetectorModels:
         return self._model
 
-    @property
-    def sample_rate(self) -> int:
-        return self._opts.sample_rate
-
-    @property
-    def local_fallback(self) -> bool:
-        return self._local_fallback
-
-    @property
-    def threshold_overrides(self) -> NotGivenOr[float | dict[str, float]]:
-        """User ``unlikely_threshold`` override(s); NOT_GIVEN when server defaults apply."""
-        return self._opts.thresholds.overrides
-
-    @property
-    def backchannel_threshold_overrides(self) -> NotGivenOr[float | dict[str, float]]:
-        """User ``backchannel_threshold`` override(s); NOT_GIVEN when server defaults apply."""
-        return self._opts.thresholds.backchannel_overrides
+    def describe_options(self) -> dict[str, Any]:
+        """What the session report shows for this detector (``telemetry.DescribesOptions``):
+        the model and where it runs, plus the threshold overrides when the user set any.
+        Server-calibrated defaults are not repeated here; credentials and endpoints never."""
+        options: dict[str, Any] = {
+            "model": self.model,
+            "provider": self.provider,
+            "sample_rate": self._opts.sample_rate,
+            "local_fallback": self._local_fallback,
+        }
+        thresholds = self._opts.thresholds
+        if is_given(thresholds.overrides):
+            options["threshold_overrides"] = thresholds.overrides
+        if is_given(thresholds.backchannel_overrides):
+            options["backchannel_threshold_overrides"] = thresholds.backchannel_overrides
+        return options
 
     def _warn_threshold_override(self) -> None:
         thresholds = self._opts.thresholds

--- a/livekit-agents/livekit/agents/telemetry/__init__.py
+++ b/livekit-agents/livekit/agents/telemetry/__init__.py
@@ -1,5 +1,6 @@
 from . import gen_ai, http_server, metrics, otel_metrics, pii, trace_types, utils
 from .traces import (
+    DescribesOptions,
     _setup_cloud_tracer,
     _upload_session_report,
     set_tracer_provider,
@@ -7,6 +8,7 @@ from .traces import (
 )
 
 __all__ = [
+    "DescribesOptions",
     "tracer",
     "gen_ai",
     "pii",

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -71,6 +71,7 @@ from ..types import (
     ATTRIBUTE_SIMULATION_ENABLED,
     recording_enabled,
 )
+from ..utils import is_given
 from . import pii, trace_types, utils as telemetry_utils
 
 if TYPE_CHECKING:
@@ -85,16 +86,65 @@ _SESSION_OPTION_KEY_ALIASES = {
 }
 
 
-def _serialize_session_options(options: AgentSessionOptions) -> dict[str, Any]:
-    def _serialize(value: dict[str, Any]) -> dict[str, Any]:
-        return {
-            _SESSION_OPTION_KEY_ALIASES.get(key, key): (
-                _serialize(nested_value) if isinstance(nested_value, dict) else nested_value
-            )
-            for key, nested_value in value.items()
-        }
+# Public, non-callable attributes worth showing when a model-like object (turn detector,
+# interruption detector, ...) appears in the session options. Read in this order; missing,
+# NOT_GIVEN and None values are skipped. Kept to a whitelist so a plugin's credentials or
+# internals never end up in the report.
+_OPTION_OBJECT_DESCRIPTOR_ATTRS = (
+    "model",
+    "provider",
+    "label",
+    "sample_rate",
+    "local_fallback",
+    "threshold_overrides",
+    "backchannel_threshold_overrides",
+)
 
-    return _serialize(vars(options))
+_OPTION_PRIMITIVES = (str, bool, int, float)
+
+
+def _describe_option_object(obj: object) -> str:
+    """Render a model-like object from the session options as ``ClassName(k=v, ...)``.
+
+    The OTel log exporter stringifies anything that is not a primitive, which for these
+    objects yields the default ``<... object at 0x...>`` repr. Build a stable description
+    from whitelisted public attributes instead.
+    """
+    parts: list[str] = []
+    for name in _OPTION_OBJECT_DESCRIPTOR_ATTRS:
+        try:
+            value = getattr(obj, name)
+        except Exception:
+            continue
+        if value is None or not is_given(value) or callable(value):
+            continue
+        if isinstance(value, Mapping):
+            rendered = json.dumps(value, sort_keys=True, default=str)
+        elif isinstance(value, _OPTION_PRIMITIVES):
+            rendered = str(value)
+        else:
+            continue
+        parts.append(f"{name}={rendered}")
+    return f"{type(obj).__name__}({', '.join(parts)})"
+
+
+def _serialize_option_value(value: Any) -> Any:
+    if value is None or isinstance(value, _OPTION_PRIMITIVES):
+        return value
+    if isinstance(value, Mapping):
+        return {
+            _SESSION_OPTION_KEY_ALIASES.get(k, k): _serialize_option_value(v)
+            for k, v in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_serialize_option_value(v) for v in value]
+    return _describe_option_object(value)
+
+
+def _serialize_session_options(options: AgentSessionOptions) -> dict[str, Any]:
+    serialized = _serialize_option_value(vars(options))
+    assert isinstance(serialized, dict)
+    return serialized
 
 
 class _DynamicTracer(Tracer):

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -9,7 +9,7 @@ import random
 import threading
 import time
 import weakref
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence, Set
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
@@ -136,8 +136,11 @@ def _serialize_option_value(value: Any) -> Any:
             _SESSION_OPTION_KEY_ALIASES.get(k, k): _serialize_option_value(v)
             for k, v in value.items()
         }
-    if isinstance(value, (list, tuple)):
-        return [_serialize_option_value(v) for v in value]
+    if isinstance(value, (Sequence, Set)) and not isinstance(value, (str, bytes)):
+        # any Sequence is a valid option value (tts_text_transforms accepts one), so
+        # serialize the elements rather than collapsing the container to its class name
+        items = sorted(value, key=str) if isinstance(value, Set) else value
+        return [_serialize_option_value(v) for v in items]
     return _describe_option_object(value)
 
 

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -85,6 +85,11 @@ _SESSION_OPTION_KEY_ALIASES = {
     "keyterms": "lk.pii.keyterms",
 }
 
+# Option keys never written to the report: prompt text authored by the customer
+# (``stt_context_options.keyterm_detection.instructions``) can embed anything about their
+# business or users, and the report has no use for it.
+_SESSION_OPTION_OMITTED_KEYS = frozenset({"instructions"})
+
 
 # Public, non-callable attributes worth showing when a model-like object (turn detector,
 # interruption detector, ...) appears in the session options. Read in this order; missing,
@@ -135,6 +140,7 @@ def _serialize_option_value(value: Any) -> Any:
         return {
             _SESSION_OPTION_KEY_ALIASES.get(k, k): _serialize_option_value(v)
             for k, v in value.items()
+            if k not in _SESSION_OPTION_OMITTED_KEYS
         }
     if isinstance(value, (Sequence, Set)) and not isinstance(value, (str, bytes)):
         # any Sequence is a valid option value (tts_text_transforms accepts one), so

--- a/livekit-agents/livekit/agents/telemetry/traces.py
+++ b/livekit-agents/livekit/agents/telemetry/traces.py
@@ -12,7 +12,7 @@ import weakref
 from collections.abc import Callable, Iterator, Mapping, Sequence, Set
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import aiofiles
 import aiohttp
@@ -95,42 +95,49 @@ _SESSION_OPTION_OMITTED_KEYS = frozenset({"instructions"})
 # interruption detector, ...) appears in the session options. Read in this order; missing,
 # NOT_GIVEN and None values are skipped. Kept to a whitelist so a plugin's credentials or
 # internals never end up in the report.
-_OPTION_OBJECT_DESCRIPTOR_ATTRS = (
-    "model",
-    "provider",
-    "label",
-    "sample_rate",
-    "local_fallback",
-    "threshold_overrides",
-    "backchannel_threshold_overrides",
-)
-
 _OPTION_PRIMITIVES = (str, bool, int, float)
 
 
+@runtime_checkable
+class DescribesOptions(Protocol):
+    """An object that can appear in ``AgentSession`` options (a turn detector, a model) and
+    wants the session report to show its configuration.
+
+    Return the options worth reporting, keyed by name; values can be primitives, mappings
+    or sequences of them. Leave secrets and endpoints out: the report is uploaded. Objects
+    without this method are reported by class name alone."""
+
+    def describe_options(self) -> Mapping[str, Any]: ...
+
+
 def _describe_option_object(obj: object) -> str:
-    """Render a model-like object from the session options as ``ClassName(k=v, ...)``.
+    """Render an object from the session options as ``module.Class`` or, when it implements
+    :class:`DescribesOptions`, ``module.Class(k=v, ...)``.
 
     The OTel log exporter stringifies anything that is not a primitive, which for these
-    objects yields the default ``<... object at 0x...>`` repr. Build a stable description
-    from whitelisted public attributes instead.
-    """
+    objects yields the default ``<... object at 0x...>`` repr. The class alone is stable and
+    safe; the object itself decides what else is worth showing."""
+    cls = type(obj)
+    name = f"{cls.__module__}.{cls.__name__}"
+    describe = getattr(obj, "describe_options", None)
+    if not callable(describe):
+        return name
+    try:
+        options = describe()
+    except Exception:
+        logger.debug("describe_options() failed on %s", name, exc_info=True)
+        return name
     parts: list[str] = []
-    for name in _OPTION_OBJECT_DESCRIPTOR_ATTRS:
-        try:
-            value = getattr(obj, name)
-        except Exception:
+    for key, value in options.items():
+        if value is None or not is_given(value):
             continue
-        if value is None or not is_given(value) or callable(value):
-            continue
-        if isinstance(value, Mapping):
-            rendered = json.dumps(value, sort_keys=True, default=str)
-        elif isinstance(value, _OPTION_PRIMITIVES):
-            rendered = str(value)
-        else:
-            continue
-        parts.append(f"{name}={rendered}")
-    return f"{type(obj).__name__}({', '.join(parts)})"
+        rendered = (
+            str(value)
+            if isinstance(value, _OPTION_PRIMITIVES)
+            else json.dumps(_serialize_option_value(value), sort_keys=True, default=str)
+        )
+        parts.append(f"{key}={rendered}")
+    return f"{name}({', '.join(parts)})"
 
 
 def _serialize_option_value(value: Any) -> Any:

--- a/tests/test_session_options_report.py
+++ b/tests/test_session_options_report.py
@@ -1,0 +1,143 @@
+"""The session report ships ``session.options`` as a log attribute. The OTel exporter
+stringifies anything that is not a primitive, so an object left in the options (the turn
+detector, for one) used to reach the cloud as ``<... object at 0x...>``. These tests pin the
+descriptive form the serializer produces instead."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from livekit.agents import AgentSession, inference
+from livekit.agents.telemetry.traces import (
+    _describe_option_object,
+    _serialize_option_value,
+    _serialize_session_options,
+)
+from livekit.agents.types import NOT_GIVEN
+
+pytestmark = pytest.mark.unit
+
+
+def _turn_detection(serialized: dict[str, Any]) -> Any:
+    return serialized["turn_handling"]["turn_detection"]
+
+
+def _assert_report_safe(value: Any) -> None:
+    """Everything left after serialization must be JSON primitives, lists, or dicts."""
+    json.dumps(value)  # raises on anything the exporter would have to stringify
+    if isinstance(value, dict):
+        for v in value.values():
+            _assert_report_safe(v)
+    elif isinstance(value, list):
+        for v in value:
+            _assert_report_safe(v)
+    else:
+        assert value is None or isinstance(value, (str, bool, int, float))
+
+
+def test_default_turn_detector_is_described_not_reprd() -> None:
+    session = AgentSession()  # eager inference.TurnDetector() default
+    serialized = _serialize_session_options(session.options)
+
+    td = _turn_detection(serialized)
+    assert isinstance(td, str)
+    assert "object at 0x" not in td
+    assert td.startswith("TurnDetector(")
+    assert "model=turn-detector-" in td
+    assert "provider=livekit" in td
+    assert "sample_rate=16000" in td
+    assert "local_fallback=True" in td
+    # server-calibrated defaults in use: the override fields must be absent, not "NOT_GIVEN"
+    assert "threshold_overrides" not in td
+    assert "NOT_GIVEN" not in td
+    _assert_report_safe(serialized)
+
+
+def test_turn_detector_threshold_overrides_are_shown() -> None:
+    td = inference.TurnDetector(
+        version="v1-mini",
+        unlikely_threshold=0.2,
+        backchannel_threshold={"en": 0.7, "fr": 0.6},
+    )
+    desc = _describe_option_object(td)
+    assert "threshold_overrides=0.2" in desc
+    # dict overrides are rendered deterministically
+    assert 'backchannel_threshold_overrides={"en": 0.7, "fr": 0.6}' in desc
+
+
+def test_turn_detector_description_leaks_no_credentials() -> None:
+    td = inference.TurnDetector(
+        version="v1",
+        base_url="https://inference.example.com",
+        api_key="APIsecretkey123",
+        api_secret="verysecretvalue",
+    )
+    desc = _describe_option_object(td)
+    assert "APIsecretkey123" not in desc
+    assert "verysecretvalue" not in desc
+    assert "inference.example.com" not in desc
+
+
+def test_mode_strings_pass_through() -> None:
+    session = AgentSession(turn_handling={"turn_detection": "vad"})
+    assert _turn_detection(_serialize_session_options(session.options)) == "vad"
+
+    session = AgentSession(turn_handling={"turn_detection": "manual"})
+    assert _turn_detection(_serialize_session_options(session.options)) == "manual"
+
+
+def test_plugin_like_detector_uses_model_and_provider() -> None:
+    class ThirdPartyDetector:
+        @property
+        def model(self) -> str:
+            return "eou-v9"
+
+        @property
+        def provider(self) -> str:
+            return "acme"
+
+        # a method that happens to share a whitelisted name must never be rendered
+        def label(self) -> str:
+            return "not-an-attribute"
+
+        async def unlikely_threshold(self, language: str | None) -> float | None:
+            return 0.5
+
+    assert _describe_option_object(ThirdPartyDetector()) == (
+        "ThirdPartyDetector(model=eou-v9, provider=acme)"
+    )
+
+
+def test_object_without_descriptors_falls_back_to_class_name() -> None:
+    class Opaque:
+        pass
+
+    assert _describe_option_object(Opaque()) == "Opaque()"
+
+
+def test_not_given_and_none_attributes_are_skipped() -> None:
+    class Sparse:
+        model = "m"
+        provider = None
+        label = NOT_GIVEN
+
+    assert _describe_option_object(Sparse()) == "Sparse(model=m)"
+
+
+def test_nested_containers_and_key_aliases() -> None:
+    class Det:
+        model = "m"
+
+    value = {
+        "keyterms": ["LiveKit", "Acme"],
+        "nested": {"detector": Det(), "flags": (True, 1, 2.5, None)},
+    }
+    out = _serialize_option_value(value)
+    assert out == {
+        "lk.pii.keyterms": ["LiveKit", "Acme"],
+        "nested": {"detector": "Det(model=m)", "flags": [True, 1, 2.5, None]},
+    }
+    _assert_report_safe(out)

--- a/tests/test_session_options_report.py
+++ b/tests/test_session_options_report.py
@@ -156,6 +156,28 @@ def test_custom_sequence_and_set_values_keep_their_elements() -> None:
     _assert_report_safe(out)
 
 
+def test_customer_prompt_text_is_omitted() -> None:
+    # a keyterm-detection prompt override is customer-authored text; it never reaches the
+    # report, at any nesting depth
+    session = AgentSession(
+        stt_context_options={
+            "keyterms": ["Acme"],
+            "keyterm_detection": {
+                "enabled": True,
+                "instructions": "Extract product names for Acme customer Jane Doe",
+            },
+        }
+    )
+    serialized = _serialize_session_options(session.options)
+    detection = serialized["stt_context_options"]["keyterm_detection"]
+    assert "instructions" not in detection
+    assert detection["enabled"] is True
+    assert serialized["stt_context_options"]["lk.pii.keyterms"] == ["Acme"]
+    assert "Jane Doe" not in json.dumps(serialized)
+
+    assert _serialize_option_value({"a": {"instructions": "x", "keep": 1}}) == {"a": {"keep": 1}}
+
+
 def test_nested_containers_and_key_aliases() -> None:
     class Det:
         model = "m"

--- a/tests/test_session_options_report.py
+++ b/tests/test_session_options_report.py
@@ -6,6 +6,7 @@ descriptive form the serializer produces instead."""
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from typing import Any
 
 import pytest
@@ -125,6 +126,34 @@ def test_not_given_and_none_attributes_are_skipped() -> None:
         label = NOT_GIVEN
 
     assert _describe_option_object(Sparse()) == "Sparse(model=m)"
+
+
+def test_custom_sequence_and_set_values_keep_their_elements() -> None:
+    # tts_text_transforms accepts any Sequence; a user-defined one must not collapse to
+    # its class name
+    class Transforms(Sequence[str]):
+        def __init__(self, *items: str) -> None:
+            self._items = items
+
+        def __getitem__(self, i: Any) -> Any:
+            return self._items[i]
+
+        def __len__(self) -> int:
+            return len(self._items)
+
+    class Det:
+        model = "m"
+
+    out = _serialize_option_value(
+        {"tts_text_transforms": Transforms("filter_markdown", "filter_emoji"), "s": {2, 1}}
+    )
+    assert out == {
+        "tts_text_transforms": ["filter_markdown", "filter_emoji"],
+        "s": [1, 2],
+    }
+    assert _serialize_option_value(Transforms("a")) == ["a"]
+    assert _serialize_option_value([Det()]) == ["Det(model=m)"]
+    _assert_report_safe(out)
 
 
 def test_nested_containers_and_key_aliases() -> None:

--- a/tests/test_session_options_report.py
+++ b/tests/test_session_options_report.py
@@ -46,7 +46,7 @@ def test_default_turn_detector_is_described_not_reprd() -> None:
     td = _turn_detection(serialized)
     assert isinstance(td, str)
     assert "object at 0x" not in td
-    assert td.startswith("TurnDetector(")
+    assert td.startswith("livekit.agents.inference.eot.detector.TurnDetector(")
     assert "model=turn-detector-" in td
     assert "provider=livekit" in td
     assert "sample_rate=16000" in td
@@ -90,42 +90,40 @@ def test_mode_strings_pass_through() -> None:
     assert _turn_detection(_serialize_session_options(session.options)) == "manual"
 
 
-def test_plugin_like_detector_uses_model_and_provider() -> None:
+def test_object_implementing_describe_options_is_rendered_with_them() -> None:
     class ThirdPartyDetector:
-        @property
-        def model(self) -> str:
-            return "eou-v9"
-
-        @property
-        def provider(self) -> str:
-            return "acme"
-
-        # a method that happens to share a whitelisted name must never be rendered
-        def label(self) -> str:
-            return "not-an-attribute"
-
-        async def unlikely_threshold(self, language: str | None) -> float | None:
-            return 0.5
+        def describe_options(self) -> dict[str, Any]:
+            return {"model": "eou-v9", "provider": "acme", "thresholds": {"en": 0.7}}
 
     assert _describe_option_object(ThirdPartyDetector()) == (
-        "ThirdPartyDetector(model=eou-v9, provider=acme)"
+        f'{__name__}.ThirdPartyDetector(model=eou-v9, provider=acme, thresholds={{"en": 0.7}})'
     )
 
 
-def test_object_without_descriptors_falls_back_to_class_name() -> None:
+def test_object_without_describe_options_is_its_class_name() -> None:
+    # public attributes are not guessed at: a model-like object that does not opt in is
+    # reported by class alone, however tempting its `model` looks
     class Opaque:
-        pass
-
-    assert _describe_option_object(Opaque()) == "Opaque()"
-
-
-def test_not_given_and_none_attributes_are_skipped() -> None:
-    class Sparse:
         model = "m"
-        provider = None
-        label = NOT_GIVEN
+        provider = "acme"
 
-    assert _describe_option_object(Sparse()) == "Sparse(model=m)"
+    assert _describe_option_object(Opaque()) == f"{__name__}.Opaque"
+
+
+def test_describe_options_skips_none_and_not_given() -> None:
+    class Sparse:
+        def describe_options(self) -> dict[str, Any]:
+            return {"model": "m", "provider": None, "label": NOT_GIVEN}
+
+    assert _describe_option_object(Sparse()) == f"{__name__}.Sparse(model=m)"
+
+
+def test_failing_describe_options_falls_back_to_the_class_name() -> None:
+    class Broken:
+        def describe_options(self) -> dict[str, Any]:
+            raise RuntimeError("not ready")
+
+    assert _describe_option_object(Broken()) == f"{__name__}.Broken"
 
 
 def test_custom_sequence_and_set_values_keep_their_elements() -> None:
@@ -142,7 +140,8 @@ def test_custom_sequence_and_set_values_keep_their_elements() -> None:
             return len(self._items)
 
     class Det:
-        model = "m"
+        def describe_options(self) -> dict[str, Any]:
+            return {"model": "m"}
 
     out = _serialize_option_value(
         {"tts_text_transforms": Transforms("filter_markdown", "filter_emoji"), "s": {2, 1}}
@@ -152,7 +151,7 @@ def test_custom_sequence_and_set_values_keep_their_elements() -> None:
         "s": [1, 2],
     }
     assert _serialize_option_value(Transforms("a")) == ["a"]
-    assert _serialize_option_value([Det()]) == ["Det(model=m)"]
+    assert _serialize_option_value([Det()]) == [f"{__name__}.Det(model=m)"]
     _assert_report_safe(out)
 
 
@@ -180,7 +179,8 @@ def test_customer_prompt_text_is_omitted() -> None:
 
 def test_nested_containers_and_key_aliases() -> None:
     class Det:
-        model = "m"
+        def describe_options(self) -> dict[str, Any]:
+            return {"model": "m"}
 
     value = {
         "keyterms": ["LiveKit", "Acme"],
@@ -189,6 +189,6 @@ def test_nested_containers_and_key_aliases() -> None:
     out = _serialize_option_value(value)
     assert out == {
         "lk.pii.keyterms": ["LiveKit", "Acme"],
-        "nested": {"detector": "Det(model=m)", "flags": [True, 1, 2.5, None]},
+        "nested": {"detector": f"{__name__}.Det(model=m)", "flags": [True, 1, 2.5, None]},
     }
     _assert_report_safe(out)


### PR DESCRIPTION
## What

`session.options` in the session report carried the turn detector as its default repr:

```
turn_detection: "<livekit.agents.inference.eot.detector.TurnDetector object at 0x7fc5518a2a50>"
```

The OTel exporter stringifies any non-primitive log attribute, so anything left as an object in the options dict ends up like this.

## How

- `_serialize_session_options` now serializes explicitly: primitives pass through, mappings recurse, any non-string `Sequence` or `Set` is serialized elementwise (`tts_text_transforms` accepts any `Sequence`), and any other object is reported by class, `module.Class`. An object that wants its configuration shown implements the `telemetry.DescribesOptions` protocol, a `describe_options()` method returning the options worth reporting; it is then rendered as `module.Class(k=v, ...)`. The object decides what is safe to show, so nothing is guessed from public attributes and credentials and endpoints stay out by construction (test included; a failing `describe_options()` falls back to the class name).
- Customer-authored prompt text is never written to the report: `instructions` keys (the keyterm-detection prompt override) are dropped at any depth rather than emitted under an unmarked key.
- `TurnDetector` implements `describe_options()`: model, provider, sample rate, local fallback, and the threshold overrides only when the user set any. Mode strings (`"vad"`, `"manual"`, ...) pass through unchanged. Third-party detectors and models opt in the same way.

Result:

```
livekit.agents.inference.eot.detector.TurnDetector(model=turn-detector-v1-mini, provider=livekit, sample_rate=16000, local_fallback=True)
```

with `threshold_overrides` / `backchannel_threshold_overrides` appended only when the user set them.

## Tests

`tests/test_session_options_report.py` (unit): default detector description, threshold overrides, no credential leakage, mode strings, plugin-like objects, custom `Sequence` and `Set` values, omitted prompt text, nested containers and the `keyterms` PII alias, and a JSON-safety invariant on the whole serialized dict.

Bottom layer of the tracing coverage stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
