### PR TITLE
feat(telemetry): trace the end-of-turn wait and the turn handoff

### DIFF
--- a/livekit-agents/livekit/agents/telemetry/trace_types.py
+++ b/livekit-agents/livekit/agents/telemetry/trace_types.py
@@ -73,6 +73,17 @@ ATTR_END_OF_TURN_DELAY = "lk.end_of_turn_delay"
 ATTR_EOU_SOURCE = "lk.eou.source"
 ATTR_EOU_DETECTION_DELAY = "lk.eou.detection_delay"
 ATTR_EOU_FROM_CACHE = "lk.eou.from_cache"
+# eot_wait span: from the user's last speech to the turn decision
+ATTR_EOU_OUTCOME = "lk.eou.outcome"
+"""How the wait ended: ``committed``, ``user_resumed``, or ``dropped``."""
+ATTR_EOU_WAIT_DURATION = "lk.eou.wait_duration"
+"""Seconds from the end of the user's speech to the turn decision."""
+ATTR_EOU_REARM_COUNT = "lk.eou.rearm_count"
+"""Times the endpointing wait restarted on a later trigger (late transcript, VAD)."""
+
+# speech scheduling
+ATTR_SPEECH_QUEUE_WAIT = "lk.speech.queue_wait"
+"""Seconds a speech handle waited in the queue before generation was authorized."""
 
 # metrics
 ATTR_LLM_METRICS = "lk.llm_metrics"

--- a/livekit-agents/livekit/agents/telemetry/trace_types.py
+++ b/livekit-agents/livekit/agents/telemetry/trace_types.py
@@ -73,7 +73,7 @@ ATTR_END_OF_TURN_DELAY = "lk.end_of_turn_delay"
 ATTR_EOU_SOURCE = "lk.eou.source"
 ATTR_EOU_DETECTION_DELAY = "lk.eou.detection_delay"
 ATTR_EOU_FROM_CACHE = "lk.eou.from_cache"
-# eot_wait span: from the user's last speech to the turn decision
+# eou_wait span: from the user's last speech to the turn decision
 ATTR_EOU_OUTCOME = "lk.eou.outcome"
 """How the wait ended: ``committed``, ``user_resumed``, or ``dropped``."""
 ATTR_EOU_WAIT_DURATION = "lk.eou.wait_duration"

--- a/livekit-agents/livekit/agents/telemetry/trace_types.py
+++ b/livekit-agents/livekit/agents/telemetry/trace_types.py
@@ -79,6 +79,12 @@ ATTR_EOU_OUTCOME = "lk.eou.outcome"
 ATTR_EOU_WAIT_DURATION = "lk.eou.wait_duration"
 """Seconds from the end of the user's speech to the turn decision."""
 ATTR_EOU_REARM_COUNT = "lk.eou.rearm_count"
+ATTR_EOU_NOT_COMMITTED_COUNT = "lk.eou.not_committed_count"
+"""Turn decisions the wait rejected (the detector said the user was not done) before it ended."""
+ATTR_EOU_RESUME_COUNT = "lk.eou.resume_count"
+"""On user_turn: endpointing waits the user cut short by speaking again."""
+ATTR_ON_USER_TURN_COMPLETED_DELAY = "lk.on_user_turn_completed_delay"
+"""Seconds the on_user_turn_completed hook took; on the reply's agent_turn with the other stages."""
 """Times the endpointing wait restarted on a later trigger (late transcript, VAD)."""
 
 # speech scheduling

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -215,6 +215,17 @@ class _PausedSpeechInfo:
 
 
 # NOTE: AgentActivity isn't exposed to the public API
+def _record_queue_wait(speech_handle: SpeechHandle) -> None:
+    """Stamp how long the speech sat in the queue on its agent_turn span.
+
+    Module-level on purpose: the reply tasks are also driven with lightweight stand-ins for
+    the activity in tests, which must not need to know about telemetry helpers."""
+    if (queue_wait := speech_handle._queue_wait()) is None:
+        return
+    span = trace.get_current_span(context=speech_handle._agent_turn_context)
+    span.set_attribute(trace_types.ATTR_SPEECH_QUEUE_WAIT, queue_wait)
+
+
 class AgentActivity(RecognitionHooks):
     def __init__(self, agent: Agent, sess: AgentSession) -> None:
         self._agent, self._session = agent, sess
@@ -1830,13 +1841,6 @@ class AgentActivity(RecognitionHooks):
             skip_reply=skip_reply,
         )
 
-    def _record_queue_wait(self, speech_handle: SpeechHandle) -> None:
-        """Stamp how long the speech sat in the queue on its agent_turn span."""
-        if (queue_wait := speech_handle._queue_wait()) is None:
-            return
-        span = trace.get_current_span(context=speech_handle._agent_turn_context)
-        span.set_attribute(trace_types.ATTR_SPEECH_QUEUE_WAIT, queue_wait)
-
     def _schedule_speech(self, speech: SpeechHandle, priority: int, force: bool = False) -> None:
         # when force=True, we still allow to schedule a new speech even if
         # `pause_speech_scheduling` is waiting for the schedule_task to drain.
@@ -2999,7 +3003,7 @@ class AgentActivity(RecognitionHooks):
             authorization_tasks.append(asyncio.ensure_future(self._user_silence_event.wait()))
         await speech_handle.wait_if_not_interrupted(authorization_tasks)
         speech_handle._clear_authorization()
-        self._record_queue_wait(speech_handle)
+        _record_queue_wait(speech_handle)
 
         if speech_handle.interrupted:
             current_span.set_attribute(trace_types.ATTR_SPEECH_INTERRUPTED, True)
@@ -3494,7 +3498,7 @@ class AgentActivity(RecognitionHooks):
             authorization_tasks.append(asyncio.ensure_future(self._user_silence_event.wait()))
         await speech_handle.wait_if_not_interrupted(authorization_tasks)
         speech_handle._clear_authorization()
-        self._record_queue_wait(speech_handle)
+        _record_queue_wait(speech_handle)
 
         if speech_handle.interrupted:
             current_span.set_attribute(trace_types.ATTR_SPEECH_INTERRUPTED, True)
@@ -3896,7 +3900,7 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.allow_interruptions and not self._rt_overlapping_speech_enabled:
             authorization_tasks.append(asyncio.ensure_future(self._user_silence_event.wait()))
         await speech_handle.wait_if_not_interrupted(authorization_tasks)
-        self._record_queue_wait(speech_handle)
+        _record_queue_wait(speech_handle)
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(*authorization_tasks)
             return
@@ -4138,7 +4142,7 @@ class AgentActivity(RecognitionHooks):
             authorization_tasks.append(asyncio.ensure_future(self._user_silence_event.wait()))
         await speech_handle.wait_if_not_interrupted(authorization_tasks)
         speech_handle._clear_authorization()
-        self._record_queue_wait(speech_handle)
+        _record_queue_wait(speech_handle)
 
         if speech_handle.interrupted:
             # nothing was played, but the response may still be generating server-side

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -228,8 +228,10 @@ def _record_queue_wait(speech_handle: SpeechHandle) -> None:
     """Stamp how long the speech sat in the queue on its agent_turn span.
 
     Module-level: tests drive the reply tasks with stand-in activities."""
-    if (queue_wait := speech_handle._queue_wait()) is None:
-        return
+    if (
+        queue_wait := speech_handle._queue_wait()
+    ) is None or speech_handle._agent_turn_context is None:
+        return  # no agent_turn span yet: never fall back to whatever span is current
     span = trace.get_current_span(context=speech_handle._agent_turn_context)
     span.set_attribute(trace_types.ATTR_SPEECH_QUEUE_WAIT, queue_wait)
 
@@ -3927,7 +3929,7 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.allow_interruptions and not self._rt_overlapping_speech_enabled:
             authorization_tasks.append(asyncio.ensure_future(self._user_silence_event.wait()))
         await speech_handle.wait_if_not_interrupted(authorization_tasks)
-        _record_queue_wait(speech_handle)
+        # the queue wait is recorded by _realtime_generation_task, which owns the agent_turn span
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(*authorization_tasks)
             return

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -224,6 +224,20 @@ def _end_user_turn_span(info: _EndOfTurnInfo) -> None:
         info.user_turn_span_adopted = False
 
 
+def _record_user_turn_stages(span: trace.Span, user_metrics: llm.MetricsReport) -> None:
+    """The stages between the user stopping and the reply starting, next to lk.e2e_latency on
+    the reply's agent_turn: a per-turn breakdown readable off one span."""
+    attrs: dict[str, float] = {}
+    if (v := user_metrics.get("end_of_turn_delay")) is not None:
+        attrs[trace_types.ATTR_END_OF_TURN_DELAY] = v
+    if (v := user_metrics.get("transcription_delay")) is not None:
+        attrs[trace_types.ATTR_TRANSCRIPTION_DELAY] = v
+    if (v := user_metrics.get("on_user_turn_completed_delay")) is not None:
+        attrs[trace_types.ATTR_ON_USER_TURN_COMPLETED_DELAY] = v
+    if attrs:
+        span.set_attributes(attrs)
+
+
 def _record_queue_wait(speech_handle: SpeechHandle) -> None:
     """Stamp how long the speech sat in the queue on its agent_turn span.
 
@@ -3205,6 +3219,7 @@ class AgentActivity(RecognitionHooks):
                 e2e_latency = started_speaking_at - _previous_user_metrics["stopped_speaking_at"]
                 assistant_metrics["e2e_latency"] = e2e_latency
                 current_span.set_attribute(trace_types.ATTR_E2E_LATENCY, e2e_latency)
+                _record_user_turn_stages(current_span, _previous_user_metrics)
 
         if forwarded_text and add_to_chat_ctx:
             msg = self._agent._chat_ctx.add_message(
@@ -3705,6 +3720,7 @@ class AgentActivity(RecognitionHooks):
                 e2e_latency = started_speaking_at - user_metrics["stopped_speaking_at"]
                 assistant_metrics["e2e_latency"] = e2e_latency
                 current_span.set_attribute(trace_types.ATTR_E2E_LATENCY, e2e_latency)
+                _record_user_turn_stages(current_span, user_metrics)
 
             if self._session._unanswered_user_metrics is user_metrics:
                 self._session._unanswered_user_metrics = None

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -214,12 +214,10 @@ class _PausedSpeechInfo:
     timeout: float
 
 
-# NOTE: AgentActivity isn't exposed to the public API
-def _end_user_turn(info: _EndOfTurnInfo) -> None:
-    """End the ``user_turn`` span the activity adopted from recognition: the turn is over once
-    ``on_user_turn_completed`` has run (or the turn was skipped), just before any reply.
+def _end_user_turn_span(info: _EndOfTurnInfo) -> None:
+    """End the ``user_turn`` span the activity adopted from recognition (see ``_EndOfTurnInfo``).
 
-    Module-level for the same reason as ``_record_queue_wait``."""
+    Module-level: tests drive the reply tasks with stand-in activities."""
     if info.user_turn_span_adopted and info.user_turn_span is not None:
         if info.user_turn_span.is_recording():
             info.user_turn_span.end()
@@ -229,14 +227,14 @@ def _end_user_turn(info: _EndOfTurnInfo) -> None:
 def _record_queue_wait(speech_handle: SpeechHandle) -> None:
     """Stamp how long the speech sat in the queue on its agent_turn span.
 
-    Module-level on purpose: the reply tasks are also driven with lightweight stand-ins for
-    the activity in tests, which must not need to know about telemetry helpers."""
+    Module-level: tests drive the reply tasks with stand-in activities."""
     if (queue_wait := speech_handle._queue_wait()) is None:
         return
     span = trace.get_current_span(context=speech_handle._agent_turn_context)
     span.set_attribute(trace_types.ATTR_SPEECH_QUEUE_WAIT, queue_wait)
 
 
+# NOTE: AgentActivity isn't exposed to the public API
 class AgentActivity(RecognitionHooks):
     def __init__(self, agent: Agent, sess: AgentSession) -> None:
         self._agent, self._session = agent, sess
@@ -2571,7 +2569,7 @@ class AgentActivity(RecognitionHooks):
             self._cancel_false_interruption_timer()
 
         old_task = self._user_turn_completed_atask
-        # the turn is not over until the user hook has run: take the span and end it there
+        # the user turn ends after on_user_turn_completed (see _end_user_turn_span)
         info.user_turn_span_adopted = info.user_turn_span is not None
         self._user_turn_completed_atask = self._create_speech_task(
             self._user_turn_completed_task(old_task, info),
@@ -2586,7 +2584,7 @@ class AgentActivity(RecognitionHooks):
         try:
             await self._user_turn_completed_impl(old_task, info)
         finally:
-            _end_user_turn(info)
+            _end_user_turn_span(info)
 
     async def _user_turn_completed_impl(
         self, old_task: asyncio.Task[None] | None, info: _EndOfTurnInfo
@@ -2671,8 +2669,7 @@ class AgentActivity(RecognitionHooks):
         # Agent.chat_ctx
         temp_mutable_chat_ctx = self._agent.chat_ctx.copy()
         start_time = time.perf_counter()
-        # user code that gates the reply: a slow hook here is a gap between user_turn and
-        # agent_turn that nothing else explains
+        # user code that gates the reply; without a span a slow hook is an unexplained gap
         with tracer.start_as_current_span(
             "on_user_turn_completed",
             context=(
@@ -2690,8 +2687,7 @@ class AgentActivity(RecognitionHooks):
                 hook_span.add_event("stop_response")
                 return  # ignore this turn
             except Exception as e:
-                # the hook is user code and its message can quote the transcript; honour a
-                # redaction switched on for this session alone as well as the job's
+                # the message may quote the transcript: honour the session's redaction too
                 trace_utils.record_exception(
                     hook_span,
                     e,
@@ -2700,7 +2696,6 @@ class AgentActivity(RecognitionHooks):
                 logger.exception("error occurred during on_user_turn_completed")
                 return
 
-        _end_user_turn(info)
         on_user_turn_completed_delay = time.perf_counter() - start_time
         metrics_report["on_user_turn_completed_delay"] = on_user_turn_completed_delay
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1830,6 +1830,13 @@ class AgentActivity(RecognitionHooks):
             skip_reply=skip_reply,
         )
 
+    def _record_queue_wait(self, speech_handle: SpeechHandle) -> None:
+        """Stamp how long the speech sat in the queue on its agent_turn span."""
+        if (queue_wait := speech_handle._queue_wait()) is None:
+            return
+        span = trace.get_current_span(context=speech_handle._agent_turn_context)
+        span.set_attribute(trace_types.ATTR_SPEECH_QUEUE_WAIT, queue_wait)
+
     def _schedule_speech(self, speech: SpeechHandle, priority: int, force: bool = False) -> None:
         # when force=True, we still allow to schedule a new speech even if
         # `pause_speech_scheduling` is waiting for the schedule_task to drain.
@@ -2639,15 +2646,24 @@ class AgentActivity(RecognitionHooks):
         # Agent.chat_ctx
         temp_mutable_chat_ctx = self._agent.chat_ctx.copy()
         start_time = time.perf_counter()
-        try:
-            await self._agent.on_user_turn_completed(
-                temp_mutable_chat_ctx, new_message=user_message
-            )
-        except StopResponse:
-            return  # ignore this turn
-        except Exception:
-            logger.exception("error occurred during on_user_turn_completed")
-            return
+        # user code that gates the reply: a slow hook here is a gap between user_turn and
+        # agent_turn that nothing else explains
+        with tracer.start_as_current_span(
+            "on_user_turn_completed",
+            context=self._session._root_span_context,
+            attributes={trace_types.ATTR_AGENT_LABEL: self._agent.label},
+        ) as hook_span:
+            try:
+                await self._agent.on_user_turn_completed(
+                    temp_mutable_chat_ctx, new_message=user_message
+                )
+            except StopResponse:
+                hook_span.add_event("stop_response")
+                return  # ignore this turn
+            except Exception as e:
+                trace_utils.record_exception(hook_span, e)
+                logger.exception("error occurred during on_user_turn_completed")
+                return
 
         on_user_turn_completed_delay = time.perf_counter() - start_time
         metrics_report["on_user_turn_completed_delay"] = on_user_turn_completed_delay
@@ -2983,6 +2999,7 @@ class AgentActivity(RecognitionHooks):
             authorization_tasks.append(asyncio.ensure_future(self._user_silence_event.wait()))
         await speech_handle.wait_if_not_interrupted(authorization_tasks)
         speech_handle._clear_authorization()
+        self._record_queue_wait(speech_handle)
 
         if speech_handle.interrupted:
             current_span.set_attribute(trace_types.ATTR_SPEECH_INTERRUPTED, True)
@@ -3477,6 +3494,7 @@ class AgentActivity(RecognitionHooks):
             authorization_tasks.append(asyncio.ensure_future(self._user_silence_event.wait()))
         await speech_handle.wait_if_not_interrupted(authorization_tasks)
         speech_handle._clear_authorization()
+        self._record_queue_wait(speech_handle)
 
         if speech_handle.interrupted:
             current_span.set_attribute(trace_types.ATTR_SPEECH_INTERRUPTED, True)
@@ -3878,6 +3896,7 @@ class AgentActivity(RecognitionHooks):
         if speech_handle.allow_interruptions and not self._rt_overlapping_speech_enabled:
             authorization_tasks.append(asyncio.ensure_future(self._user_silence_event.wait()))
         await speech_handle.wait_if_not_interrupted(authorization_tasks)
+        self._record_queue_wait(speech_handle)
         if speech_handle.interrupted:
             await utils.aio.cancel_and_wait(*authorization_tasks)
             return
@@ -4119,6 +4138,7 @@ class AgentActivity(RecognitionHooks):
             authorization_tasks.append(asyncio.ensure_future(self._user_silence_event.wait()))
         await speech_handle.wait_if_not_interrupted(authorization_tasks)
         speech_handle._clear_authorization()
+        self._record_queue_wait(speech_handle)
 
         if speech_handle.interrupted:
             # nothing was played, but the response may still be generating server-side

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -215,6 +215,17 @@ class _PausedSpeechInfo:
 
 
 # NOTE: AgentActivity isn't exposed to the public API
+def _end_user_turn(info: _EndOfTurnInfo) -> None:
+    """End the ``user_turn`` span the activity adopted from recognition: the turn is over once
+    ``on_user_turn_completed`` has run (or the turn was skipped), just before any reply.
+
+    Module-level for the same reason as ``_record_queue_wait``."""
+    if info.user_turn_span_adopted and info.user_turn_span is not None:
+        if info.user_turn_span.is_recording():
+            info.user_turn_span.end()
+        info.user_turn_span_adopted = False
+
+
 def _record_queue_wait(speech_handle: SpeechHandle) -> None:
     """Stamp how long the speech sat in the queue on its agent_turn span.
 
@@ -2560,6 +2571,8 @@ class AgentActivity(RecognitionHooks):
             self._cancel_false_interruption_timer()
 
         old_task = self._user_turn_completed_atask
+        # the turn is not over until the user hook has run: take the span and end it there
+        info.user_turn_span_adopted = info.user_turn_span is not None
         self._user_turn_completed_atask = self._create_speech_task(
             self._user_turn_completed_task(old_task, info),
             name="AgentActivity._user_turn_completed_task",
@@ -2568,6 +2581,14 @@ class AgentActivity(RecognitionHooks):
 
     @utils.log_exceptions(logger=logger)
     async def _user_turn_completed_task(
+        self, old_task: asyncio.Task[None] | None, info: _EndOfTurnInfo
+    ) -> None:
+        try:
+            await self._user_turn_completed_impl(old_task, info)
+        finally:
+            _end_user_turn(info)
+
+    async def _user_turn_completed_impl(
         self, old_task: asyncio.Task[None] | None, info: _EndOfTurnInfo
     ) -> None:
         if old_task is not None:
@@ -2654,7 +2675,11 @@ class AgentActivity(RecognitionHooks):
         # agent_turn that nothing else explains
         with tracer.start_as_current_span(
             "on_user_turn_completed",
-            context=self._session._root_span_context,
+            context=(
+                trace.set_span_in_context(info.user_turn_span)
+                if info.user_turn_span_adopted and info.user_turn_span is not None
+                else self._session._root_span_context
+            ),
             attributes={trace_types.ATTR_AGENT_LABEL: self._agent.label},
         ) as hook_span:
             try:
@@ -2675,6 +2700,7 @@ class AgentActivity(RecognitionHooks):
                 logger.exception("error occurred during on_user_turn_completed")
                 return
 
+        _end_user_turn(info)
         on_user_turn_completed_delay = time.perf_counter() - start_time
         metrics_report["on_user_turn_completed_delay"] = on_user_turn_completed_delay
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2665,7 +2665,13 @@ class AgentActivity(RecognitionHooks):
                 hook_span.add_event("stop_response")
                 return  # ignore this turn
             except Exception as e:
-                trace_utils.record_exception(hook_span, e)
+                # the hook is user code and its message can quote the transcript; honour a
+                # redaction switched on for this session alone as well as the job's
+                trace_utils.record_exception(
+                    hook_span,
+                    e,
+                    redacted=self._session._redaction_enabled or trace_utils.redaction_enabled(),
+                )
                 logger.exception("error occurred during on_user_turn_completed")
                 return
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -330,6 +330,10 @@ class AudioRecognition:
 
         self._user_turn_span: trace.Span | None = None
         self._user_turn_start: float | None = None
+        # eot_wait: one span per user turn, from the last speech anchor to the turn decision
+        self._eot_wait_span: trace.Span | None = None
+        self._eot_wait_started_at: float | None = None
+        self._eot_wait_rearms: int = 0
         self._stt_request_ids: list[str] = []
         self._closing = asyncio.Event()
         self.__stt_context: BaseModel | None = None
@@ -1349,6 +1353,7 @@ class AudioRecognition:
             # otherwise fall back to message arrival time.
             if self._speech_start_time is None:
                 self._speech_start_time = ev.speech_start_time or time.time()
+            self._end_eot_wait_span("user_resumed", end_time=ev.speech_start_time or now)
 
             with tracer.use_span(self._ensure_user_turn_span(start_time=self._speech_start_time)):
                 self._hooks.on_start_of_speech(None, speech_start_time=self._speech_start_time)
@@ -1369,6 +1374,7 @@ class AudioRecognition:
                 self._vad_speech_started = True
 
             self._cancel_transcription_timeout()
+            self._end_eot_wait_span("user_resumed", end_time=speech_start_time)
 
             with tracer.use_span(self._ensure_user_turn_span(start_time=speech_start_time)):
                 self._hooks.on_start_of_speech(ev, speech_start_time=speech_start_time)
@@ -1511,6 +1517,11 @@ class AudioRecognition:
         ) -> None:
             endpointing_delay = self._endpointing.min_delay
             user_turn_span = self._ensure_user_turn_span()
+            eot_wait_span = self._ensure_eot_wait_span(
+                user_turn_span,
+                trigger=trigger,
+                last_speaking_time=last_speaking_time,
+            )
 
             end_of_turn_probability: float | None = None
             unlikely_threshold: float | None = None
@@ -1521,8 +1532,8 @@ class AudioRecognition:
                     logger.info("Turn detector does not support language %s", self._last_language)
                 else:
                     with (
-                        tracer.use_span(user_turn_span),
-                        tracer.start_as_current_span("eou_detection") as eou_detection_span,
+                        tracer.use_span(eot_wait_span),
+                        tracer.start_as_current_span("eot_detection") as eou_detection_span,
                     ):
                         from_cache = False
                         prediction_event: TurnDetectionEvent | None = None
@@ -1676,6 +1687,8 @@ class AudioRecognition:
                                 prediction_event.detection_delay,
                             )
 
+            eot_wait_span.set_attribute(trace_types.ATTR_EOU_DELAY, endpointing_delay)
+
             extra_sleep = endpointing_delay
             if last_speaking_time:
                 extra_sleep += last_speaking_time - time.time()
@@ -1736,6 +1749,7 @@ class AudioRecognition:
                     user_turn_span.set_attribute(
                         trace_types.ATTR_PROVIDER_REQUEST_IDS, self._stt_request_ids
                     )
+                self._end_eot_wait_span("committed")
                 user_turn_span.end()
                 self._user_turn_span = None
                 self._user_turn_start = None
@@ -1757,6 +1771,9 @@ class AudioRecognition:
                     self._turn_detector_stream.flush(reason="turn committed")
                     self._turn_detector_prediction_fut = None
                     self._turn_detector_flushed = True
+
+            elif eot_wait_span.is_recording():
+                eot_wait_span.add_event("not_committed")
 
             # reset turn-scoped barge-in state once per logical turn (commit or drop)
             self._turn_backchannel_over_agent = False
@@ -1957,7 +1974,64 @@ class AudioRecognition:
         return self._user_turn_span
 
     def _end_user_turn_span(self) -> None:
+        # a wait still open here never reached a decision (teardown, clear_user_turn, ...)
+        self._end_eot_wait_span("dropped")
         if self._user_turn_span is not None and self._user_turn_span.is_recording():
             self._user_turn_span.end()
         self._user_turn_span = None
         self._user_turn_start = None
+
+    def _ensure_eot_wait_span(
+        self,
+        user_turn_span: trace.Span,
+        *,
+        trigger: str,
+        last_speaking_time: float | None,
+    ) -> trace.Span:
+        """The turn's ``eot_wait`` span, created on the first end-of-turn trigger.
+
+        The span is back-dated to ``last_speaking_time`` so it starts where the user stopped
+        talking. Later triggers for the same turn (a late STT final, another VAD end of
+        speech) re-arm the wait rather than start a new span; each re-arm is an event, so the
+        bar stays whole and the reason for a long wait is readable off it.
+        """
+        span = self._eot_wait_span
+        if span is not None and span.is_recording():
+            self._eot_wait_rearms += 1
+            span.add_event("rearmed", {trace_types.ATTR_EOU_SOURCE: trigger})
+            span.set_attribute(trace_types.ATTR_EOU_SOURCE, trigger)
+            return span
+
+        now = time.time()
+        started_at = min(last_speaking_time, now) if last_speaking_time is not None else now
+        with tracer.use_span(user_turn_span):
+            span = tracer.start_span(
+                "eot_wait",
+                start_time=int(started_at * 1_000_000_000),
+                attributes={trace_types.ATTR_EOU_SOURCE: trigger},
+            )
+        self._eot_wait_span = span
+        self._eot_wait_started_at = started_at
+        self._eot_wait_rearms = 0
+        return span
+
+    def _end_eot_wait_span(self, outcome: str, *, end_time: float | None = None) -> None:
+        span, self._eot_wait_span = self._eot_wait_span, None
+        started_at, self._eot_wait_started_at = self._eot_wait_started_at, None
+        rearms, self._eot_wait_rearms = self._eot_wait_rearms, 0
+        if span is None or not span.is_recording():
+            return
+
+        ended_at = end_time if end_time is not None else time.time()
+        if started_at is not None:
+            ended_at = max(ended_at, started_at)
+        span.set_attributes(
+            {
+                trace_types.ATTR_EOU_OUTCOME: outcome,
+                trace_types.ATTR_EOU_WAIT_DURATION: (
+                    ended_at - started_at if started_at is not None else 0.0
+                ),
+                trace_types.ATTR_EOU_REARM_COUNT: rearms,
+            }
+        )
+        span.end(end_time=int(ended_at * 1_000_000_000))

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -332,7 +332,7 @@ class AudioRecognition:
         self._user_turn_start: float | None = None
         # eot_wait: one span per user turn, from the last speech anchor to the turn decision
         self._eot_wait_span: trace.Span | None = None
-        self._eot_wait_started_at: float | None = None
+        self._eot_wait_started_at_ns: int | None = None
         self._eot_wait_rearms: int = 0
         self._stt_request_ids: list[str] = []
         self._closing = asyncio.Event()
@@ -2004,34 +2004,42 @@ class AudioRecognition:
 
         now = time.time()
         started_at = min(last_speaking_time, now) if last_speaking_time is not None else now
+        # the span's own start; lk.eou.wait_duration is derived from this same value at the end
+        # so the attribute and the bar are exactly the same length
+        started_at_ns = int(started_at * 1_000_000_000)
         with tracer.use_span(user_turn_span):
             span = tracer.start_span(
                 "eot_wait",
-                start_time=int(started_at * 1_000_000_000),
+                start_time=started_at_ns,
                 attributes={trace_types.ATTR_EOU_SOURCE: trigger},
             )
         self._eot_wait_span = span
-        self._eot_wait_started_at = started_at
+        self._eot_wait_started_at_ns = started_at_ns
         self._eot_wait_rearms = 0
         return span
 
     def _end_eot_wait_span(self, outcome: str, *, end_time: float | None = None) -> None:
         span, self._eot_wait_span = self._eot_wait_span, None
-        started_at, self._eot_wait_started_at = self._eot_wait_started_at, None
+        started_at_ns, self._eot_wait_started_at_ns = self._eot_wait_started_at_ns, None
         rearms, self._eot_wait_rearms = self._eot_wait_rearms, 0
         if span is None or not span.is_recording():
             return
 
-        ended_at = end_time if end_time is not None else time.time()
-        if started_at is not None:
-            ended_at = max(ended_at, started_at)
+        ended_at_ns = int((end_time if end_time is not None else time.time()) * 1_000_000_000)
+        if started_at_ns is not None:
+            # resumed speech can carry a VAD timestamp from before the anchor; never negative
+            ended_at_ns = max(ended_at_ns, started_at_ns)
         span.set_attributes(
             {
                 trace_types.ATTR_EOU_OUTCOME: outcome,
+                # from the same two integers the span is bounded by, so the attribute equals
+                # the bar's length exactly
                 trace_types.ATTR_EOU_WAIT_DURATION: (
-                    ended_at - started_at if started_at is not None else 0.0
+                    (ended_at_ns - started_at_ns) / 1_000_000_000
+                    if started_at_ns is not None
+                    else 0.0
                 ),
                 trace_types.ATTR_EOU_REARM_COUNT: rearms,
             }
         )
-        span.end(end_time=int(ended_at * 1_000_000_000))
+        span.end(end_time=ended_at_ns)

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import math
 import time
 from collections import deque
-from collections.abc import AsyncIterable, Callable
+from collections.abc import AsyncIterable, Callable, Iterator
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
@@ -334,6 +335,9 @@ class AudioRecognition:
         self._eou_wait_span: trace.Span | None = None
         self._eou_wait_started_at_ns: int | None = None
         self._eou_wait_rearms: int = 0
+        # nothing recorded inside the wait (a re-arm, a detection) may fall after its end
+        self._eou_wait_floor_ns: int | None = None
+        self._eou_detection_span: trace.Span | None = None
         self._stt_request_ids: list[str] = []
         self._closing = asyncio.Event()
         self.__stt_context: BaseModel | None = None
@@ -383,6 +387,9 @@ class AudioRecognition:
                         if not self._end_of_turn_task.done():
                             self._end_of_turn_task.cancel()
                     self._end_of_turn_task = None
+                    # the pending decision is abandoned with the mode; the user turn stays
+                    # open for whatever the new mode does with the speech that follows
+                    self._end_eou_wait_span("dropped")
                     self._user_turn_committed = False
                     if self._turn_detector_stream is not None:
                         self._turn_detector_stream.cancel_inference()
@@ -1531,9 +1538,14 @@ class AudioRecognition:
                 if not await turn_detector.supports_language(self._last_language):
                     logger.info("Turn detector does not support language %s", self._last_language)
                 else:
+                    # ended by hand: when the user resumes mid-inference the wait closes
+                    # first (see _end_eou_wait_span) and the child must not outlive it
                     with (
                         tracer.use_span(eou_wait_span),
-                        tracer.start_as_current_span("eou_detection") as eou_detection_span,
+                        tracer.start_as_current_span(
+                            "eou_detection", end_on_exit=False
+                        ) as eou_detection_span,
+                        self._track_eou_detection_span(eou_detection_span),
                     ):
                         from_cache = False
                         prediction_event: TurnDetectionEvent | None = None
@@ -1998,7 +2010,12 @@ class AudioRecognition:
         span = self._eou_wait_span
         if span is not None and span.is_recording():
             self._eou_wait_rearms += 1
-            span.add_event("rearmed", {trace_types.ATTR_EOU_SOURCE: trigger})
+            self._eou_wait_floor_ns = time.time_ns()
+            span.add_event(
+                "rearmed",
+                {trace_types.ATTR_EOU_SOURCE: trigger},
+                timestamp=self._eou_wait_floor_ns,
+            )
             span.set_attribute(trace_types.ATTR_EOU_SOURCE, trigger)
             return span
 
@@ -2016,7 +2033,21 @@ class AudioRecognition:
         self._eou_wait_span = span
         self._eou_wait_started_at_ns = started_at_ns
         self._eou_wait_rearms = 0
+        self._eou_wait_floor_ns = None
         return span
+
+    @contextlib.contextmanager
+    def _track_eou_detection_span(self, span: trace.Span) -> Iterator[None]:
+        """Own the ``eou_detection`` span's end so the wait can close it early."""
+        self._eou_detection_span = span
+        try:
+            yield
+        finally:
+            if self._eou_detection_span is span:
+                self._eou_detection_span = None
+            if span.is_recording():
+                self._eou_wait_floor_ns = time.time_ns()
+                span.end(end_time=self._eou_wait_floor_ns)
 
     def _end_eou_wait_span(self, outcome: str, *, end_time: float | None = None) -> None:
         span, self._eou_wait_span = self._eou_wait_span, None
@@ -2025,10 +2056,27 @@ class AudioRecognition:
         if span is None or not span.is_recording():
             return
 
-        ended_at_ns = int((end_time if end_time is not None else time.time()) * 1_000_000_000)
+        requested_ns = int((end_time if end_time is not None else time.time()) * 1_000_000_000)
+        ended_at_ns = requested_ns
         if started_at_ns is not None:
             # resumed speech can carry a VAD timestamp from before the anchor; never negative
             ended_at_ns = max(ended_at_ns, started_at_ns)
+
+        detection, self._eou_detection_span = self._eou_detection_span, None
+        if detection is not None and detection.is_recording():
+            # the user resumed while the detector was still running: the inference is moot,
+            # and the wait ends when it does so the child stays inside the parent
+            self._eou_wait_floor_ns = time.time_ns()
+            detection.add_event("superseded", {trace_types.ATTR_EOU_OUTCOME: outcome})
+            detection.end(end_time=self._eou_wait_floor_ns)
+        floor_ns, self._eou_wait_floor_ns = self._eou_wait_floor_ns, None
+        if floor_ns is not None:
+            # a re-arm or a detection recorded after the requested end (VAD reports the
+            # resumed speech's start after the fact): the bar covers what it contains
+            ended_at_ns = max(ended_at_ns, floor_ns)
+        if outcome == "user_resumed":
+            # where the speech actually resumed, even when the bar had to run past it
+            span.add_event("user_resumed", timestamp=max(requested_ns, started_at_ns or 0))
         span.set_attributes(
             {
                 trace_types.ATTR_EOU_OUTCOME: outcome,

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -330,10 +330,10 @@ class AudioRecognition:
 
         self._user_turn_span: trace.Span | None = None
         self._user_turn_start: float | None = None
-        # eot_wait: one span per user turn, from the last speech anchor to the turn decision
-        self._eot_wait_span: trace.Span | None = None
-        self._eot_wait_started_at_ns: int | None = None
-        self._eot_wait_rearms: int = 0
+        # eou_wait: one span per user turn, from the last speech anchor to the turn decision
+        self._eou_wait_span: trace.Span | None = None
+        self._eou_wait_started_at_ns: int | None = None
+        self._eou_wait_rearms: int = 0
         self._stt_request_ids: list[str] = []
         self._closing = asyncio.Event()
         self.__stt_context: BaseModel | None = None
@@ -1353,7 +1353,7 @@ class AudioRecognition:
             # otherwise fall back to message arrival time.
             if self._speech_start_time is None:
                 self._speech_start_time = ev.speech_start_time or time.time()
-            self._end_eot_wait_span("user_resumed", end_time=ev.speech_start_time or now)
+            self._end_eou_wait_span("user_resumed", end_time=ev.speech_start_time or now)
 
             with tracer.use_span(self._ensure_user_turn_span(start_time=self._speech_start_time)):
                 self._hooks.on_start_of_speech(None, speech_start_time=self._speech_start_time)
@@ -1374,7 +1374,7 @@ class AudioRecognition:
                 self._vad_speech_started = True
 
             self._cancel_transcription_timeout()
-            self._end_eot_wait_span("user_resumed", end_time=speech_start_time)
+            self._end_eou_wait_span("user_resumed", end_time=speech_start_time)
 
             with tracer.use_span(self._ensure_user_turn_span(start_time=speech_start_time)):
                 self._hooks.on_start_of_speech(ev, speech_start_time=speech_start_time)
@@ -1517,7 +1517,7 @@ class AudioRecognition:
         ) -> None:
             endpointing_delay = self._endpointing.min_delay
             user_turn_span = self._ensure_user_turn_span()
-            eot_wait_span = self._ensure_eot_wait_span(
+            eou_wait_span = self._ensure_eou_wait_span(
                 user_turn_span,
                 trigger=trigger,
                 last_speaking_time=last_speaking_time,
@@ -1532,8 +1532,8 @@ class AudioRecognition:
                     logger.info("Turn detector does not support language %s", self._last_language)
                 else:
                     with (
-                        tracer.use_span(eot_wait_span),
-                        tracer.start_as_current_span("eot_detection") as eou_detection_span,
+                        tracer.use_span(eou_wait_span),
+                        tracer.start_as_current_span("eou_detection") as eou_detection_span,
                     ):
                         from_cache = False
                         prediction_event: TurnDetectionEvent | None = None
@@ -1687,7 +1687,7 @@ class AudioRecognition:
                                 prediction_event.detection_delay,
                             )
 
-            eot_wait_span.set_attribute(trace_types.ATTR_EOU_DELAY, endpointing_delay)
+            eou_wait_span.set_attribute(trace_types.ATTR_EOU_DELAY, endpointing_delay)
 
             extra_sleep = endpointing_delay
             if last_speaking_time:
@@ -1749,7 +1749,7 @@ class AudioRecognition:
                     user_turn_span.set_attribute(
                         trace_types.ATTR_PROVIDER_REQUEST_IDS, self._stt_request_ids
                     )
-                self._end_eot_wait_span("committed")
+                self._end_eou_wait_span("committed")
                 user_turn_span.end()
                 self._user_turn_span = None
                 self._user_turn_start = None
@@ -1772,8 +1772,8 @@ class AudioRecognition:
                     self._turn_detector_prediction_fut = None
                     self._turn_detector_flushed = True
 
-            elif eot_wait_span.is_recording():
-                eot_wait_span.add_event("not_committed")
+            elif eou_wait_span.is_recording():
+                eou_wait_span.add_event("not_committed")
 
             # reset turn-scoped barge-in state once per logical turn (commit or drop)
             self._turn_backchannel_over_agent = False
@@ -1975,29 +1975,29 @@ class AudioRecognition:
 
     def _end_user_turn_span(self) -> None:
         # a wait still open here never reached a decision (teardown, clear_user_turn, ...)
-        self._end_eot_wait_span("dropped")
+        self._end_eou_wait_span("dropped")
         if self._user_turn_span is not None and self._user_turn_span.is_recording():
             self._user_turn_span.end()
         self._user_turn_span = None
         self._user_turn_start = None
 
-    def _ensure_eot_wait_span(
+    def _ensure_eou_wait_span(
         self,
         user_turn_span: trace.Span,
         *,
         trigger: str,
         last_speaking_time: float | None,
     ) -> trace.Span:
-        """The turn's ``eot_wait`` span, created on the first end-of-turn trigger.
+        """The turn's ``eou_wait`` span, created on the first end-of-turn trigger.
 
         The span is back-dated to ``last_speaking_time`` so it starts where the user stopped
         talking. Later triggers for the same turn (a late STT final, another VAD end of
         speech) re-arm the wait rather than start a new span; each re-arm is an event, so the
         bar stays whole and the reason for a long wait is readable off it.
         """
-        span = self._eot_wait_span
+        span = self._eou_wait_span
         if span is not None and span.is_recording():
-            self._eot_wait_rearms += 1
+            self._eou_wait_rearms += 1
             span.add_event("rearmed", {trace_types.ATTR_EOU_SOURCE: trigger})
             span.set_attribute(trace_types.ATTR_EOU_SOURCE, trigger)
             return span
@@ -2009,19 +2009,19 @@ class AudioRecognition:
         started_at_ns = int(started_at * 1_000_000_000)
         with tracer.use_span(user_turn_span):
             span = tracer.start_span(
-                "eot_wait",
+                "eou_wait",
                 start_time=started_at_ns,
                 attributes={trace_types.ATTR_EOU_SOURCE: trigger},
             )
-        self._eot_wait_span = span
-        self._eot_wait_started_at_ns = started_at_ns
-        self._eot_wait_rearms = 0
+        self._eou_wait_span = span
+        self._eou_wait_started_at_ns = started_at_ns
+        self._eou_wait_rearms = 0
         return span
 
-    def _end_eot_wait_span(self, outcome: str, *, end_time: float | None = None) -> None:
-        span, self._eot_wait_span = self._eot_wait_span, None
-        started_at_ns, self._eot_wait_started_at_ns = self._eot_wait_started_at_ns, None
-        rearms, self._eot_wait_rearms = self._eot_wait_rearms, 0
+    def _end_eou_wait_span(self, outcome: str, *, end_time: float | None = None) -> None:
+        span, self._eou_wait_span = self._eou_wait_span, None
+        started_at_ns, self._eou_wait_started_at_ns = self._eou_wait_started_at_ns, None
+        rearms, self._eou_wait_rearms = self._eou_wait_rearms, 0
         if span is None or not span.is_recording():
             return
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1531,6 +1531,7 @@ class AudioRecognition:
                 user_turn_span,
                 trigger=trigger,
                 last_speaking_time=last_speaking_time,
+                endpointing_delay=endpointing_delay,
             )
 
             end_of_turn_probability: float | None = None
@@ -1701,7 +1702,8 @@ class AudioRecognition:
                                 prediction_event.detection_delay,
                             )
 
-            eou_wait_span.set_attribute(trace_types.ATTR_EOU_DELAY, endpointing_delay)
+            if eou_wait_span.is_recording():  # the wait may have ended with resumed speech
+                eou_wait_span.set_attribute(trace_types.ATTR_EOU_DELAY, endpointing_delay)
 
             extra_sleep = endpointing_delay
             if last_speaking_time:
@@ -2002,6 +2004,7 @@ class AudioRecognition:
         *,
         trigger: str,
         last_speaking_time: float | None,
+        endpointing_delay: float,
     ) -> trace.Span:
         """The turn's ``eou_wait`` span, created on the first end-of-turn trigger and back-dated
         to ``last_speaking_time``. Later triggers for the same turn (a late STT final, another
@@ -2015,7 +2018,13 @@ class AudioRecognition:
                 {trace_types.ATTR_EOU_SOURCE: trigger},
                 timestamp=self._eou_wait_floor_ns,
             )
-            span.set_attribute(trace_types.ATTR_EOU_SOURCE, trigger)
+            span.set_attributes(
+                {
+                    trace_types.ATTR_EOU_SOURCE: trigger,
+                    # the delay in force now; a prediction may raise it later
+                    trace_types.ATTR_EOU_DELAY: endpointing_delay,
+                }
+            )
             return span
 
         now = time.time()
@@ -2026,7 +2035,10 @@ class AudioRecognition:
             span = tracer.start_span(
                 "eou_wait",
                 start_time=started_at_ns,
-                attributes={trace_types.ATTR_EOU_SOURCE: trigger},
+                attributes={
+                    trace_types.ATTR_EOU_SOURCE: trigger,
+                    trace_types.ATTR_EOU_DELAY: endpointing_delay,
+                },
             )
         self._eou_wait_span = span
         self._eou_wait_started_at_ns = started_at_ns

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -77,9 +77,8 @@ class _EndOfTurnInfo:
     backchannel_over_agent: bool = False
     """The turn's speech overlapped agent speech and was classified a backchannel by adaptive interruption."""
     user_turn_span: trace.Span | None = None
-    """The turn's open ``user_turn`` span. The activity that schedules ``on_user_turn_completed``
-    takes ownership (``user_turn_span_adopted``) and ends it after the hook, so the hook nests
-    under the turn and the turn covers the wait for it; otherwise recognition ends it here."""
+    """The turn's open ``user_turn`` span. The activity sets ``user_turn_span_adopted`` to take
+    ownership and ends it after ``on_user_turn_completed``; otherwise recognition ends it."""
     user_turn_span_adopted: bool = False
 
 
@@ -340,7 +339,7 @@ class AudioRecognition:
         self._eou_wait_span: trace.Span | None = None
         self._eou_wait_started_at_ns: int | None = None
         self._eou_wait_rearms: int = 0
-        # nothing recorded inside the wait (a re-arm, a detection) may fall after its end
+        # latest timestamp recorded inside the wait; the span must not end before it
         self._eou_wait_floor_ns: int | None = None
         self._eou_detection_span: trace.Span | None = None
         self._stt_request_ids: list[str] = []
@@ -392,8 +391,7 @@ class AudioRecognition:
                         if not self._end_of_turn_task.done():
                             self._end_of_turn_task.cancel()
                     self._end_of_turn_task = None
-                    # the pending decision is abandoned with the mode; the user turn stays
-                    # open for whatever the new mode does with the speech that follows
+                    # the pending decision is abandoned with the mode; the user turn stays open
                     self._end_eou_wait_span("dropped")
                     self._user_turn_committed = False
                     if self._turn_detector_stream is not None:
@@ -1543,8 +1541,7 @@ class AudioRecognition:
                 if not await turn_detector.supports_language(self._last_language):
                     logger.info("Turn detector does not support language %s", self._last_language)
                 else:
-                    # ended by hand: when the user resumes mid-inference the wait closes
-                    # first (see _end_eou_wait_span) and the child must not outlive it
+                    # ended explicitly: _end_eou_wait_span closes it early if the user resumes
                     with (
                         tracer.use_span(eou_wait_span),
                         tracer.start_as_current_span(
@@ -2006,13 +2003,9 @@ class AudioRecognition:
         trigger: str,
         last_speaking_time: float | None,
     ) -> trace.Span:
-        """The turn's ``eou_wait`` span, created on the first end-of-turn trigger.
-
-        The span is back-dated to ``last_speaking_time`` so it starts where the user stopped
-        talking. Later triggers for the same turn (a late STT final, another VAD end of
-        speech) re-arm the wait rather than start a new span; each re-arm is an event, so the
-        bar stays whole and the reason for a long wait is readable off it.
-        """
+        """The turn's ``eou_wait`` span, created on the first end-of-turn trigger and back-dated
+        to ``last_speaking_time``. Later triggers for the same turn (a late STT final, another
+        VAD end of speech) re-arm the wait as an event rather than start a new span."""
         span = self._eou_wait_span
         if span is not None and span.is_recording():
             self._eou_wait_rearms += 1
@@ -2027,8 +2020,7 @@ class AudioRecognition:
 
         now = time.time()
         started_at = min(last_speaking_time, now) if last_speaking_time is not None else now
-        # the span's own start; lk.eou.wait_duration is derived from this same value at the end
-        # so the attribute and the bar are exactly the same length
+        # lk.eou.wait_duration is computed from this same value, so it equals the span's length
         started_at_ns = int(started_at * 1_000_000_000)
         with tracer.use_span(user_turn_span):
             span = tracer.start_span(
@@ -2070,24 +2062,20 @@ class AudioRecognition:
 
         detection, self._eou_detection_span = self._eou_detection_span, None
         if detection is not None and detection.is_recording():
-            # the user resumed while the detector was still running: the inference is moot,
-            # and the wait ends when it does so the child stays inside the parent
+            # the detector is still running: end it first so the child stays inside the parent
             self._eou_wait_floor_ns = time.time_ns()
             detection.add_event("superseded", {trace_types.ATTR_EOU_OUTCOME: outcome})
             detection.end(end_time=self._eou_wait_floor_ns)
         floor_ns, self._eou_wait_floor_ns = self._eou_wait_floor_ns, None
         if floor_ns is not None:
-            # a re-arm or a detection recorded after the requested end (VAD reports the
-            # resumed speech's start after the fact): the bar covers what it contains
+            # VAD reports a resume after the fact: never end before what the span contains
             ended_at_ns = max(ended_at_ns, floor_ns)
         if outcome == "user_resumed":
-            # where the speech actually resumed, even when the bar had to run past it
             span.add_event("user_resumed", timestamp=max(requested_ns, started_at_ns or 0))
         span.set_attributes(
             {
                 trace_types.ATTR_EOU_OUTCOME: outcome,
-                # from the same two integers the span is bounded by, so the attribute equals
-                # the bar's length exactly
+                # same integers as the span bounds, so the attribute equals the span's length
                 trace_types.ATTR_EOU_WAIT_DURATION: (
                     (ended_at_ns - started_at_ns) / 1_000_000_000
                     if started_at_ns is not None

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -76,6 +76,11 @@ class _EndOfTurnInfo:
     metrics: _EndOfTurnMetrics
     backchannel_over_agent: bool = False
     """The turn's speech overlapped agent speech and was classified a backchannel by adaptive interruption."""
+    user_turn_span: trace.Span | None = None
+    """The turn's open ``user_turn`` span. The activity that schedules ``on_user_turn_completed``
+    takes ownership (``user_turn_span_adopted``) and ends it after the hook, so the hook nests
+    under the turn and the turn covers the wait for it; otherwise recognition ends it here."""
+    user_turn_span_adopted: bool = False
 
 
 def _compute_end_of_turn_metrics(
@@ -1727,15 +1732,15 @@ class AudioRecognition:
                 last_final_transcript_time=last_final_transcript_time,
                 now=time.time(),
             )
-            committed = self._hooks.on_end_of_turn(
-                _EndOfTurnInfo(
-                    skip_reply=skip_reply,
-                    new_transcript=self._audio_transcript,
-                    transcript_confidence=confidence_avg,
-                    metrics=metrics,
-                    backchannel_over_agent=self._turn_backchannel_over_agent,
-                )
+            end_of_turn = _EndOfTurnInfo(
+                skip_reply=skip_reply,
+                new_transcript=self._audio_transcript,
+                transcript_confidence=confidence_avg,
+                metrics=metrics,
+                backchannel_over_agent=self._turn_backchannel_over_agent,
+                user_turn_span=user_turn_span,
             )
+            committed = self._hooks.on_end_of_turn(end_of_turn)
             if committed:
                 logger.debug(
                     "user turn committed",
@@ -1762,7 +1767,8 @@ class AudioRecognition:
                         trace_types.ATTR_PROVIDER_REQUEST_IDS, self._stt_request_ids
                     )
                 self._end_eou_wait_span("committed")
-                user_turn_span.end()
+                if not end_of_turn.user_turn_span_adopted:
+                    user_turn_span.end()
                 self._user_turn_span = None
                 self._user_turn_start = None
                 self._stt_request_ids = []

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -2064,7 +2064,11 @@ class AudioRecognition:
         if detection is not None and detection.is_recording():
             # the detector is still running: end it first so the child stays inside the parent
             self._eou_wait_floor_ns = time.time_ns()
-            detection.add_event("superseded", {trace_types.ATTR_EOU_OUTCOME: outcome})
+            detection.add_event(
+                "superseded",
+                {trace_types.ATTR_EOU_OUTCOME: outcome},
+                timestamp=self._eou_wait_floor_ns,
+            )
             detection.end(end_time=self._eou_wait_floor_ns)
         floor_ns, self._eou_wait_floor_ns = self._eou_wait_floor_ns, None
         if floor_ns is not None:

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -339,6 +339,9 @@ class AudioRecognition:
         self._eou_wait_span: trace.Span | None = None
         self._eou_wait_started_at_ns: int | None = None
         self._eou_wait_rearms: int = 0
+        self._eou_wait_not_committed: int = 0
+        # eou_wait spans this user turn went through that ended with the user resuming
+        self._user_turn_resumes: int = 0
         # latest timestamp recorded inside the wait; the span must not end before it
         self._eou_wait_floor_ns: int | None = None
         self._eou_detection_span: trace.Span | None = None
@@ -1526,7 +1529,12 @@ class AudioRecognition:
             speech_start_time: float | None = None,
         ) -> None:
             endpointing_delay = self._endpointing.min_delay
-            user_turn_span = self._ensure_user_turn_span()
+            # a turn created here (no VAD/start-of-speech opened it) starts at the earliest
+            # anchor known, so the eou_wait child back-dated to last_speaking_time fits inside
+            anchors = [t for t in (speech_start_time, last_speaking_time) if t is not None]
+            user_turn_span = self._ensure_user_turn_span(
+                start_time=min(anchors) if anchors else None
+            )
             eou_wait_span = self._ensure_eou_wait_span(
                 user_turn_span,
                 trigger=trigger,
@@ -1766,6 +1774,7 @@ class AudioRecognition:
                         trace_types.ATTR_PROVIDER_REQUEST_IDS, self._stt_request_ids
                     )
                 self._end_eou_wait_span("committed")
+                self._stamp_user_turn_resumes(user_turn_span)
                 if not end_of_turn.user_turn_span_adopted:
                     user_turn_span.end()
                 self._user_turn_span = None
@@ -1790,7 +1799,7 @@ class AudioRecognition:
                     self._turn_detector_flushed = True
 
             elif eou_wait_span.is_recording():
-                eou_wait_span.add_event("not_committed")
+                self._eou_wait_not_committed += 1
 
             # reset turn-scoped barge-in state once per logical turn (commit or drop)
             self._turn_backchannel_over_agent = False
@@ -1994,9 +2003,15 @@ class AudioRecognition:
         # a wait still open here never reached a decision (teardown, clear_user_turn, ...)
         self._end_eou_wait_span("dropped")
         if self._user_turn_span is not None and self._user_turn_span.is_recording():
+            self._stamp_user_turn_resumes(self._user_turn_span)
             self._user_turn_span.end()
         self._user_turn_span = None
         self._user_turn_start = None
+
+    def _stamp_user_turn_resumes(self, user_turn_span: trace.Span) -> None:
+        resumes, self._user_turn_resumes = self._user_turn_resumes, 0
+        if resumes and user_turn_span.is_recording():
+            user_turn_span.set_attribute(trace_types.ATTR_EOU_RESUME_COUNT, resumes)
 
     def _ensure_eou_wait_span(
         self,
@@ -2043,6 +2058,7 @@ class AudioRecognition:
         self._eou_wait_span = span
         self._eou_wait_started_at_ns = started_at_ns
         self._eou_wait_rearms = 0
+        self._eou_wait_not_committed = 0
         self._eou_wait_floor_ns = None
         return span
 
@@ -2063,6 +2079,7 @@ class AudioRecognition:
         span, self._eou_wait_span = self._eou_wait_span, None
         started_at_ns, self._eou_wait_started_at_ns = self._eou_wait_started_at_ns, None
         rearms, self._eou_wait_rearms = self._eou_wait_rearms, 0
+        not_committed, self._eou_wait_not_committed = self._eou_wait_not_committed, 0
         if span is None or not span.is_recording():
             return
 
@@ -2098,6 +2115,9 @@ class AudioRecognition:
                     else 0.0
                 ),
                 trace_types.ATTR_EOU_REARM_COUNT: rearms,
+                trace_types.ATTR_EOU_NOT_COMMITTED_COUNT: not_committed,
             }
         )
         span.end(end_time=ended_at_ns)
+        if outcome == "user_resumed":
+            self._user_turn_resumes += 1

--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import time
 from collections.abc import Callable, Generator, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -51,6 +52,8 @@ class SpeechHandle:
         self._chat_items: list[llm.ChatItem] = []
         self._num_steps = 1
         self._agent_turn_context: otel_context.Context | None = None
+        self._scheduled_at: float | None = None
+        self._authorized_at: float | None = None
 
         self._interrupt_timeout_handle: asyncio.TimerHandle | None = None
 
@@ -298,6 +301,8 @@ class SpeechHandle:
     def _authorize_generation(self) -> None:
         fut = asyncio.Future[None]()
         self._generations.append(fut)
+        if self._authorized_at is None:
+            self._authorized_at = time.perf_counter()
         self._authorize_event.set()
 
     def _clear_authorization(self) -> None:
@@ -338,5 +343,13 @@ class SpeechHandle:
             self._interrupt_timeout_handle = None
 
     def _mark_scheduled(self) -> None:
+        if self._scheduled_at is None:
+            self._scheduled_at = time.perf_counter()
         with contextlib.suppress(asyncio.InvalidStateError):
             self._scheduled_fut.set_result(None)
+
+    def _queue_wait(self) -> float | None:
+        """Seconds between scheduling and the first generation authorization, once known."""
+        if self._scheduled_at is None or self._authorized_at is None:
+            return None
+        return max(self._authorized_at - self._scheduled_at, 0.0)

--- a/tests/fake_session.py
+++ b/tests/fake_session.py
@@ -12,6 +12,7 @@ from livekit.agents import (
     EndpointingOptions,
     InterruptionOptions,
     NotGivenOr,
+    RecordingOptions,
     TurnHandlingOptions,
     utils,
 )
@@ -99,7 +100,13 @@ def create_session(
     return session
 
 
-async def run_session(session: AgentSession, agent: Agent, *, drain_delay: float = 5) -> float:
+async def run_session(
+    session: AgentSession,
+    agent: Agent,
+    *,
+    drain_delay: float = 5,
+    record: NotGivenOr[bool | RecordingOptions] = NOT_GIVEN,
+) -> float:
     stt = session.stt
     audio_input = session.input.audio
     assert isinstance(audio_input, FakeAudioInput)
@@ -108,7 +115,7 @@ async def run_session(session: AgentSession, agent: Agent, *, drain_delay: float
     if isinstance(session.output.audio, _SyncedAudioOutput):
         transcription_sync = session.output.audio._synchronizer
 
-    await session.start(agent)
+    await session.start(agent, record=record)
 
     # start the fake vad and stt
     t_origin = time.time()

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -34,6 +34,9 @@ class TestAudioRecognitionAclose:
         audio_recognition._AudioRecognition__stt_context = None
         audio_recognition._user_turn_span = None
         audio_recognition._user_turn_start = None
+        audio_recognition._eot_wait_span = None
+        audio_recognition._eot_wait_started_at = None
+        audio_recognition._eot_wait_rearms = 0
         audio_recognition._transcription_timeout_handle = None
 
         return audio_recognition

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -37,6 +37,8 @@ class TestAudioRecognitionAclose:
         audio_recognition._eou_wait_span = None
         audio_recognition._eou_wait_started_at_ns = None
         audio_recognition._eou_wait_rearms = 0
+        audio_recognition._eou_wait_floor_ns = None
+        audio_recognition._eou_detection_span = None
         audio_recognition._transcription_timeout_handle = None
 
         return audio_recognition

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -34,9 +34,9 @@ class TestAudioRecognitionAclose:
         audio_recognition._AudioRecognition__stt_context = None
         audio_recognition._user_turn_span = None
         audio_recognition._user_turn_start = None
-        audio_recognition._eot_wait_span = None
-        audio_recognition._eot_wait_started_at_ns = None
-        audio_recognition._eot_wait_rearms = 0
+        audio_recognition._eou_wait_span = None
+        audio_recognition._eou_wait_started_at_ns = None
+        audio_recognition._eou_wait_rearms = 0
         audio_recognition._transcription_timeout_handle = None
 
         return audio_recognition

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -35,7 +35,7 @@ class TestAudioRecognitionAclose:
         audio_recognition._user_turn_span = None
         audio_recognition._user_turn_start = None
         audio_recognition._eot_wait_span = None
-        audio_recognition._eot_wait_started_at = None
+        audio_recognition._eot_wait_started_at_ns = None
         audio_recognition._eot_wait_rearms = 0
         audio_recognition._transcription_timeout_handle = None
 

--- a/tests/test_audio_recognition_aclose.py
+++ b/tests/test_audio_recognition_aclose.py
@@ -38,6 +38,8 @@ class TestAudioRecognitionAclose:
         audio_recognition._eou_wait_started_at_ns = None
         audio_recognition._eou_wait_rearms = 0
         audio_recognition._eou_wait_floor_ns = None
+        audio_recognition._eou_wait_not_committed = 0
+        audio_recognition._user_turn_resumes = 0
         audio_recognition._eou_detection_span = None
         audio_recognition._transcription_timeout_handle = None
 

--- a/tests/test_audio_recognition_turn_detection.py
+++ b/tests/test_audio_recognition_turn_detection.py
@@ -102,6 +102,9 @@ def _make_full_recognition_for_eou() -> AudioRecognition:
     )
     ar._user_turn_span = None
     ar._user_turn_start = None
+    ar._eot_wait_span = None
+    ar._eot_wait_started_at = None
+    ar._eot_wait_rearms = 0
     ar._user_silence_ev = asyncio.Event()
     ar._speaking = False
     ar._final_transcript_confidence = []

--- a/tests/test_audio_recognition_turn_detection.py
+++ b/tests/test_audio_recognition_turn_detection.py
@@ -103,7 +103,7 @@ def _make_full_recognition_for_eou() -> AudioRecognition:
     ar._user_turn_span = None
     ar._user_turn_start = None
     ar._eot_wait_span = None
-    ar._eot_wait_started_at = None
+    ar._eot_wait_started_at_ns = None
     ar._eot_wait_rearms = 0
     ar._user_silence_ev = asyncio.Event()
     ar._speaking = False

--- a/tests/test_audio_recognition_turn_detection.py
+++ b/tests/test_audio_recognition_turn_detection.py
@@ -105,6 +105,8 @@ def _make_full_recognition_for_eou() -> AudioRecognition:
     ar._eou_wait_span = None
     ar._eou_wait_started_at_ns = None
     ar._eou_wait_rearms = 0
+    ar._eou_wait_floor_ns = None
+    ar._eou_detection_span = None
     ar._user_silence_ev = asyncio.Event()
     ar._speaking = False
     ar._final_transcript_confidence = []

--- a/tests/test_audio_recognition_turn_detection.py
+++ b/tests/test_audio_recognition_turn_detection.py
@@ -102,9 +102,9 @@ def _make_full_recognition_for_eou() -> AudioRecognition:
     )
     ar._user_turn_span = None
     ar._user_turn_start = None
-    ar._eot_wait_span = None
-    ar._eot_wait_started_at_ns = None
-    ar._eot_wait_rearms = 0
+    ar._eou_wait_span = None
+    ar._eou_wait_started_at_ns = None
+    ar._eou_wait_rearms = 0
     ar._user_silence_ev = asyncio.Event()
     ar._speaking = False
     ar._final_transcript_confidence = []

--- a/tests/test_audio_recognition_turn_detection.py
+++ b/tests/test_audio_recognition_turn_detection.py
@@ -106,6 +106,8 @@ def _make_full_recognition_for_eou() -> AudioRecognition:
     ar._eou_wait_started_at_ns = None
     ar._eou_wait_rearms = 0
     ar._eou_wait_floor_ns = None
+    ar._eou_wait_not_committed = 0
+    ar._user_turn_resumes = 0
     ar._eou_detection_span = None
     ar._user_silence_ev = asyncio.Event()
     ar._speaking = False

--- a/tests/test_eot_wait_span.py
+++ b/tests/test_eot_wait_span.py
@@ -1,0 +1,330 @@
+"""The ``eot_wait`` span: one per user turn, from the last speech anchor to the turn decision.
+
+``eot_detection`` (the turn-detector inference) nests under it; the wait itself was previously
+invisible, so a 2.5 s endpointing delay showed up as an empty gap between ``eot_detection`` and
+``agent_turn``. Also covers the ``on_user_turn_completed`` span and the queue-wait attribute on
+``agent_turn`` through a full fake session."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from livekit.agents import Agent, llm, vad
+from livekit.agents.telemetry import set_tracer_provider, trace_types, tracer
+from livekit.agents.voice.audio_recognition import AudioRecognition
+from livekit.agents.voice.turn import (
+    TurnDetectionEvent,
+    _StreamingTurnDetector,
+    _StreamingTurnDetectorStream,
+)
+
+from .fake_session import FakeActions, create_session, run_session
+
+pytestmark = [pytest.mark.unit, pytest.mark.no_concurrent]
+
+
+@pytest.fixture
+def span_exporter() -> Iterator[InMemorySpanExporter]:
+    original_provider = tracer._tracer_provider
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        set_tracer_provider(original_provider)
+        provider.shutdown()
+
+
+def _spans(exporter: InMemorySpanExporter, name: str) -> list[ReadableSpan]:
+    return [s for s in exporter.get_finished_spans() if s.name == name]
+
+
+def _events(span: ReadableSpan, name: str) -> list:
+    return [e for e in span.events if e.name == name]
+
+
+def _make_recognition(*, min_delay: float, with_detector: bool = False) -> AudioRecognition:
+    """Enough of ``AudioRecognition`` to drive ``_run_eou_detection`` with real spans.
+
+    ``_hooks.on_end_of_turn`` commits by default. VAD-only turn detection unless
+    ``with_detector`` wires the streaming turn-detector mocks (for ``eot_detection``)."""
+    ar = AudioRecognition.__new__(AudioRecognition)
+    ar._session = MagicMock()
+    ar._session._room_io = None  # keep participant attributes off the user_turn span
+    ar._session.amd = None
+    ar._session.options.transcription_timeout = None
+    ar._hooks = MagicMock()
+    ar._hooks.on_end_of_turn.return_value = True
+    ar._hooks.retrieve_chat_ctx.return_value = llm.ChatContext()
+    ar._stt = None
+    ar._stt_pipeline = None
+    ar._stt_model = None
+    ar._stt_provider = None
+    ar._vad = None
+    ar._turn_detection_mode = "vad"
+    ar._turn_detector = None
+    ar._turn_detector_stream = None
+    ar._turn_detector_prediction_fut = None
+    ar._turn_detector_flushed = False
+    ar._turn_detector_late_prediction_warned = False
+    ar._vad_base_turn_detection = False
+    ar._agent_speaking = False
+    ar._interruption_enabled = False
+    ar._interruption_ch = None
+    ar._turn_backchannel_over_agent = False
+    ar._overlap_in_current_turn = False
+    ar._active_vad_speech_started_at = None
+    ar._transcription_timeout_handle = None
+    ar._turn_speech_duration = 0.0
+    ar._turn_transcript_received = False
+    ar._audio_transcript = "hello there"
+    ar._final_transcript_confidence = []
+    ar._stt_request_ids = []
+    ar._last_speaking_time = None
+    ar._last_final_transcript_time = None
+    ar._speech_start_time = None
+    ar._vad_speech_started = False
+    ar._user_silence_ev = asyncio.Event()  # backs the _speaking setter
+    ar._speaking = False
+    ar._end_of_turn_task = None
+    ar._user_turn_committed = False
+    ar._last_language = None
+    ar._last_emitted_prediction = None
+    ar._user_turn_span = None
+    ar._user_turn_start = None
+    ar._eot_wait_span = None
+    ar._eot_wait_started_at = None
+    ar._eot_wait_rearms = 0
+    ar._closing = asyncio.Event()
+
+    endpointing = MagicMock()
+    endpointing.min_delay = min_delay
+    endpointing.max_delay = max(min_delay, 1.0)
+    ar._endpointing = endpointing
+
+    if with_detector:
+        ar._turn_detector = MagicMock(spec=_StreamingTurnDetector)
+        stream_mock = MagicMock(spec=_StreamingTurnDetectorStream)
+        stream_mock.supports_language = AsyncMock(return_value=True)
+        stream_mock.unlikely_threshold = AsyncMock(return_value=0.5)
+        stream_mock.backchannel_threshold = AsyncMock(return_value=None)
+        stream_mock.predict = MagicMock(side_effect=asyncio.Future)
+        stream_mock.flush = MagicMock()
+        stream_mock.cancel_inference = MagicMock()
+        stream_mock.prediction_timeout = 0.01
+        ar._turn_detector_stream = stream_mock
+        event = TurnDetectionEvent(
+            type="eot_prediction",
+            last_speaking_time=time.time(),
+            end_of_turn_probability=0.9,
+            inference_duration=0.01,
+            detection_delay=None,
+            backchannel_probability=None,
+        )
+        fut: asyncio.Future[TurnDetectionEvent] = asyncio.Future()
+        fut.set_result(event)
+        ar._turn_detector_prediction_fut = fut
+    return ar
+
+
+def _start_of_speech() -> vad.VADEvent:
+    return vad.VADEvent(
+        type=vad.VADEventType.START_OF_SPEECH,
+        samples_index=0,
+        timestamp=0.0,
+        speech_duration=0.5,
+        silence_duration=0.0,
+    )
+
+
+async def _await_bounce(ar: AudioRecognition) -> None:
+    task = ar._end_of_turn_task
+    assert task is not None
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+async def _cancel_bounce(ar: AudioRecognition) -> None:
+    task = ar._end_of_turn_task
+    if task is not None:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+async def test_wait_span_covers_last_speech_to_commit(span_exporter: InMemorySpanExporter) -> None:
+    ar = _make_recognition(min_delay=0.05)
+    # the user stopped talking 0.3 s ago: the wait is back-dated there and commits at once
+    last_speaking = time.time() - 0.3
+    ar._last_speaking_time = last_speaking
+
+    ar._run_eou_detection(llm.ChatContext(), trigger="vad")
+    await _await_bounce(ar)
+
+    [wait] = _spans(span_exporter, "eot_wait")
+    [user_turn] = _spans(span_exporter, "user_turn")
+    assert wait.parent is not None
+    assert wait.parent.span_id == user_turn.context.span_id
+
+    assert wait.start_time == int(last_speaking * 1_000_000_000)
+    attrs = wait.attributes or {}
+    assert attrs[trace_types.ATTR_EOU_OUTCOME] == "committed"
+    assert attrs[trace_types.ATTR_EOU_SOURCE] == "vad"
+    assert attrs[trace_types.ATTR_EOU_DELAY] == 0.05
+    assert attrs[trace_types.ATTR_EOU_REARM_COUNT] == 0
+    wait_duration = attrs[trace_types.ATTR_EOU_WAIT_DURATION]
+    assert isinstance(wait_duration, float)
+    assert 0.3 <= wait_duration < 0.6
+    assert wait.end_time is not None
+    assert abs((wait.end_time - wait.start_time) / 1e9 - wait_duration) < 1e-6
+    # the wait closes before the turn does
+    assert user_turn.end_time is not None and wait.end_time <= user_turn.end_time
+    assert ar._eot_wait_span is None
+
+
+async def test_later_trigger_rearms_the_same_span(span_exporter: InMemorySpanExporter) -> None:
+    ar = _make_recognition(min_delay=0.3)
+    ar._last_speaking_time = time.time()
+
+    ar._run_eou_detection(llm.ChatContext(), trigger="vad")
+    await asyncio.sleep(0.05)
+    # a late STT final re-triggers end of turn; the bounce task restarts, the span must not
+    ar._run_eou_detection(llm.ChatContext(), trigger="stt")
+    await _await_bounce(ar)
+
+    [wait] = _spans(span_exporter, "eot_wait")
+    attrs = wait.attributes or {}
+    assert attrs[trace_types.ATTR_EOU_OUTCOME] == "committed"
+    assert attrs[trace_types.ATTR_EOU_REARM_COUNT] == 1
+    assert attrs[trace_types.ATTR_EOU_SOURCE] == "stt"
+    [rearmed] = _events(wait, "rearmed")
+    assert (rearmed.attributes or {})[trace_types.ATTR_EOU_SOURCE] == "stt"
+
+
+async def test_resumed_speech_ends_wait_at_speech_start(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    ar = _make_recognition(min_delay=1.0)
+    ar._last_speaking_time = time.time()
+    ar._run_eou_detection(llm.ChatContext(), trigger="vad")
+    await asyncio.sleep(0.05)
+
+    before = time.time()
+    await ar._on_vad_event(_start_of_speech())  # speech_duration=0.5 -> started 0.5 s ago
+    after = time.time()
+    await _cancel_bounce(ar)
+
+    [wait] = _spans(span_exporter, "eot_wait")
+    attrs = wait.attributes or {}
+    assert attrs[trace_types.ATTR_EOU_OUTCOME] == "user_resumed"
+    # ended where the resumed speech started, per VAD, clamped to the wait's own start
+    assert wait.end_time is not None
+    speech_started_between = (int((before - 0.5) * 1e9), int((after - 0.5) * 1e9))
+    assert wait.start_time <= wait.end_time
+    assert wait.end_time <= max(speech_started_between[1], wait.start_time)
+    # the user turn itself stays open: they are still talking
+    assert _spans(span_exporter, "user_turn") == []
+    assert ar._user_turn_span is not None and ar._user_turn_span.is_recording()
+    ar._end_user_turn_span()
+
+
+async def test_teardown_drops_an_open_wait(span_exporter: InMemorySpanExporter) -> None:
+    ar = _make_recognition(min_delay=1.0)
+    ar._last_speaking_time = time.time()
+    ar._run_eou_detection(llm.ChatContext(), trigger="vad")
+    await asyncio.sleep(0.02)
+
+    ar._end_user_turn_span()
+    await _cancel_bounce(ar)
+
+    [wait] = _spans(span_exporter, "eot_wait")
+    assert (wait.attributes or {})[trace_types.ATTR_EOU_OUTCOME] == "dropped"
+    [user_turn] = _spans(span_exporter, "user_turn")
+    assert user_turn.end_time is not None and wait.end_time is not None
+    assert wait.end_time <= user_turn.end_time
+
+
+async def test_not_committed_turn_keeps_waiting(span_exporter: InMemorySpanExporter) -> None:
+    ar = _make_recognition(min_delay=0.01)
+    ar._hooks.on_end_of_turn.return_value = False  # e.g. below interruption min_words
+    ar._last_speaking_time = time.time()
+    ar._run_eou_detection(llm.ChatContext(), trigger="vad")
+    await _await_bounce(ar)
+
+    # the decision is deferred: the span records the rejection and stays open
+    assert _spans(span_exporter, "eot_wait") == []
+    assert ar._eot_wait_span is not None and ar._eot_wait_span.is_recording()
+    ar._end_user_turn_span()
+    [wait] = _spans(span_exporter, "eot_wait")
+    assert len(_events(wait, "not_committed")) == 1
+    assert (wait.attributes or {})[trace_types.ATTR_EOU_OUTCOME] == "dropped"
+
+
+async def test_detection_nests_under_wait_with_new_name(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    ar = _make_recognition(min_delay=0.01, with_detector=True)
+    ar._last_speaking_time = time.time()
+    ar._run_eou_detection(llm.ChatContext(), trigger="vad")
+    await _await_bounce(ar)
+
+    assert _spans(span_exporter, "eou_detection") == []
+    [detection] = _spans(span_exporter, "eot_detection")
+    [wait] = _spans(span_exporter, "eot_wait")
+    assert detection.parent is not None
+    assert detection.parent.span_id == wait.context.span_id
+    assert (detection.attributes or {})[trace_types.ATTR_EOU_PROBABILITY] == 0.9
+    # the delay decided by the prediction is stamped on the wait too
+    assert (wait.attributes or {})[trace_types.ATTR_EOU_DELAY] == 0.01
+
+
+class _HookAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="test")
+
+    async def on_user_turn_completed(
+        self, turn_ctx: llm.ChatContext, new_message: llm.ChatMessage
+    ) -> None:
+        await asyncio.sleep(0.05)
+
+
+async def test_full_session_turn_handoff_spans(span_exporter: InMemorySpanExporter) -> None:
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 1.5, "Hello, how are you?", stt_delay=0.1)
+    actions.add_llm("I'm doing well, thank you!", ttft=0.1, duration=0.2)
+    actions.add_tts(0.5, ttfb=0.1, duration=0.2)
+
+    session = create_session(actions, speed_factor=2.0)
+    await asyncio.wait_for(run_session(session, _HookAgent(), drain_delay=1.0), timeout=30)
+
+    [wait] = _spans(span_exporter, "eot_wait")
+    [user_turn] = _spans(span_exporter, "user_turn")
+    assert wait.parent is not None and wait.parent.span_id == user_turn.context.span_id
+    assert (wait.attributes or {})[trace_types.ATTR_EOU_OUTCOME] == "committed"
+
+    [hook] = _spans(span_exporter, "on_user_turn_completed")
+    assert hook.end_time is not None
+    assert (hook.end_time - hook.start_time) / 1e9 >= 0.05
+    assert (hook.attributes or {})[trace_types.ATTR_AGENT_LABEL] == "_hook_agent"
+
+    # the reply's agent_turn records how long it sat in the speech queue
+    turns = [
+        s
+        for s in _spans(span_exporter, "agent_turn")
+        if trace_types.ATTR_SPEECH_QUEUE_WAIT in (s.attributes or {})
+    ]
+    assert turns, "no agent_turn carries the queue wait"
+    for turn in turns:
+        queue_wait = (turn.attributes or {})[trace_types.ATTR_SPEECH_QUEUE_WAIT]
+        assert isinstance(queue_wait, float) and 0.0 <= queue_wait < 5.0

--- a/tests/test_eot_wait_span.py
+++ b/tests/test_eot_wait_span.py
@@ -104,7 +104,7 @@ def _make_recognition(*, min_delay: float, with_detector: bool = False) -> Audio
     ar._user_turn_span = None
     ar._user_turn_start = None
     ar._eot_wait_span = None
-    ar._eot_wait_started_at = None
+    ar._eot_wait_started_at_ns = None
     ar._eot_wait_rearms = 0
     ar._closing = asyncio.Event()
 
@@ -187,7 +187,8 @@ async def test_wait_span_covers_last_speech_to_commit(span_exporter: InMemorySpa
     assert isinstance(wait_duration, float)
     assert 0.3 <= wait_duration < 0.6
     assert wait.end_time is not None
-    assert abs((wait.end_time - wait.start_time) / 1e9 - wait_duration) < 1e-6
+    # the attribute is derived from the span's own start/end nanoseconds: identical, not close
+    assert (wait.end_time - wait.start_time) / 1e9 == wait_duration
     # the wait closes before the turn does
     assert user_turn.end_time is not None and wait.end_time <= user_turn.end_time
     assert ar._eot_wait_span is None

--- a/tests/test_eou_wait_span.py
+++ b/tests/test_eou_wait_span.py
@@ -1,7 +1,7 @@
-"""The ``eot_wait`` span: one per user turn, from the last speech anchor to the turn decision.
+"""The ``eou_wait`` span: one per user turn, from the last speech anchor to the turn decision.
 
-``eot_detection`` (the turn-detector inference) nests under it; the wait itself was previously
-invisible, so a 2.5 s endpointing delay showed up as an empty gap between ``eot_detection`` and
+``eou_detection`` (the turn-detector inference) nests under it; the wait itself was previously
+invisible, so a 2.5 s endpointing delay showed up as an empty gap between ``eou_detection`` and
 ``agent_turn``. Also covers the ``on_user_turn_completed`` span and the queue-wait attribute on
 ``agent_turn`` through a full fake session."""
 
@@ -58,7 +58,7 @@ def _make_recognition(*, min_delay: float, with_detector: bool = False) -> Audio
     """Enough of ``AudioRecognition`` to drive ``_run_eou_detection`` with real spans.
 
     ``_hooks.on_end_of_turn`` commits by default. VAD-only turn detection unless
-    ``with_detector`` wires the streaming turn-detector mocks (for ``eot_detection``)."""
+    ``with_detector`` wires the streaming turn-detector mocks (for ``eou_detection``)."""
     ar = AudioRecognition.__new__(AudioRecognition)
     ar._session = MagicMock()
     ar._session._room_io = None  # keep participant attributes off the user_turn span
@@ -103,9 +103,9 @@ def _make_recognition(*, min_delay: float, with_detector: bool = False) -> Audio
     ar._last_emitted_prediction = None
     ar._user_turn_span = None
     ar._user_turn_start = None
-    ar._eot_wait_span = None
-    ar._eot_wait_started_at_ns = None
-    ar._eot_wait_rearms = 0
+    ar._eou_wait_span = None
+    ar._eou_wait_started_at_ns = None
+    ar._eou_wait_rearms = 0
     ar._closing = asyncio.Event()
 
     endpointing = MagicMock()
@@ -172,7 +172,7 @@ async def test_wait_span_covers_last_speech_to_commit(span_exporter: InMemorySpa
     ar._run_eou_detection(llm.ChatContext(), trigger="vad")
     await _await_bounce(ar)
 
-    [wait] = _spans(span_exporter, "eot_wait")
+    [wait] = _spans(span_exporter, "eou_wait")
     [user_turn] = _spans(span_exporter, "user_turn")
     assert wait.parent is not None
     assert wait.parent.span_id == user_turn.context.span_id
@@ -191,7 +191,7 @@ async def test_wait_span_covers_last_speech_to_commit(span_exporter: InMemorySpa
     assert (wait.end_time - wait.start_time) / 1e9 == wait_duration
     # the wait closes before the turn does
     assert user_turn.end_time is not None and wait.end_time <= user_turn.end_time
-    assert ar._eot_wait_span is None
+    assert ar._eou_wait_span is None
 
 
 async def test_later_trigger_rearms_the_same_span(span_exporter: InMemorySpanExporter) -> None:
@@ -204,7 +204,7 @@ async def test_later_trigger_rearms_the_same_span(span_exporter: InMemorySpanExp
     ar._run_eou_detection(llm.ChatContext(), trigger="stt")
     await _await_bounce(ar)
 
-    [wait] = _spans(span_exporter, "eot_wait")
+    [wait] = _spans(span_exporter, "eou_wait")
     attrs = wait.attributes or {}
     assert attrs[trace_types.ATTR_EOU_OUTCOME] == "committed"
     assert attrs[trace_types.ATTR_EOU_REARM_COUNT] == 1
@@ -226,7 +226,7 @@ async def test_resumed_speech_ends_wait_at_speech_start(
     after = time.time()
     await _cancel_bounce(ar)
 
-    [wait] = _spans(span_exporter, "eot_wait")
+    [wait] = _spans(span_exporter, "eou_wait")
     attrs = wait.attributes or {}
     assert attrs[trace_types.ATTR_EOU_OUTCOME] == "user_resumed"
     # ended where the resumed speech started, per VAD, clamped to the wait's own start
@@ -249,7 +249,7 @@ async def test_teardown_drops_an_open_wait(span_exporter: InMemorySpanExporter) 
     ar._end_user_turn_span()
     await _cancel_bounce(ar)
 
-    [wait] = _spans(span_exporter, "eot_wait")
+    [wait] = _spans(span_exporter, "eou_wait")
     assert (wait.attributes or {})[trace_types.ATTR_EOU_OUTCOME] == "dropped"
     [user_turn] = _spans(span_exporter, "user_turn")
     assert user_turn.end_time is not None and wait.end_time is not None
@@ -264,25 +264,22 @@ async def test_not_committed_turn_keeps_waiting(span_exporter: InMemorySpanExpor
     await _await_bounce(ar)
 
     # the decision is deferred: the span records the rejection and stays open
-    assert _spans(span_exporter, "eot_wait") == []
-    assert ar._eot_wait_span is not None and ar._eot_wait_span.is_recording()
+    assert _spans(span_exporter, "eou_wait") == []
+    assert ar._eou_wait_span is not None and ar._eou_wait_span.is_recording()
     ar._end_user_turn_span()
-    [wait] = _spans(span_exporter, "eot_wait")
+    [wait] = _spans(span_exporter, "eou_wait")
     assert len(_events(wait, "not_committed")) == 1
     assert (wait.attributes or {})[trace_types.ATTR_EOU_OUTCOME] == "dropped"
 
 
-async def test_detection_nests_under_wait_with_new_name(
-    span_exporter: InMemorySpanExporter,
-) -> None:
+async def test_detection_nests_under_wait(span_exporter: InMemorySpanExporter) -> None:
     ar = _make_recognition(min_delay=0.01, with_detector=True)
     ar._last_speaking_time = time.time()
     ar._run_eou_detection(llm.ChatContext(), trigger="vad")
     await _await_bounce(ar)
 
-    assert _spans(span_exporter, "eou_detection") == []
-    [detection] = _spans(span_exporter, "eot_detection")
-    [wait] = _spans(span_exporter, "eot_wait")
+    [detection] = _spans(span_exporter, "eou_detection")
+    [wait] = _spans(span_exporter, "eou_wait")
     assert detection.parent is not None
     assert detection.parent.span_id == wait.context.span_id
     assert (detection.attributes or {})[trace_types.ATTR_EOU_PROBABILITY] == 0.9
@@ -309,7 +306,7 @@ async def test_full_session_turn_handoff_spans(span_exporter: InMemorySpanExport
     session = create_session(actions, speed_factor=2.0)
     await asyncio.wait_for(run_session(session, _HookAgent(), drain_delay=1.0), timeout=30)
 
-    [wait] = _spans(span_exporter, "eot_wait")
+    [wait] = _spans(span_exporter, "eou_wait")
     [user_turn] = _spans(span_exporter, "user_turn")
     assert wait.parent is not None and wait.parent.span_id == user_turn.context.span_id
     assert (wait.attributes or {})[trace_types.ATTR_EOU_OUTCOME] == "committed"

--- a/tests/test_eou_wait_span.py
+++ b/tests/test_eou_wait_span.py
@@ -20,6 +20,8 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 from livekit.agents import Agent, llm, vad
 from livekit.agents.telemetry import set_tracer_provider, trace_types, tracer
+from livekit.agents.telemetry.utils import REDACTED_EXCEPTION_MESSAGE
+from livekit.agents.voice.agent_session import _RECORDING_ALL_OFF
 from livekit.agents.voice.audio_recognition import AudioRecognition
 from livekit.agents.voice.turn import (
     TurnDetectionEvent,
@@ -106,6 +108,8 @@ def _make_recognition(*, min_delay: float, with_detector: bool = False) -> Audio
     ar._eou_wait_span = None
     ar._eou_wait_started_at_ns = None
     ar._eou_wait_rearms = 0
+    ar._eou_wait_floor_ns = None
+    ar._eou_detection_span = None
     ar._closing = asyncio.Event()
 
     endpointing = MagicMock()
@@ -287,6 +291,59 @@ async def test_detection_nests_under_wait(span_exporter: InMemorySpanExporter) -
     assert (wait.attributes or {})[trace_types.ATTR_EOU_DELAY] == 0.01
 
 
+async def test_resumed_speech_during_detection_keeps_the_child_inside(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """VAD reports a resumed speech start after the fact; if the detector was still running
+    the wait cannot end back there, or eou_detection would outlive its parent."""
+    ar = _make_recognition(min_delay=1.0, with_detector=True)
+    pending: asyncio.Future[TurnDetectionEvent] = asyncio.Future()
+    ar._turn_detector_prediction_fut = pending  # inference never answers
+    ar._turn_detector_stream.prediction_timeout = 10.0  # type: ignore[union-attr]
+    ar._last_speaking_time = time.time()
+    ar._run_eou_detection(llm.ChatContext(), trigger="vad")
+    await asyncio.sleep(0.05)
+    assert ar._eou_detection_span is not None and ar._eou_detection_span.is_recording()
+
+    await ar._on_vad_event(_start_of_speech())  # started 0.5 s ago, before the detection began
+    await _cancel_bounce(ar)
+
+    [wait] = _spans(span_exporter, "eou_wait")
+    [detection] = _spans(span_exporter, "eou_detection")
+    assert detection.parent is not None and detection.parent.span_id == wait.context.span_id
+    assert wait.start_time <= detection.start_time
+    assert detection.end_time is not None and wait.end_time is not None
+    assert detection.end_time <= wait.end_time
+    assert [e.name for e in detection.events] == ["superseded"]
+    attrs = wait.attributes or {}
+    assert attrs[trace_types.ATTR_EOU_OUTCOME] == "user_resumed"
+    assert attrs[trace_types.ATTR_EOU_WAIT_DURATION] == pytest.approx(
+        (wait.end_time - wait.start_time) / 1e9
+    )
+    # the real resume time survives as an event inside the bar
+    [resumed] = _events(wait, "user_resumed")
+    assert wait.start_time <= resumed.timestamp <= wait.end_time
+    ar._end_user_turn_span()
+
+
+async def test_turn_mode_change_drops_an_open_wait(span_exporter: InMemorySpanExporter) -> None:
+    ar = _make_recognition(min_delay=1.0)
+    ar._last_speaking_time = time.time()
+    ar._run_eou_detection(llm.ChatContext(), trigger="vad")
+    await asyncio.sleep(0.02)
+    assert ar._eou_wait_span is not None
+
+    ar._update_options(turn_detection="manual")
+    await asyncio.sleep(0)  # let the cancelled bounce task unwind
+
+    [wait] = _spans(span_exporter, "eou_wait")
+    assert (wait.attributes or {})[trace_types.ATTR_EOU_OUTCOME] == "dropped"
+    assert ar._eou_wait_span is None and ar._end_of_turn_task is None
+    # the user turn is still open for whatever the manual mode does with the next speech
+    assert ar._user_turn_span is not None and ar._user_turn_span.is_recording()
+    ar._end_user_turn_span()
+
+
 class _HookAgent(Agent):
     def __init__(self) -> None:
         super().__init__(instructions="test")
@@ -326,3 +383,46 @@ async def test_full_session_turn_handoff_spans(span_exporter: InMemorySpanExport
     for turn in turns:
         queue_wait = (turn.attributes or {})[trace_types.ATTR_SPEECH_QUEUE_WAIT]
         assert isinstance(queue_wait, float) and 0.0 <= queue_wait < 5.0
+
+
+class _RaisingHookAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="test")
+
+    async def on_user_turn_completed(
+        self, turn_ctx: llm.ChatContext, new_message: llm.ChatMessage
+    ) -> None:
+        raise RuntimeError(f"lookup failed for {new_message.text_content}")
+
+
+async def test_hook_exception_honours_session_redaction(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """``record={"redaction": True}`` on the session alone (no job flag) must still keep the
+    hook's exception message, which can quote the transcript, out of the trace."""
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 1.5, "My name is Jane Doe", stt_delay=0.1)
+    actions.add_llm("Sorry about that.", ttft=0.1, duration=0.2)
+    actions.add_tts(0.5, ttfb=0.1, duration=0.2)
+
+    session = create_session(actions, speed_factor=2.0)
+    await asyncio.wait_for(
+        run_session(
+            session,
+            _RaisingHookAgent(),
+            drain_delay=1.0,
+            record={**_RECORDING_ALL_OFF, "redaction": True},  # type: ignore[typeddict-item]
+        ),
+        timeout=30,
+    )
+    assert session._redaction_enabled
+
+    [hook] = _spans(span_exporter, "on_user_turn_completed")
+    assert hook.status.status_code.name == "ERROR"
+    attrs = hook.attributes or {}
+    assert attrs[trace_types.ATTR_EXCEPTION_TYPE] == "RuntimeError"
+    assert attrs[trace_types.ATTR_EXCEPTION_MESSAGE] == REDACTED_EXCEPTION_MESSAGE
+    rendered = repr(hook.attributes) + repr(
+        [(e.name, dict(e.attributes or {})) for e in hook.events]
+    )
+    assert "Jane Doe" not in rendered and "lookup failed" not in rendered

--- a/tests/test_eou_wait_span.py
+++ b/tests/test_eou_wait_span.py
@@ -372,6 +372,10 @@ async def test_full_session_turn_handoff_spans(span_exporter: InMemorySpanExport
     assert hook.end_time is not None
     assert (hook.end_time - hook.start_time) / 1e9 >= 0.05
     assert (hook.attributes or {})[trace_types.ATTR_AGENT_LABEL] == "_hook_agent"
+    # the hook is part of the turn: it nests under user_turn, which ends after it (a
+    # preemptive generation may already have started its agent_turn by then; that is fine)
+    assert hook.parent is not None and hook.parent.span_id == user_turn.context.span_id
+    assert user_turn.end_time is not None and user_turn.end_time >= hook.end_time
 
     # the reply's agent_turn records how long it sat in the speech queue
     turns = [

--- a/tests/test_eou_wait_span.py
+++ b/tests/test_eou_wait_span.py
@@ -317,6 +317,9 @@ async def test_resumed_speech_during_detection_keeps_the_child_inside(
     assert [e.name for e in detection.events] == ["superseded"]
     attrs = wait.attributes or {}
     assert attrs[trace_types.ATTR_EOU_OUTCOME] == "user_resumed"
+    # the delay in force is stamped when the wait opens, so a wait ended by resumed speech
+    # before the detector answered still carries it
+    assert trace_types.ATTR_EOU_DELAY in attrs
     assert attrs[trace_types.ATTR_EOU_WAIT_DURATION] == pytest.approx(
         (wait.end_time - wait.start_time) / 1e9
     )

--- a/tests/test_eou_wait_span.py
+++ b/tests/test_eou_wait_span.py
@@ -199,7 +199,8 @@ async def test_wait_span_covers_last_speech_to_commit(span_exporter: InMemorySpa
 
 
 async def test_later_trigger_rearms_the_same_span(span_exporter: InMemorySpanExporter) -> None:
-    ar = _make_recognition(min_delay=0.3)
+    # the wait is long relative to the re-trigger so a slow CI runner cannot let it commit first
+    ar = _make_recognition(min_delay=1.0)
     ar._last_speaking_time = time.time()
 
     ar._run_eou_detection(llm.ChatContext(), trigger="vad")

--- a/tests/test_eou_wait_span.py
+++ b/tests/test_eou_wait_span.py
@@ -109,6 +109,8 @@ def _make_recognition(*, min_delay: float, with_detector: bool = False) -> Audio
     ar._eou_wait_started_at_ns = None
     ar._eou_wait_rearms = 0
     ar._eou_wait_floor_ns = None
+    ar._eou_wait_not_committed = 0
+    ar._user_turn_resumes = 0
     ar._eou_detection_span = None
     ar._closing = asyncio.Event()
 
@@ -182,6 +184,9 @@ async def test_wait_span_covers_last_speech_to_commit(span_exporter: InMemorySpa
     assert wait.parent.span_id == user_turn.context.span_id
 
     assert wait.start_time == int(last_speaking * 1_000_000_000)
+    # no VAD opened this turn: created here, it starts at the last speaking time too, so the
+    # back-dated wait never starts before its parent
+    assert user_turn.start_time <= wait.start_time
     attrs = wait.attributes or {}
     assert attrs[trace_types.ATTR_EOU_OUTCOME] == "committed"
     assert attrs[trace_types.ATTR_EOU_SOURCE] == "vad"
@@ -243,6 +248,9 @@ async def test_resumed_speech_ends_wait_at_speech_start(
     assert _spans(span_exporter, "user_turn") == []
     assert ar._user_turn_span is not None and ar._user_turn_span.is_recording()
     ar._end_user_turn_span()
+    # the turn counts the waits the user cut short
+    [user_turn] = _spans(span_exporter, "user_turn")
+    assert (user_turn.attributes or {})[trace_types.ATTR_EOU_RESUME_COUNT] == 1
 
 
 async def test_teardown_drops_an_open_wait(span_exporter: InMemorySpanExporter) -> None:
@@ -273,8 +281,10 @@ async def test_not_committed_turn_keeps_waiting(span_exporter: InMemorySpanExpor
     assert ar._eou_wait_span is not None and ar._eou_wait_span.is_recording()
     ar._end_user_turn_span()
     [wait] = _spans(span_exporter, "eou_wait")
-    assert len(_events(wait, "not_committed")) == 1
-    assert (wait.attributes or {})[trace_types.ATTR_EOU_OUTCOME] == "dropped"
+    attrs = wait.attributes or {}
+    assert attrs[trace_types.ATTR_EOU_NOT_COMMITTED_COUNT] == 1
+    assert attrs[trace_types.ATTR_EOU_OUTCOME] == "dropped"
+    assert wait.events == ()
 
 
 async def test_detection_nests_under_wait(span_exporter: InMemorySpanExporter) -> None:
@@ -391,6 +401,22 @@ async def test_full_session_turn_handoff_spans(span_exporter: InMemorySpanExport
     for turn in turns:
         queue_wait = (turn.attributes or {})[trace_types.ATTR_SPEECH_QUEUE_WAIT]
         assert isinstance(queue_wait, float) and 0.0 <= queue_wait < 5.0
+
+    # the reply that answered the turn carries the user-side stages next to lk.e2e_latency,
+    # so the per-turn breakdown reads off one span
+    [reply] = [
+        s
+        for s in _spans(span_exporter, "agent_turn")
+        if trace_types.ATTR_E2E_LATENCY in (s.attributes or {})
+    ]
+    attrs = reply.attributes or {}
+    for key in (
+        trace_types.ATTR_END_OF_TURN_DELAY,
+        trace_types.ATTR_TRANSCRIPTION_DELAY,
+        trace_types.ATTR_ON_USER_TURN_COMPLETED_DELAY,
+    ):
+        assert isinstance(attrs[key], float), key
+    assert attrs[trace_types.ATTR_ON_USER_TURN_COMPLETED_DELAY] >= 0.05  # the hook sleeps
 
 
 class _RaisingHookAgent(Agent):

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -92,6 +92,9 @@ def _recognition(hooks: AgentActivity, last_speaking_time: float) -> AudioRecogn
     )
     ar._user_turn_span = None
     ar._user_turn_start = None
+    ar._eot_wait_span = None
+    ar._eot_wait_started_at = None
+    ar._eot_wait_rearms = 0
     ar._user_silence_ev = asyncio.Event()
     ar._speaking = False
     ar._final_transcript_confidence = []

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -92,9 +92,9 @@ def _recognition(hooks: AgentActivity, last_speaking_time: float) -> AudioRecogn
     )
     ar._user_turn_span = None
     ar._user_turn_start = None
-    ar._eot_wait_span = None
-    ar._eot_wait_started_at_ns = None
-    ar._eot_wait_rearms = 0
+    ar._eou_wait_span = None
+    ar._eou_wait_started_at_ns = None
+    ar._eou_wait_rearms = 0
     ar._user_silence_ev = asyncio.Event()
     ar._speaking = False
     ar._final_transcript_confidence = []

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -93,7 +93,7 @@ def _recognition(hooks: AgentActivity, last_speaking_time: float) -> AudioRecogn
     ar._user_turn_span = None
     ar._user_turn_start = None
     ar._eot_wait_span = None
-    ar._eot_wait_started_at = None
+    ar._eot_wait_started_at_ns = None
     ar._eot_wait_rearms = 0
     ar._user_silence_ev = asyncio.Event()
     ar._speaking = False

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -95,6 +95,8 @@ def _recognition(hooks: AgentActivity, last_speaking_time: float) -> AudioRecogn
     ar._eou_wait_span = None
     ar._eou_wait_started_at_ns = None
     ar._eou_wait_rearms = 0
+    ar._eou_wait_floor_ns = None
+    ar._eou_detection_span = None
     ar._user_silence_ev = asyncio.Event()
     ar._speaking = False
     ar._final_transcript_confidence = []

--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -96,6 +96,8 @@ def _recognition(hooks: AgentActivity, last_speaking_time: float) -> AudioRecogn
     ar._eou_wait_started_at_ns = None
     ar._eou_wait_rearms = 0
     ar._eou_wait_floor_ns = None
+    ar._eou_wait_not_committed = 0
+    ar._user_turn_resumes = 0
     ar._eou_detection_span = None
     ar._user_silence_ev = asyncio.Event()
     ar._speaking = False

--- a/tests/test_speech_start_time_persistence.py
+++ b/tests/test_speech_start_time_persistence.py
@@ -51,6 +51,9 @@ class TestUserTurnStartPersistence:
         audio_recognition._end_of_turn_task = None
         audio_recognition._user_turn_span = None
         audio_recognition._user_turn_start = None
+        audio_recognition._eot_wait_span = None
+        audio_recognition._eot_wait_started_at = None
+        audio_recognition._eot_wait_rearms = 0
         audio_recognition._user_turn_committed = False
         # disable EOU detection from EOS branch — we're testing VAD state, not EOT
         audio_recognition._vad_base_turn_detection = False

--- a/tests/test_speech_start_time_persistence.py
+++ b/tests/test_speech_start_time_persistence.py
@@ -54,6 +54,8 @@ class TestUserTurnStartPersistence:
         audio_recognition._eou_wait_span = None
         audio_recognition._eou_wait_started_at_ns = None
         audio_recognition._eou_wait_rearms = 0
+        audio_recognition._eou_wait_floor_ns = None
+        audio_recognition._eou_detection_span = None
         audio_recognition._user_turn_committed = False
         # disable EOU detection from EOS branch — we're testing VAD state, not EOT
         audio_recognition._vad_base_turn_detection = False

--- a/tests/test_speech_start_time_persistence.py
+++ b/tests/test_speech_start_time_persistence.py
@@ -52,7 +52,7 @@ class TestUserTurnStartPersistence:
         audio_recognition._user_turn_span = None
         audio_recognition._user_turn_start = None
         audio_recognition._eot_wait_span = None
-        audio_recognition._eot_wait_started_at = None
+        audio_recognition._eot_wait_started_at_ns = None
         audio_recognition._eot_wait_rearms = 0
         audio_recognition._user_turn_committed = False
         # disable EOU detection from EOS branch — we're testing VAD state, not EOT

--- a/tests/test_speech_start_time_persistence.py
+++ b/tests/test_speech_start_time_persistence.py
@@ -51,9 +51,9 @@ class TestUserTurnStartPersistence:
         audio_recognition._end_of_turn_task = None
         audio_recognition._user_turn_span = None
         audio_recognition._user_turn_start = None
-        audio_recognition._eot_wait_span = None
-        audio_recognition._eot_wait_started_at_ns = None
-        audio_recognition._eot_wait_rearms = 0
+        audio_recognition._eou_wait_span = None
+        audio_recognition._eou_wait_started_at_ns = None
+        audio_recognition._eou_wait_rearms = 0
         audio_recognition._user_turn_committed = False
         # disable EOU detection from EOS branch — we're testing VAD state, not EOT
         audio_recognition._vad_base_turn_detection = False

--- a/tests/test_speech_start_time_persistence.py
+++ b/tests/test_speech_start_time_persistence.py
@@ -55,6 +55,8 @@ class TestUserTurnStartPersistence:
         audio_recognition._eou_wait_started_at_ns = None
         audio_recognition._eou_wait_rearms = 0
         audio_recognition._eou_wait_floor_ns = None
+        audio_recognition._eou_wait_not_committed = 0
+        audio_recognition._user_turn_resumes = 0
         audio_recognition._eou_detection_span = None
         audio_recognition._user_turn_committed = False
         # disable EOU detection from EOS branch — we're testing VAD state, not EOT

--- a/tests/test_trace_types_pii.py
+++ b/tests/test_trace_types_pii.py
@@ -163,6 +163,11 @@ SAFE_KEYS = frozenset(
         "gen_ai.client.token.usage",
         "gen_ai.execute_tool.duration",
         "gen_ai.invoke_agent.duration",
+        # eot_wait / speech scheduling (timings and enums)
+        "lk.eou.outcome",
+        "lk.eou.wait_duration",
+        "lk.eou.rearm_count",
+        "lk.speech.queue_wait",
         # event loop blocking (timings, task name, source-location stack; no values)
         "lk.blocking.duration",
         "lk.blocking.threshold",

--- a/tests/test_trace_types_pii.py
+++ b/tests/test_trace_types_pii.py
@@ -163,7 +163,7 @@ SAFE_KEYS = frozenset(
         "gen_ai.client.token.usage",
         "gen_ai.execute_tool.duration",
         "gen_ai.invoke_agent.duration",
-        # eot_wait / speech scheduling (timings and enums)
+        # eou_wait / speech scheduling (timings and enums)
         "lk.eou.outcome",
         "lk.eou.wait_duration",
         "lk.eou.rearm_count",

--- a/tests/test_trace_types_pii.py
+++ b/tests/test_trace_types_pii.py
@@ -167,6 +167,9 @@ SAFE_KEYS = frozenset(
         "lk.eou.outcome",
         "lk.eou.wait_duration",
         "lk.eou.rearm_count",
+        "lk.eou.not_committed_count",
+        "lk.eou.resume_count",
+        "lk.on_user_turn_completed_delay",
         "lk.speech.queue_wait",
         # event loop blocking (timings, task name, source-location stack; no values)
         "lk.blocking.duration",

--- a/tests/test_transcription_delay_anchor.py
+++ b/tests/test_transcription_delay_anchor.py
@@ -83,6 +83,9 @@ def _make_recognition(
     # only reached by the stt-mode END_OF_SPEECH / START_OF_SPEECH branches
     ar._user_turn_span = None
     ar._user_turn_start = None
+    ar._eot_wait_span = None
+    ar._eot_wait_started_at = None
+    ar._eot_wait_rearms = 0
     ar._stt_model = None
     ar._stt_provider = None
     ar._vad_stream = None

--- a/tests/test_transcription_delay_anchor.py
+++ b/tests/test_transcription_delay_anchor.py
@@ -86,6 +86,8 @@ def _make_recognition(
     ar._eou_wait_span = None
     ar._eou_wait_started_at_ns = None
     ar._eou_wait_rearms = 0
+    ar._eou_wait_floor_ns = None
+    ar._eou_detection_span = None
     ar._stt_model = None
     ar._stt_provider = None
     ar._vad_stream = None

--- a/tests/test_transcription_delay_anchor.py
+++ b/tests/test_transcription_delay_anchor.py
@@ -84,7 +84,7 @@ def _make_recognition(
     ar._user_turn_span = None
     ar._user_turn_start = None
     ar._eot_wait_span = None
-    ar._eot_wait_started_at = None
+    ar._eot_wait_started_at_ns = None
     ar._eot_wait_rearms = 0
     ar._stt_model = None
     ar._stt_provider = None

--- a/tests/test_transcription_delay_anchor.py
+++ b/tests/test_transcription_delay_anchor.py
@@ -83,9 +83,9 @@ def _make_recognition(
     # only reached by the stt-mode END_OF_SPEECH / START_OF_SPEECH branches
     ar._user_turn_span = None
     ar._user_turn_start = None
-    ar._eot_wait_span = None
-    ar._eot_wait_started_at_ns = None
-    ar._eot_wait_rearms = 0
+    ar._eou_wait_span = None
+    ar._eou_wait_started_at_ns = None
+    ar._eou_wait_rearms = 0
     ar._stt_model = None
     ar._stt_provider = None
     ar._vad_stream = None


### PR DESCRIPTION
## What

`eou_detection` only covered the turn-detector inference, so the endpointing delay itself (often seconds) showed up as an empty gap between `user_turn` and `agent_turn`. This makes the wait, the user hook, and the speech queue visible.

## How

**`eou_wait`** span, one per user turn, child of `user_turn`:
- back-dated to `last_speaking_time`, so the bar starts where the user stopped talking;
- ends on the turn decision with `lk.eou.outcome` (`committed` / `user_resumed` / `dropped`), `lk.eou.wait_duration`, `lk.eou.rearm_count`, the final `lk.eou.endpointing_delay`, and the last `lk.eou.source`;
- a later trigger for the same turn (late STT final, another VAD end of speech) **re-arms** the wait and records a `rearmed` event instead of starting a new span, so the bar stays whole and late transcripts are readable off it;
- a rejected commit (`min_words`, realtime backchannel) records a `lk.eou.not_committed_count` and keeps waiting; resumed speech ends the span at the VAD/STT speech start; teardown drops it.
- resumed speech ends the span at the VAD/STT speech start, kept as a `user_resumed` event; when that start is reported after the fact and a detection or re-arm was recorded in between, the bar runs to the last of those so it always contains its children (an `eou_detection` still running is closed with a `superseded` event). A turn-detection mode change to or from `manual` drops the pending wait.

`eou_detection` keeps its name and now nests under `eou_wait`; the span names and the `lk.eou.*` attribute keys stay on the same vocabulary, so nothing on the cloud side needs to change.

**`on_user_turn_completed`** span around the user hook that gates the reply, nested under the `user_turn` it completes: recognition hands the open `user_turn` span to the activity when it schedules the hook, and the activity ends it after the hook (or when the turn is skipped), so the turn's duration covers the wait for the hook. Exceptions are recorded redaction-aware, honouring `record={"redaction": True}` on the session as well as the job's flag; `StopResponse` is an event.

**`lk.speech.queue_wait`** on `agent_turn`: seconds between scheduling the speech and its first generation authorization.

```
user_turn
├─ user_speaking
└─ eou_wait                 ← new, 2.5s, rearmed ×1
   └─ eou_detection         ← now nested under the wait
on_user_turn_completed      ← new
agent_turn  (lk.speech.queue_wait=0.01)
├─ llm_node
└─ tts_node
```

## Tests

`tests/test_eou_wait_span.py` drives `_run_eou_detection` with real spans: commit (parent, back-dated start, attributes), re-arm keeps one span, resumed speech ends at speech start and leaves `user_turn` open, teardown drops, `not_committed` keeps waiting, `eou_detection` nests under the wait and stays inside it when the user resumes mid-inference, a mode change drops the wait; plus a full fake session asserting `eou_wait`, the hook span, the queue-wait attribute, and a session-only redaction keeping a hook exception's message out of the trace.

Stacked on #7128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- **Counts, not events.** `lk.eou.not_committed_count` on `eou_wait` (turn decisions the detector rejected before the wait ended) replaces the `not_committed` event; `lk.eou.resume_count` on `user_turn` counts the waits the user cut short by speaking again.
- **Stages on the reply.** The reply's `agent_turn` carries `lk.end_of_turn_delay`, `lk.transcription_delay` and `lk.on_user_turn_completed_delay` next to `lk.e2e_latency`, so a per-turn breakdown reads off one span.
- A `user_turn` created lazily from an STT final (no VAD opened it) starts at the earliest anchor known, so its back-dated `eou_wait` child never starts before it.
