### PR TITLE
fix(neuphonic): invalidate the TTS pool when connection params change

### DIFF
--- a/livekit-plugins/livekit-plugins-neuphonic/livekit/plugins/neuphonic/tts.py
+++ b/livekit-plugins/livekit-plugins-neuphonic/livekit/plugins/neuphonic/tts.py
@@ -196,12 +196,24 @@ class TTS(tts.TTS):
             voice_id (str, optional): The voice ID for the desired voice.
             speed (float, optional): The audio playback speed.
         """
+        connection_params_changed = False
         if is_given(lang_code):
             self._opts.lang_code = LanguageCode(lang_code)
+            connection_params_changed = True
         if is_given(voice_id):
             self._opts.voice_id = voice_id
+            connection_params_changed = True
         if is_given(speed):
             self._opts.speed = speed
+            connection_params_changed = True
+
+        if connection_params_changed:
+            # lang_code, voice_id and speed are all baked into the URL _connect_ws
+            # builds, so a pooled connection keeps synthesising with the previous
+            # settings. mark_refreshed_on_get=True restarts max_session_duration on
+            # every acquire, so under steady use that connection can outlive the
+            # change indefinitely.
+            self._pool.invalidate()
 
     def synthesize(
         self,

--- a/tests/test_plugin_neuphonic_tts.py
+++ b/tests/test_plugin_neuphonic_tts.py
@@ -1,0 +1,76 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Neuphonic TTS: settings that are baked into the websocket URL.
+
+``_connect_ws`` builds its url as
+``/speak/{lang_code}?speed={speed}&lang_code={lang_code}&encoding=...&voice_id={voice_id}``,
+so ``lang_code``, ``speed`` and ``voice_id`` are all fixed at connection time. The
+socket then lives in a ``utils.ConnectionPool`` created with
+``mark_refreshed_on_get=True``, which restarts ``max_session_duration`` on every
+acquire, so a reused connection can outlive a settings change indefinitely. Changing
+any of the three must therefore invalidate the pool.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from livekit.plugins.neuphonic import TTS
+
+pytestmark = pytest.mark.plugin("neuphonic")
+
+
+def _tts_with_recording_pool() -> tuple[TTS, list[bool]]:
+    tts = TTS(api_key="test-key")
+    calls: list[bool] = []
+    tts._pool.invalidate = lambda: calls.append(True)  # type: ignore[method-assign]
+    return tts, calls
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("voice_id", "some-other-voice-id"),
+        ("speed", 1.25),
+        ("lang_code", "es"),
+    ],
+)
+def test_update_options_invalidates_pool_for_connection_params(field: str, value: object) -> None:
+    """Each of the three fields is a url parameter, so each must invalidate."""
+    tts, calls = _tts_with_recording_pool()
+
+    tts.update_options(**{field: value})
+
+    assert calls == [True], f"changing {field} must invalidate the pooled connection"
+
+
+def test_update_options_noop_leaves_pool_alone() -> None:
+    """A call that changes nothing must not tear down a healthy pooled connection."""
+    tts, calls = _tts_with_recording_pool()
+
+    tts.update_options()
+
+    assert calls == []
+
+
+def test_update_options_invalidates_once_for_several_changes() -> None:
+    """Changing all three together still only needs a single invalidation."""
+    tts, calls = _tts_with_recording_pool()
+
+    tts.update_options(lang_code="fr", voice_id="another-voice", speed=0.9)
+
+    assert calls == [True]
+    assert tts._opts.voice_id == "another-voice"
+    assert tts._opts.speed == 0.9


### PR DESCRIPTION
## Problem

`TTS.update_options()` mutates `lang_code`, `voice_id` and `speed`. All three are baked into the URL `_connect_ws()` builds:

```python
url = self._opts.get_ws_url(
    f"/speak/{self._opts.lang_code.language}?speed={self._opts.speed}"
    f"&lang_code={self._opts.lang_code.language}&encoding={self._opts.encoding}"
    f"&sampling_rate={self._opts.sample_rate}&voice_id={self._opts.voice_id}"
)
```

The socket then goes into a `utils.ConnectionPool`, so the next utterance can reuse a connection opened with the *previous* settings:

```python
self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
    connect_cb=self._connect_ws,
    close_cb=self._close_ws,
    max_session_duration=300,
    mark_refreshed_on_get=True,
)
```

`mark_refreshed_on_get=True` restarts `max_session_duration` on every acquire, so under steady traffic the 5-minute cap never expires and a stale connection can outlive the change indefinitely. The only pool teardown in the file today is `aclose()`, at shutdown.

Nothing surfaces the gap: `self._opts.voice_id` reports the new voice, the audio keeps arriving in the old one, and no error is raised.

## Why this shape

`deepgram/tts.py` already guards the same thing, and its comment states the reasoning:

```python
if connection_params_changed:
    # These params are baked into the WebSocket URL at connection time, so any
    # existing pooled connection must be invalidated to avoid serving audio at
    # the wrong rate/encoding.
    self._pool.invalidate()
```

`respeecher/tts.py` solves it a different way — it retires the current pool into `_retired_pools` and builds a fresh one, so in-flight streams can finish on the old connection. Either is fine; this PR applies deepgram's form, which is the smaller change here.

Only the three url parameters set the flag, so a no-op `update_options()` still leaves a healthy pooled connection alone. `encoding` and `sample_rate` are also in the url but are constructor-only, so they are not part of this.

## Tests

`tests/test_plugin_neuphonic_tts.py`, following `test_update_options_invalidates_pool_on_change` in `tests/test_plugin_deepgram_tts.py`:

- each of `voice_id` / `speed` / `lang_code` invalidates (parametrised)
- a no-op `update_options()` does not
- all three at once invalidates exactly once

**Verified by mutation, not assumption.** With the `self._pool.invalidate()` call removed, 4 of the 5 fail; with it, all 5 pass. `ruff check .` and `ruff format --check` are clean.

## Related

Same bug and same fix as [#7132](https://github.com/livekit/agents/pull/7132) for the asyncai plugin, filed separately since they are different providers and reviewers may differ. I found both by intersecting the settings a plugin bakes into its connect callback with the settings `update_options` mutates — the remaining pooled TTS plugins either invalidate already (deepgram, rime, bland, fishaudio, soniox, xai), retire the pool (respeecher), or do not put mutable settings in the connection (murf, resemble, smallestai, inworld).
