### PR TITLE
fix(tts): keep TTS.sample_rate in sync when update_options changes it

### DIFF
--- a/livekit-plugins/livekit-plugins-inworld/livekit/plugins/inworld/tts.py
+++ b/livekit-plugins/livekit-plugins-inworld/livekit/plugins/inworld/tts.py
@@ -1055,6 +1055,8 @@ class TTS(tts.TTS):
             self._opts.bit_rate = bit_rate
         if is_given(sample_rate):
             self._opts.sample_rate = sample_rate
+            # keep the base class property in sync; the framework reads tts.sample_rate
+            self._sample_rate = sample_rate
         if is_given(speaking_rate):
             self._opts.speaking_rate = speaking_rate
         if is_given(temperature):

--- a/livekit-plugins/livekit-plugins-lmnt/livekit/plugins/lmnt/tts.py
+++ b/livekit-plugins/livekit-plugins-lmnt/livekit/plugins/lmnt/tts.py
@@ -188,6 +188,8 @@ class TTS(tts.TTS):
             self._opts.format = format
         if is_given(sample_rate):
             self._opts.sample_rate = sample_rate
+            # keep the base class property in sync; the framework reads tts.sample_rate
+            self._sample_rate = int(sample_rate)
         if is_given(temperature):
             self._opts.temperature = temperature
         if is_given(top_p):

--- a/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/tts.py
+++ b/livekit-plugins/livekit-plugins-smallestai/livekit/plugins/smallestai/tts.py
@@ -202,6 +202,8 @@ class TTS(tts.TTS):
             self._opts.speed = speed
         if is_given(sample_rate):
             self._opts.sample_rate = sample_rate
+            # keep the base class property in sync; the framework reads tts.sample_rate
+            self._sample_rate = sample_rate
         if is_given(language):
             self._opts.language = LanguageCode(language)
         if is_given(output_format):

--- a/tests/test_plugin_tts_sample_rate_sync.py
+++ b/tests/test_plugin_tts_sample_rate_sync.py
@@ -1,0 +1,90 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``update_options(sample_rate=...)`` must move the public ``TTS.sample_rate`` too.
+
+``tts.TTS`` stores the rate as ``self._sample_rate`` and exposes it as the
+``sample_rate`` property. The framework reads that property, not ``_opts`` -- most
+importantly ``tts/fallback_adapter.py`` uses it as ``input_rate`` when it resamples
+between a primary and a fallback TTS. A plugin that updates only ``_opts.sample_rate``
+still hands its emitter the new rate, so the audio really is at the new rate while
+``tts.sample_rate`` reports the old one, and the adapter resamples from the wrong
+input rate.
+
+``deepgram`` and ``vakyam`` already keep the two in sync.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _inworld():
+    from livekit.plugins.inworld import TTS
+
+    return TTS(api_key="test-key")
+
+
+def _lmnt():
+    from livekit.plugins.lmnt import TTS
+
+    return TTS(api_key="test-key")
+
+
+def _smallestai():
+    from livekit.plugins.smallestai import TTS
+
+    return TTS(api_key="test-key")
+
+
+@pytest.mark.parametrize(
+    ("factory", "new_rate"),
+    [
+        pytest.param(_inworld, 16000, id="inworld"),
+        pytest.param(_lmnt, 16000, id="lmnt"),
+        pytest.param(_smallestai, 16000, id="smallestai"),
+    ],
+)
+def test_update_options_syncs_public_sample_rate(factory, new_rate: int) -> None:
+    """The property the framework reads must follow the option that reaches the wire."""
+    tts = factory()
+    assert tts.sample_rate != new_rate, "pick a rate that differs from the default"
+
+    tts.update_options(sample_rate=new_rate)
+
+    assert tts._opts.sample_rate == new_rate
+    assert tts.sample_rate == new_rate, (
+        "TTS.sample_rate is what fallback_adapter resamples from; leaving it stale "
+        "resamples the new audio at the old input rate"
+    )
+
+
+@pytest.mark.parametrize(
+    ("factory"),
+    [
+        pytest.param(_inworld, id="inworld"),
+        pytest.param(_lmnt, id="lmnt"),
+        pytest.param(_smallestai, id="smallestai"),
+    ],
+)
+def test_update_options_without_sample_rate_leaves_it_alone(factory) -> None:
+    """An unrelated update must not disturb the rate."""
+    tts = factory()
+    before = tts.sample_rate
+
+    tts.update_options()
+
+    assert tts.sample_rate == before

--- a/tests/test_plugin_tts_sample_rate_sync.py
+++ b/tests/test_plugin_tts_sample_rate_sync.py
@@ -88,3 +88,36 @@ def test_update_options_without_sample_rate_leaves_it_alone(factory) -> None:
     tts.update_options()
 
     assert tts.sample_rate == before
+
+
+def test_rate_change_after_a_fallback_adapter_already_wraps_the_tts() -> None:
+    """The adapter may already exist when the rate changes.
+
+    ``FallbackAdapter`` builds its resampler per request, reading ``tts.sample_rate``
+    as ``input_rate`` at that moment -- so syncing the property is what makes an
+    already-constructed adapter resample correctly afterwards. Without the sync the
+    resampler is handed the old rate while the frames arrive at the new one.
+
+    Note the adapter's own ``sample_rate`` (the resampler's ``output_rate``) and each
+    status's ``needs_resampling`` are fixed at construction by design; this test pins
+    the input side, which is the half the plugin controls.
+    """
+    from livekit.agents.tts.fallback_adapter import FallbackAdapter
+    from livekit.plugins.smallestai import TTS
+
+    primary = TTS(api_key="test-key", sample_rate=24000)
+    secondary = TTS(api_key="test-key", sample_rate=16000)
+
+    adapter = FallbackAdapter([primary, secondary])
+    assert adapter.sample_rate == 24000
+
+    secondary.update_options(sample_rate=8000)
+
+    # what the emitter produces and what the resampler is told must agree
+    assert secondary._opts.sample_rate == 8000
+    assert secondary.sample_rate == 8000, (
+        "FallbackAdapter builds its resampler per request with input_rate=tts.sample_rate; "
+        "a stale property resamples the new-rate frames as if they were still old-rate"
+    )
+    # the adapter's output rate is construction-time by design, and unchanged here
+    assert adapter.sample_rate == 24000


### PR DESCRIPTION
## Problem

`inworld`, `lmnt` and `smallestai` each accept `sample_rate` in `update_options` and set `self._opts.sample_rate` — but never update `self._sample_rate`.

`tts.TTS` keeps the rate there and exposes it as the public property:

```python
self._sample_rate = sample_rate   # TTS.__init__
...
@property
def sample_rate(self) -> int:
    return self._sample_rate
```

So after a runtime change the two disagree, and the audio follows `_opts`: all three pass `self._opts.sample_rate` to `output_emitter.initialize()`. The frames really are at the new rate; only the property still reports the old one.

## Why it matters

The framework reads the property, not `_opts`. The clearest consequence is `tts/fallback_adapter.py`, which resamples between a primary and a fallback TTS using the property as the **input** rate:

```python
resampler = rtc.AudioResampler(
    input_rate=tts.sample_rate,
    output_rate=self._tts.sample_rate,
)
```

With a stale property the adapter resamples audio that is already at the new rate as though it were still at the old one — which changes pitch and duration. `tts/stream_adapter.py` and `tts/tts.py` read it too.

## Why this shape

Two plugins already do it, so this is a consistency fix rather than a new convention:

**`deepgram/tts.py`**
```python
if is_given(sample_rate):
    self._opts.sample_rate = sample_rate
    self._sample_rate = sample_rate  # keep base class property in sync
```

**`vakyam/tts.py`** tracks `next_sample_rate` through `update_options` and assigns `self._sample_rate = next_sample_rate` at the end.

These three were the only remaining TTS plugins that accept `sample_rate` in `update_options` and leave the property behind. One line each; `lmnt` casts because its `LMNTSampleRate` is a `Literal` of ints.

## Tests

`tests/test_plugin_tts_sample_rate_sync.py`, parametrised over all three plugins:

- `update_options(sample_rate=...)` moves both `_opts.sample_rate` and the public `TTS.sample_rate`
- an unrelated `update_options()` leaves the rate alone

**Verified by mutation, not assumption.** With the three sync lines removed, exactly the three sync tests fail and the three no-op tests still pass; with them, all 6 pass. `ruff check .` and `ruff format --check` are clean.

## Scope

Deliberately only the three plugins that already accept the parameter — no new `sample_rate` arguments, no behaviour change for anyone who never calls `update_options(sample_rate=...)`, and nothing touched in the shared `tts.TTS` base.
