### PR TITLE
fix(agents): don't close in-use connections when the pool is invalidated

### DIFF
--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -51,6 +51,10 @@ class ConnectionPool(Generic[T]):
         # their current holder and are queued for closing once returned.
         self._retired: set[T] = set()
 
+        # bumped by invalidate() so a connection whose handshake was already in
+        # flight can be recognised as stale once it completes.
+        self._generation: int = 0
+
         self._prewarm_task: weakref.ref[asyncio.Task[None]] | None = None
 
         # Timing info from the last get() call
@@ -68,7 +72,15 @@ class ConnectionPool(Generic[T]):
         """
         if self._connect_cb is None:
             raise NotImplementedError("Must provide connect_cb or implement connect()")
+        generation = self._generation
         connection = await self._connect_cb(timeout)
+        if generation != self._generation:
+            # invalidated while the handshake was in flight, so this connection was
+            # negotiated with settings that are already stale. the caller asked for it
+            # before the change and still gets it, but it is retired so nothing reuses
+            # it afterwards.
+            self._retired.add(connection)
+            return connection
         self._connections[connection] = time.time()
         return connection
 
@@ -181,8 +193,10 @@ class ConnectionPool(Generic[T]):
         working for whoever holds them and are queued for closing when returned via
         :meth:`put` or :meth:`remove`. Closing them here would sever a connection that
         is still streaming, so a caller changing options mid-session would interrupt
-        the request in flight.
+        the request in flight. A connection whose handshake is still in flight is
+        retired too, once it completes, since it was negotiated with the old settings.
         """
+        self._generation += 1
         for conn in list(self._connections.keys()):
             if conn in self._available:
                 self._to_close.add(conn)
@@ -211,7 +225,13 @@ class ConnectionPool(Generic[T]):
                 async with self._connect_lock:
                     if not self._connections:
                         conn = await self._connect(timeout=self._connect_timeout)
-                        self._available.add(conn)
+                        if conn in self._connections:
+                            self._available.add(conn)
+                        else:
+                            # retired mid-handshake; nothing ever used it, so it can
+                            # go straight to the close queue.
+                            self._retired.discard(conn)
+                            self._to_close.add(conn)
             except Exception as e:
                 # exception details can contain request headers or URL credentials.
                 logger.warning(

--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -222,16 +222,22 @@ class ConnectionPool(Generic[T]):
 
         async def _prewarm_impl() -> None:
             try:
-                async with self._connect_lock:
-                    if not self._connections:
+                # an invalidation landing mid-handshake discards the connection being
+                # warmed. retry once so the pool does not stay cold just because
+                # options changed while it was warming up; bounded so repeated
+                # invalidations cannot spin here.
+                for _ in range(2):
+                    async with self._connect_lock:
+                        if self._connections:
+                            return
                         conn = await self._connect(timeout=self._connect_timeout)
                         if conn in self._connections:
                             self._available.add(conn)
-                        else:
-                            # retired mid-handshake; nothing ever used it, so it can
-                            # go straight to the close queue.
-                            self._retired.discard(conn)
-                            self._to_close.add(conn)
+                            return
+                        # retired mid-handshake; nothing ever used it, so it can
+                        # go straight to the close queue.
+                        self._retired.discard(conn)
+                        self._to_close.add(conn)
             except Exception as e:
                 # exception details can contain request headers or URL credentials.
                 logger.warning(

--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -47,6 +47,10 @@ class ConnectionPool(Generic[T]):
         # store connections to be reaped (closed) later.
         self._to_close: set[T] = set()
 
+        # connections that were invalidated while checked out. they stay usable for
+        # their current holder and are queued for closing once returned.
+        self._retired: set[T] = set()
+
         self._prewarm_task: weakref.ref[asyncio.Task[None]] | None = None
 
         # Timing info from the last get() call
@@ -128,10 +132,17 @@ class ConnectionPool(Generic[T]):
         """Mark a connection as available for reuse.
 
         If connection has been reset, it will not be added to the pool.
+        A connection retired by :meth:`invalidate` while it was checked out is queued
+        for closing instead of being made available again.
 
         Args:
             conn: The connection to make available
         """
+        if conn in self._retired:
+            self._retired.discard(conn)
+            self._to_close.add(conn)
+            return
+
         if conn in self._connections:
             self._available.add(conn)
 
@@ -153,17 +164,30 @@ class ConnectionPool(Generic[T]):
             conn: The connection to reset
         """
         self._available.discard(conn)
+        if conn in self._retired:
+            self._retired.discard(conn)
+            self._to_close.add(conn)
+            return
+
         if conn in self._connections:
             self._to_close.add(conn)
             self._connections.pop(conn, None)
 
     def invalidate(self) -> None:
-        """Clear all existing connections.
+        """Stop reusing every existing connection.
 
-        Marks all current connections to be closed during the next drain cycle.
+        Idle connections are marked to be closed during the next drain cycle.
+        Connections that are currently checked out are *retired* instead: they keep
+        working for whoever holds them and are queued for closing when returned via
+        :meth:`put` or :meth:`remove`. Closing them here would sever a connection that
+        is still streaming, so a caller changing options mid-session would interrupt
+        the request in flight.
         """
         for conn in list(self._connections.keys()):
-            self._to_close.add(conn)
+            if conn in self._available:
+                self._to_close.add(conn)
+            else:
+                self._retired.add(conn)
         self._connections.clear()
         self._available.clear()
 
@@ -206,4 +230,8 @@ class ConnectionPool(Generic[T]):
                 await aio.gracefully_cancel(task)
 
         self.invalidate()
+        # the pool is going away, so retired connections are closed too rather than
+        # waiting for holders that may never return them.
+        self._to_close.update(self._retired)
+        self._retired.clear()
         await self._drain_to_close()

--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -93,6 +93,12 @@ class ConnectionPool(Generic[T]):
                 await self._maybe_close_connection(conn)
             except Exception as e:
                 logger.warning("error closing connection %s: %s", conn, e)
+            except BaseException:
+                # the connection has already left _to_close and is not in _connections,
+                # so nothing else owns it. put it back before unwinding, otherwise a
+                # cancelled drain strands an open connection for good.
+                self._to_close.add(conn)
+                raise
 
     @asynccontextmanager
     async def connection(self, *, timeout: float) -> AsyncGenerator[T, None]:

--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -77,8 +77,11 @@ class ConnectionPool(Generic[T]):
             connection = await self._connect_cb(timeout)
             if invalidations == self._invalidations:
                 break
-            # options changed during the handshake, so this socket carries the old ones
+            # options changed during the handshake, so this socket carries the old ones.
+            # close it here rather than leaving it queued: the drain at the top of get()
+            # has already run, so nothing else would reach it until the next acquisition.
             self._to_close.add(connection)
+            await self._drain_to_close()
         self._connections[connection] = time.time()
         return connection
 

--- a/livekit-agents/livekit/agents/utils/connection_pool.py
+++ b/livekit-agents/livekit/agents/utils/connection_pool.py
@@ -53,7 +53,7 @@ class ConnectionPool(Generic[T]):
 
         # bumped by invalidate() so a connection whose handshake was already in
         # flight can be recognised as stale once it completes.
-        self._generation: int = 0
+        self._invalidations: int = 0
 
         self._prewarm_task: weakref.ref[asyncio.Task[None]] | None = None
 
@@ -72,15 +72,13 @@ class ConnectionPool(Generic[T]):
         """
         if self._connect_cb is None:
             raise NotImplementedError("Must provide connect_cb or implement connect()")
-        generation = self._generation
-        connection = await self._connect_cb(timeout)
-        if generation != self._generation:
-            # invalidated while the handshake was in flight, so this connection was
-            # negotiated with settings that are already stale. the caller asked for it
-            # before the change and still gets it, but it is retired so nothing reuses
-            # it afterwards.
-            self._retired.add(connection)
-            return connection
+        while True:
+            invalidations = self._invalidations
+            connection = await self._connect_cb(timeout)
+            if invalidations == self._invalidations:
+                break
+            # options changed during the handshake, so this socket carries the old ones
+            self._to_close.add(connection)
         self._connections[connection] = time.time()
         return connection
 
@@ -151,8 +149,7 @@ class ConnectionPool(Generic[T]):
             conn: The connection to make available
         """
         if conn in self._retired:
-            self._retired.discard(conn)
-            self._to_close.add(conn)
+            self.remove(conn)
             return
 
         if conn in self._connections:
@@ -193,10 +190,11 @@ class ConnectionPool(Generic[T]):
         working for whoever holds them and are queued for closing when returned via
         :meth:`put` or :meth:`remove`. Closing them here would sever a connection that
         is still streaming, so a caller changing options mid-session would interrupt
-        the request in flight. A connection whose handshake is still in flight is
-        retired too, once it completes, since it was negotiated with the old settings.
+        the request in flight. A handshake that was already in flight is discarded
+        and retried by :meth:`_connect`, since the socket it produced carries the old
+        settings and no caller has been handed it yet.
         """
-        self._generation += 1
+        self._invalidations += 1
         for conn in list(self._connections.keys()):
             if conn in self._available:
                 self._to_close.add(conn)
@@ -222,22 +220,10 @@ class ConnectionPool(Generic[T]):
 
         async def _prewarm_impl() -> None:
             try:
-                # an invalidation landing mid-handshake discards the connection being
-                # warmed. retry once so the pool does not stay cold just because
-                # options changed while it was warming up; bounded so repeated
-                # invalidations cannot spin here.
-                for _ in range(2):
-                    async with self._connect_lock:
-                        if self._connections:
-                            return
+                async with self._connect_lock:
+                    if not self._connections:
                         conn = await self._connect(timeout=self._connect_timeout)
-                        if conn in self._connections:
-                            self._available.add(conn)
-                            return
-                        # retired mid-handshake; nothing ever used it, so it can
-                        # go straight to the close queue.
-                        self._retired.discard(conn)
-                        self._to_close.add(conn)
+                        self._available.add(conn)
             except Exception as e:
                 # exception details can contain request headers or URL credentials.
                 logger.warning(

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -171,3 +171,101 @@ async def test_prewarm_retries_after_failure():
 
     assert attempts == 2
     assert len(pool._available) == 1
+
+
+def _closing_pool(max_session_duration: float | None = 60):
+    """A pool that records every connection handed to its close callback."""
+    closed: list[DummyConnection] = []
+
+    async def close_cb(conn: DummyConnection) -> None:
+        closed.append(conn)
+
+    pool = ConnectionPool(
+        max_session_duration=max_session_duration,
+        connect_cb=dummy_connect_factory(),
+        close_cb=close_cb,
+    )
+    return pool, closed
+
+
+@pytest.mark.asyncio
+async def test_invalidate_does_not_close_a_connection_still_in_use():
+    pool, closed = _closing_pool()
+
+    # checked out and never returned: something is streaming on it right now
+    in_use = await pool.get(timeout=10.0)
+    pool.invalidate()
+
+    # a second acquisition drains the close queue; the in-flight connection must survive
+    other = await pool.get(timeout=10.0)
+    assert other is not in_use, "Expected a fresh connection after invalidate()."
+    assert in_use not in closed, "invalidate() closed a connection that was still checked out."
+
+
+@pytest.mark.asyncio
+async def test_invalidate_closes_idle_connections_immediately():
+    pool, closed = _closing_pool()
+
+    idle = await pool.get(timeout=10.0)
+    pool.put(idle)
+    pool.invalidate()
+
+    await pool.get(timeout=10.0)
+    assert idle in closed, "Expected an idle connection to be closed by the next drain."
+
+
+@pytest.mark.asyncio
+async def test_retired_connection_is_closed_once_returned():
+    pool, closed = _closing_pool()
+
+    in_use = await pool.get(timeout=10.0)
+    pool.invalidate()
+    pool.put(in_use)  # the stream finished with it
+
+    assert in_use not in pool._available, "A retired connection must not be reused."
+    await pool.get(timeout=10.0)
+    assert in_use in closed, "Expected a retired connection to be closed once returned."
+
+
+@pytest.mark.asyncio
+async def test_retired_connection_is_closed_when_removed_after_an_error():
+    pool, closed = _closing_pool()
+
+    in_use = await pool.get(timeout=10.0)
+    pool.invalidate()
+    pool.remove(in_use)  # the stream raised; connection() calls remove()
+
+    await pool.get(timeout=10.0)
+    assert in_use in closed, "Expected a retired connection to be closed when removed."
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_retired_connections_never_returned():
+    pool, closed = _closing_pool()
+
+    leaked = await pool.get(timeout=10.0)
+    pool.invalidate()
+    await pool.aclose()
+
+    assert leaked in closed, "aclose() must close retired connections that were never returned."
+
+
+@pytest.mark.asyncio
+async def test_invalidate_mid_stream_lets_the_stream_finish_then_reconnects():
+    """The update_options case: options change while one stream is speaking."""
+    pool, closed = _closing_pool()
+
+    speaking = await pool.get(timeout=10.0)
+    pool.invalidate()  # e.g. update_options(voice=...) on the TTS
+
+    # a new stream starts and must not reuse the old settings
+    fresh = await pool.get(timeout=10.0)
+    assert fresh is not speaking
+    assert speaking not in closed, "The speaking connection was cut off mid-utterance."
+
+    # the first stream finishes normally and its connection retires
+    pool.put(speaking)
+    pool.put(fresh)
+    reused = await pool.get(timeout=10.0)
+    assert reused is fresh, "Expected the post-invalidate connection to be the reusable one."
+    assert speaking in closed

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -337,6 +337,15 @@ async def test_prewarm_discards_a_connection_invalidated_mid_handshake():
     assert task is not None
     await task
 
-    assert not pool._available, "A prewarmed connection with stale options stayed available."
+    stale = DummyConnection(1)
+    assert all(c.id != stale.id for c in pool._available), (
+        "A prewarmed connection with stale options stayed available."
+    )
+    # the discarded attempt must not leave the pool cold
+    assert len(pool._available) == 1, "Expected prewarm to retry after a mid-handshake invalidate."
+    assert next(iter(pool._available)).id == 2
+
     await pool.aclose()
-    assert len(closed) == 1, "Expected the discarded prewarm connection to be closed."
+    assert sorted(c.id for c in closed) == [1, 2], (
+        "Expected both the discarded and the replacement connection to be closed."
+    )

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 
 import pytest
@@ -269,3 +270,73 @@ async def test_invalidate_mid_stream_lets_the_stream_finish_then_reconnects():
     reused = await pool.get(timeout=10.0)
     assert reused is fresh, "Expected the post-invalidate connection to be the reusable one."
     assert speaking in closed
+
+
+@pytest.mark.asyncio
+async def test_invalidate_during_a_handshake_retires_the_new_connection():
+    """A connection negotiated with the old options must not be pooled for reuse."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+    counter = 0
+    closed: list[DummyConnection] = []
+
+    async def slow_connect(timeout: float):
+        nonlocal counter
+        counter += 1
+        started.set()
+        await release.wait()
+        return DummyConnection(counter)
+
+    async def close_cb(conn: DummyConnection) -> None:
+        closed.append(conn)
+
+    pool = ConnectionPool(connect_cb=slow_connect, close_cb=close_cb)
+
+    acquiring = asyncio.create_task(pool.get(timeout=10.0))
+    await started.wait()
+    pool.invalidate()  # options changed while the socket was still being negotiated
+    release.set()
+    stale = await acquiring
+
+    # the caller asked before the change and still gets its connection
+    assert stale is not None
+    pool.put(stale)
+    assert stale not in pool._available, "A connection negotiated with stale options was pooled."
+
+    started.clear()
+    release.set()
+    fresh = await pool.get(timeout=10.0)
+    assert fresh is not stale, "Expected a connection negotiated after the option change."
+    assert stale in closed, "Expected the stale connection to be closed once returned."
+
+
+@pytest.mark.asyncio
+async def test_prewarm_discards_a_connection_invalidated_mid_handshake():
+    started = asyncio.Event()
+    release = asyncio.Event()
+    counter = 0
+    closed: list[DummyConnection] = []
+
+    async def slow_connect(timeout: float):
+        nonlocal counter
+        counter += 1
+        started.set()
+        await release.wait()
+        return DummyConnection(counter)
+
+    async def close_cb(conn: DummyConnection) -> None:
+        closed.append(conn)
+
+    pool = ConnectionPool(connect_cb=slow_connect, close_cb=close_cb)
+
+    pool.prewarm()
+    await started.wait()
+    pool.invalidate()
+    release.set()
+    task = pool._prewarm_task()
+    assert task is not None
+    await task
+
+    assert not pool._available, "A prewarmed connection with stale options stayed available."
+    await pool.aclose()
+    assert len(closed) == 1, "Expected the discarded prewarm connection to be closed."

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -273,8 +273,8 @@ async def test_invalidate_mid_stream_lets_the_stream_finish_then_reconnects():
 
 
 @pytest.mark.asyncio
-async def test_invalidate_during_a_handshake_retires_the_new_connection():
-    """A connection negotiated with the old options must not be pooled for reuse."""
+async def test_invalidate_during_a_handshake_discards_the_stale_connection():
+    """A socket negotiated with the old options is never handed to a caller."""
     started = asyncio.Event()
     release = asyncio.Event()
     counter = 0
@@ -296,18 +296,15 @@ async def test_invalidate_during_a_handshake_retires_the_new_connection():
     await started.wait()
     pool.invalidate()  # options changed while the socket was still being negotiated
     release.set()
-    stale = await acquiring
+    conn = await acquiring
 
-    # the caller asked before the change and still gets its connection
-    assert stale is not None
-    pool.put(stale)
-    assert stale not in pool._available, "A connection negotiated with stale options was pooled."
+    assert conn.id == 2, "Expected the caller to get a connection negotiated after the change."
+    assert all(c.id != 1 for c in pool._available), "The stale connection was pooled."
+    assert conn in pool._connections
 
-    started.clear()
-    release.set()
-    fresh = await pool.get(timeout=10.0)
-    assert fresh is not stale, "Expected a connection negotiated after the option change."
-    assert stale in closed, "Expected the stale connection to be closed once returned."
+    pool.put(conn)
+    await pool.get(timeout=10.0)  # drains the close queue
+    assert [c.id for c in closed] == [1], "Expected only the stale connection to be closed."
 
 
 @pytest.mark.asyncio
@@ -337,12 +334,8 @@ async def test_prewarm_discards_a_connection_invalidated_mid_handshake():
     assert task is not None
     await task
 
-    stale = DummyConnection(1)
-    assert all(c.id != stale.id for c in pool._available), (
-        "A prewarmed connection with stale options stayed available."
-    )
-    # the discarded attempt must not leave the pool cold
-    assert len(pool._available) == 1, "Expected prewarm to retry after a mid-handshake invalidate."
+    # the discarded attempt must not leave the pool cold, and must not be reusable
+    assert len(pool._available) == 1, "Expected prewarm to end with a usable connection."
     assert next(iter(pool._available)).id == 2
 
     await pool.aclose()

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -302,9 +302,9 @@ async def test_invalidate_during_a_handshake_discards_the_stale_connection():
     assert all(c.id != 1 for c in pool._available), "The stale connection was pooled."
     assert conn in pool._connections
 
-    pool.put(conn)
-    await pool.get(timeout=10.0)  # drains the close queue
-    assert [c.id for c in closed] == [1], "Expected only the stale connection to be closed."
+    # closed on the way out of _connect, not left queued until some later acquisition
+    assert [c.id for c in closed] == [1], "The discarded socket was left open."
+    assert not pool._to_close, "The discarded socket is still queued rather than closed."
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -342,3 +342,35 @@ async def test_prewarm_discards_a_connection_invalidated_mid_handshake():
     assert sorted(c.id for c in closed) == [1, 2], (
         "Expected both the discarded and the replacement connection to be closed."
     )
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_drain_leaves_the_connection_queued_for_a_later_close():
+    """A cancelled close must not strand a connection nothing else owns."""
+    closing = asyncio.Event()
+    finish = asyncio.Event()
+    closed: list[DummyConnection] = []
+
+    async def close_cb(conn: DummyConnection) -> None:
+        closing.set()
+        await finish.wait()
+        closed.append(conn)
+
+    pool = ConnectionPool(connect_cb=dummy_connect_factory(), close_cb=close_cb)
+
+    doomed = await pool.get(timeout=10.0)
+    pool.put(doomed)
+    pool.invalidate()  # idle, so it goes straight to the close queue
+
+    acquiring = asyncio.create_task(pool.get(timeout=10.0))
+    await closing.wait()  # inside _maybe_close_connection, popped from _to_close
+    acquiring.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await acquiring
+
+    assert doomed in pool._to_close, "A cancelled drain dropped the connection entirely."
+    assert doomed not in closed
+
+    finish.set()
+    await pool.aclose()
+    assert doomed in closed, "Expected the requeued connection to be closed later."


### PR DESCRIPTION
`ConnectionPool.invalidate()` is the idiom for "these settings are baked into the handshake, so pooled sockets are now stale". Eleven call sites use it from `update_options`:

| plugin | file |
| --- | --- |
| bland | `tts.py:263` |
| deepgram | `tts.py:204`, `tts_v2.py:235` |
| fishaudio | `tts.py:305` |
| google | `stt.py:555`, `stt.py:560`, `stt.py:742` |
| mistralai | `stt.py:187` |
| openai | `stt.py:558` |
| rime | `tts.py:412` |
| xai | `tts.py:229` |

Two things went wrong for all of them.

## 1. It closed connections that were still in use

`_connections` holds every connection, not just idle ones, so `invalidate()` swept checked-out sockets into `_to_close` along with the rest. The next `get()` drains that queue — closing a socket another task was still streaming on. Change a voice mid-utterance and the utterance dies as soon as a second stream acquires a connection.

Invalidation now separates the two cases:

- **Idle** connections are queued for closing, as before.
- **Checked-out** connections are *retired*: they keep working for their current holder and are queued for closing when handed back through `put()` or `remove()`.

`put()` already refused to re-pool them, since `invalidate()` clears `_connections`, so a retired connection was never actually *reused* — only closed at the wrong moment. Same connections closed, later. `aclose()` closes retired ones too rather than waiting for holders that may never return them.

## 2. A handshake in flight escaped invalidation entirely

`invalidate()` can only act on what is already in `_connections`, and `_connect()` registers a socket only after `await connect_cb(...)` returns. A handshake that was in flight when the options changed was registered afterwards and stayed eligible for reuse, carrying the old voice, model or language.

`_connect()` now records `_invalidations` before the handshake and, if that count moved while it was in flight, closes the socket it produced and connects again. A caller never receives a connection negotiated with settings that have already changed. The discarded socket is drained inside the retry rather than left queued — `get()` drains before calling `_connect()`, so nothing else would reach it until the next acquisition.

The loop is deliberately unbounded: per review, a cap would either hand back the stale socket or raise for the caller's own option change, and spinning requires `update_options` to be called faster than a handshake completes, sustained.

## Also fixed here: a cancelled close lost the connection

`_drain_to_close()` pops a connection before awaiting its close callback, and `CancelledError` is a `BaseException`, so it skipped the `except Exception` handler — leaving the connection in neither `_to_close` nor `_connections`, owned by nothing, open for good. It is now put back before unwinding, so a later drain or `aclose()` closes it.

**This one predates the branch** — `get()` and `aclose()` have always drained this way. It is fixed here because the retry path above adds a third call site, so the change depends on that function being cancellation-safe. Happy to split it out if you would rather keep this PR to invalidation alone.

## Tests

Nine added to `tests/test_connection_pool.py`. Mutation-checked in four independent pieces — each mutation fails only its own tests:

| reverted | fails |
| --- | --- |
| the retire-instead-of-close branch in `invalidate()` | `test_invalidate_does_not_close_a_connection_still_in_use`, `test_invalidate_mid_stream_lets_the_stream_finish_then_reconnects` |
| the `self._invalidations += 1` bump | `test_invalidate_during_a_handshake_discards_the_stale_connection`, `test_prewarm_discards_a_connection_invalidated_mid_handshake` |
| the drain inside the retry | `test_invalidate_during_a_handshake_discards_the_stale_connection` |
| the `except BaseException` requeue | `test_cancelling_a_drain_leaves_the_connection_queued_for_a_later_close` |

The rest pin what the change must not break: idle connections still close promptly, a retired connection closes on `put()`, on `remove()` (the error path `connection()` takes), and via `aclose()` if it is never returned. Without those, the easy way to "fix" the first bug is to leak the socket instead of closing it late.

16 pass with the change. I also ran the full `-m unit` suite before and after: an identical set of tests fails either way, all from plugins that are not installed in my environment, so nothing here regressed.

## Related

Found while checking bot feedback on #7132 and #7133, which add `invalidate()` calls to two more plugins, and flagged again on #7140. Those PRs follow the existing idiom and are unaffected by this change either way — this makes the idiom correct for all of them at once.
