### PR TITLE
fix(google): infer "boolean" for bool enum values in the Gemini schema builder

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
@@ -216,14 +216,15 @@ class _GeminiJsonSchema:
             self._array(schema, refs_stack)
 
     def _infer_type(self, value: Any) -> str:
-        if isinstance(value, int):
+        # bool must be tested before int: bool is a subclass of int in Python
+        if isinstance(value, bool):
+            return "boolean"
+        elif isinstance(value, int):
             return "integer"
         elif isinstance(value, float):
             return "number"
         elif isinstance(value, str):
             return "string"
-        elif isinstance(value, bool):
-            return "boolean"
         else:
             raise ValueError(f"Unsupported type in Schema: {type(value)}")
 


### PR DESCRIPTION
### Problem

`_GeminiJsonSchema._infer_type` tests `int` before `bool`:

```python
def _infer_type(self, value: Any) -> str:
    if isinstance(value, int):
        return "integer"
    elif isinstance(value, float):
        return "number"
    elif isinstance(value, str):
        return "string"
    elif isinstance(value, bool):
        return "boolean"
    else:
        raise ValueError(f"Unsupported type in Schema: {type(value)}")
```

`bool` is a subclass of `int` in Python, so `isinstance(True, int)` is `True` and
the first arm swallows every boolean. The `elif isinstance(value, bool)` arm is
unreachable — `"boolean"` is never returned.

The method has one caller:

```python
if "enum" in schema and "type" not in schema:
    schema["type"] = self._infer_type(schema["enum"][0])
```

so a tool parameter whose JSON Schema carries a boolean `enum` and no explicit
`type` — e.g. a `Literal[True, False]` annotation — is declared to Gemini as
`type: "integer"` instead of `type: "boolean"`.

### Fix

Move the `bool` arm above the `int` arm, with a comment recording why the order
matters.

### Verification

The method is cut out of the real file with `ast.get_source_segment` (before:
`git show HEAD:…`; after: the patched source — neither is re-typed) and executed
standalone over a value matrix:

| value | before | after |
|---|---|---|
| `True` | `integer` | **`boolean`** |
| `False` | `integer` | **`boolean`** |
| `0` | `integer` | `integer` |
| `1` | `integer` | `integer` |
| `42` | `integer` | `integer` |
| `-7` | `integer` | `integer` |
| `3.14` | `number` | `number` |
| `0.0` | `number` | `number` |
| `'x'` | `string` | `string` |
| `''` | `string` | `string` |

```
values: 10   unchanged: 8   changed: 2

reachability of the 'boolean' arm:
  before  -> NEVER reached
  after   -> reached
```

Only the two `bool` inputs move; every `int`, `float` and `str` input keeps its
previous answer, including the `0`/`1` cases that are the ones most likely to be
confused with booleans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
