### PR TITLE
fix(asyncai): invalidate the TTS pool when connection params change

### DIFF
--- a/livekit-plugins/livekit-plugins-asyncai/livekit/plugins/asyncai/tts.py
+++ b/livekit-plugins/livekit-plugins-asyncai/livekit/plugins/asyncai/tts.py
@@ -196,12 +196,24 @@ class TTS(tts.TTS):
             language (str, optional): The language code for synthesis. Defaults to "en".
             voice (str, optional): The voice ID.
         """
+        connection_params_changed = False
         if is_given(model):
             self._opts.model = model
+            connection_params_changed = True
         if is_given(language):
             self._opts.language = language
+            connection_params_changed = True
         if is_given(voice):
             self._opts.voice = cast(str | list[float], voice)
+            connection_params_changed = True
+
+        if connection_params_changed:
+            # model, voice and language are sent once, in the init payload _connect_ws
+            # writes immediately after the handshake, so a pooled connection keeps
+            # synthesising with the previous settings. mark_refreshed_on_get=True resets
+            # max_session_duration on every acquire, so under steady use that connection
+            # can outlive the change indefinitely.
+            self._pool.invalidate()
 
     def stream(
         self, *, conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS

--- a/tests/test_plugin_asyncai_tts.py
+++ b/tests/test_plugin_asyncai_tts.py
@@ -1,0 +1,77 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AsyncAI TTS: settings that are baked into the websocket init payload.
+
+``_connect_ws`` sends ``model_id``, ``voice`` and ``language`` once, right after the
+handshake. The connection then lives in a ``utils.ConnectionPool`` created with
+``mark_refreshed_on_get=True``, so its ``max_session_duration`` restarts on every
+acquire and a reused connection can outlive a settings change indefinitely. Changing
+any of those three therefore has to invalidate the pool, or synthesis silently
+continues with the previous voice/model/language.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from livekit.plugins.asyncai import TTS
+
+pytestmark = pytest.mark.plugin("asyncai")
+
+
+def _tts_with_recording_pool() -> tuple[TTS, list[bool]]:
+    tts = TTS(api_key="test-key")
+    calls: list[bool] = []
+    tts._pool.invalidate = lambda: calls.append(True)  # type: ignore[method-assign]
+    return tts, calls
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("voice", "some-other-voice-id"),
+        ("model", "async_flash_v1.0"),
+        ("language", "es"),
+    ],
+)
+def test_update_options_invalidates_pool_for_connection_params(field: str, value: str) -> None:
+    """Each of the three fields is sent in the init payload, so each must invalidate."""
+    tts, calls = _tts_with_recording_pool()
+
+    tts.update_options(**{field: value})
+
+    assert getattr(tts._opts, field) == value
+    assert calls == [True], f"changing {field} must invalidate the pooled connection"
+
+
+def test_update_options_noop_leaves_pool_alone() -> None:
+    """A call that changes nothing must not tear down a healthy pooled connection."""
+    tts, calls = _tts_with_recording_pool()
+
+    tts.update_options()
+
+    assert calls == []
+
+
+def test_update_options_invalidates_once_for_several_changes() -> None:
+    """Changing all three together still only needs a single invalidation."""
+    tts, calls = _tts_with_recording_pool()
+
+    tts.update_options(model="async_flash_v1.0", language="fr", voice="another-voice")
+
+    assert calls == [True]
+    assert tts._opts.model == "async_flash_v1.0"
+    assert tts._opts.language == "fr"
+    assert tts._opts.voice == "another-voice"


### PR DESCRIPTION
## Problem

`TTS.update_options()` mutates `model`, `language` and `voice`, but `_connect_ws()` sends all three **once**, in the init payload it writes immediately after the handshake:

```python
init_payload = {
    "model_id": self._opts.model,
    "voice": {"mode": "id", "id": self._opts.voice},
    "output_format": {...},
}
if self._opts.language is not None:
    init_payload["language"] = self._opts.language
ws = await asyncio.wait_for(session.ws_connect(url), timeout)
await ws.send_str(json.dumps(init_payload))
```

That connection then goes into a `utils.ConnectionPool`, so the next utterance can reuse a socket negotiated with the *previous* settings. And the pool is built with `mark_refreshed_on_get=True`:

```python
self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
    connect_cb=self._connect_ws,
    close_cb=self._close_ws,
    max_session_duration=300,
    mark_refreshed_on_get=True,
)
```

`mark_refreshed_on_get=True` restarts `max_session_duration` on every acquire, so under steady traffic the 5-minute cap never expires and a stale connection can outlive the change indefinitely.

Nothing surfaces the gap: `self._opts.voice` reports the new voice, the audio keeps arriving in the old one, and no error is raised.

## Why this shape

Two sibling TTS plugins already guard exactly this, and one of them documents the reasoning almost word for word:

**`deepgram/tts.py`** tracks a flag and invalidates:
```python
if connection_params_changed:
    # These params are baked into the WebSocket URL at connection time, so any
    # existing pooled connection must be invalidated to avoid serving audio at
    # the wrong rate/encoding.
    self._pool.invalidate()
```

**`rime/tts.py`** compares the computed url:
```python
if prev_ws_url is not None and self._ws_url() != prev_ws_url:
    self._pool.invalidate()
```

The only difference for asyncai is that the settings ride in the init payload rather than the URL — the consequence for a pooled connection is identical. This PR applies deepgram's form.

Only the three fields carried in the init payload set the flag, so a no-op `update_options()` still leaves a healthy pooled connection alone. `encoding` and `sample_rate` are constructor-only here, so they are not part of this.

## Tests

`tests/test_plugin_asyncai_tts.py`, following `test_update_options_invalidates_pool_on_change` in `tests/test_plugin_deepgram_tts.py`:

- each of `voice` / `model` / `language` invalidates (parametrised)
- a no-op `update_options()` does not
- all three at once invalidates exactly once

**Verified by mutation, not assumption.** With the `self._pool.invalidate()` call removed, 4 of the 5 fail; with it, all 5 pass. `ruff check .` and `ruff format --check` are clean.

## Context

I fixed the same bug class in this vendor's Pipecat integration last week — [pipecat-ai/pipecat#5464](https://github.com/pipecat-ai/pipecat/pull/5464), where model/voice/language were written only into the websocket init message and a runtime change was stored, warned about, and never sent. Same provider, same settings, different persistence mechanism: there it was one long-lived socket, here it is a pooled one.
