### PR TITLE
fix(cartesia): honour api_version on both the pooled socket and the REST header

### DIFF
--- a/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
+++ b/livekit-plugins/livekit-plugins-cartesia/livekit/plugins/cartesia/tts.py
@@ -296,8 +296,12 @@ class TTS(tts.TTS):
             self._opts.volume = volume
         if is_given(pronunciation_dict_id):
             self._opts.pronunciation_dict_id = pronunciation_dict_id
-        if is_given(api_version):
+        if is_given(api_version) and api_version != self._opts.api_version:
             self._opts.api_version = api_version
+            # cartesia_version is a query parameter on the websocket URL, so a pooled
+            # socket keeps speaking the version it was opened with while
+            # _to_cartesia_options starts shaping the body for the new one.
+            self._pool.invalidate()
 
         if speed or emotion or volume or pronunciation_dict_id:
             self._check_generation_config()
@@ -371,7 +375,7 @@ class ChunkedStream(tts.ChunkedStream):
                 self._opts.get_http_url("/tts/bytes"),
                 headers={
                     API_AUTH_HEADER: self._opts.api_key,
-                    API_VERSION_HEADER: API_VERSION,
+                    API_VERSION_HEADER: self._opts.api_version,
                     "User-Agent": USER_AGENT,
                 },
                 json=json,

--- a/tests/test_plugin_cartesia_tts.py
+++ b/tests/test_plugin_cartesia_tts.py
@@ -174,3 +174,99 @@ async def test_synthesize_skips_stale_frames_from_previous_context():
     # stale frame (b"\x00") must be dropped; only current audio (b"\x01") is played
     assert frames, "no audio frames were synthesized"
     assert all(f == b"\x01" * 160 for f in frames)
+
+
+@pytest.mark.asyncio
+async def test_update_options_invalidates_the_pool_when_api_version_changes():
+    """cartesia_version rides on the websocket URL, so pooled sockets go stale."""
+    from livekit.plugins.cartesia import TTS
+
+    tts = TTS(api_key=SECRET_API_KEY)
+    invalidated = 0
+    original = tts._pool.invalidate
+
+    def counting_invalidate() -> None:
+        nonlocal invalidated
+        invalidated += 1
+        original()
+
+    tts._pool.invalidate = counting_invalidate  # type: ignore[method-assign]
+
+    # a no-op update must not throw away warm connections
+    tts.update_options(api_version=tts._opts.api_version)
+    assert invalidated == 0, "Expected no invalidation when api_version is unchanged."
+
+    tts.update_options(api_version="2099-01-01")
+    assert tts._opts.api_version == "2099-01-01"
+    assert invalidated == 1, "Changing api_version must drop pooled connections."
+
+    # unrelated options ride in the per-request body and need no reconnect
+    tts.update_options(speed=1.2)
+    assert invalidated == 1, "Only connection-bound options should invalidate the pool."
+
+    await tts.aclose()
+
+
+@pytest.mark.asyncio
+async def test_ws_url_carries_the_updated_api_version():
+    from livekit.plugins.cartesia import TTS
+
+    tts = TTS(api_key=SECRET_API_KEY)
+    tts.update_options(api_version="2099-01-01")
+
+    captured: dict[str, str] = {}
+
+    class _Session:
+        def ws_connect(self_, url, **kwargs):  # noqa: ANN001, N805
+            captured["url"] = str(url)
+            raise ConnectionError("stop here, the URL is what matters")
+
+    tts._ensure_session = lambda: _Session()  # type: ignore[method-assign]
+
+    with pytest.raises(APIConnectionError):
+        await tts._connect_ws(timeout=1.0)
+
+    assert "cartesia_version=2099-01-01" in captured["url"], (
+        f"Expected the new api_version in the handshake URL, got {captured['url']}"
+    )
+
+    await tts.aclose()
+
+
+@pytest.mark.asyncio
+async def test_rest_request_sends_the_configured_api_version_header():
+    """The header and the body must agree; the body is shaped by _opts.api_version."""
+    from livekit.plugins.cartesia import TTS
+    from livekit.plugins.cartesia.tts import API_VERSION_HEADER
+
+    tts = TTS(api_key=SECRET_API_KEY, api_version="2099-01-01")
+    captured: dict[str, object] = {}
+
+    class _Resp:
+        async def __aenter__(self_):  # noqa: N805
+            raise ConnectionError("stop here, the headers are what matter")
+
+        async def __aexit__(self_, *exc):  # noqa: N805
+            return False
+
+    class _Session:
+        def post(self_, url, *, headers, **kwargs):  # noqa: ANN001, N805
+            captured["headers"] = headers
+            return _Resp()
+
+    tts._ensure_session = lambda: _Session()  # type: ignore[method-assign]
+
+    stream = tts.synthesize("hello")
+    with pytest.raises(APIConnectionError):
+        async for _ in stream:
+            pass
+    await stream.aclose()
+
+    headers = captured.get("headers")
+    assert headers is not None, "The REST path never issued a request."
+    assert headers[API_VERSION_HEADER] == "2099-01-01", (
+        f"Header sent {headers[API_VERSION_HEADER]!r} while the body was built for "
+        f"{tts._opts.api_version!r}"
+    )
+
+    await tts.aclose()


### PR DESCRIPTION
`api_version` is read in three places and applied in one. Two bugs fall out of that.

## 1. A pooled socket keeps the old version

`cartesia_version` is a query parameter on the websocket URL, so it is fixed at handshake time:

```python
url = self._opts.get_ws_url(f"/tts/websocket?cartesia_version={self._opts.api_version}")
```

`update_options(api_version=...)` only reassigned `_opts.api_version`. The pool was untouched, so the next stream reuses a socket negotiated on the old version.

That is worse than a stale setting, because `_to_cartesia_options` *branches* on the same field:

```python
if opts.api_version == API_VERSION_WITH_EMBEDDINGS_AND_EXPERIMENTAL_CONTROLS:
    voice["__experimental_controls"] = voice_controls
...
if opts.api_version > API_VERSION_WITH_EMBEDDINGS_AND_EXPERIMENTAL_CONTROLS and _is_sonic_3(opts.model):
    options["generation_config"] = generation_config
```

So after the update the body is shaped for version B and sent down a connection negotiated as version A. The request payload changes, not just a parameter.

It now invalidates the pool, guarded on the value actually differing so unrelated `update_options` calls keep their warm connections. Same idiom as `xai`, `deepgram`, `fishaudio` and the other plugins with connection-bound options.

## 2. The REST path's header and body disagree

```python
headers={
    API_AUTH_HEADER: self._opts.api_key,
    API_VERSION_HEADER: API_VERSION,      # module constant
    ...
},
json=_to_cartesia_options(self._opts, streaming=False),   # shaped by _opts.api_version
```

The header is the module default while the body is built from `_opts.api_version`. They match only while nobody uses the `api_version` parameter — which is what the parameter is for. `TTS(api_version=...)` alone is enough to split them; `update_options` widens the gap. Now sends the configured value.

## Tests

Three, in `tests/test_plugin_cartesia_tts.py`:

- `update_options` invalidates on a real change, does **not** invalidate when the value is unchanged, and does not invalidate for `speed` (which rides in the per-request body).
- the handshake URL carries the updated version.
- the REST request's header matches the version its body was built for.

Mutation-checked separately, since the two fixes are independent:

```
dropping the invalidate()  -> FAILED ...test_update_options_invalidates_the_pool_when_api_version_changes
reverting the REST header  -> FAILED ...test_rest_request_sends_the_configured_api_version_header
```

Each mutation fails only its own test; 6 passed with both fixes, and the 3 pre-existing tests in the file pass throughout.

## How I found it

Swept every plugin that owns a `ConnectionPool` (19 files), intersecting what the connect callback bakes into the handshake with what `update_options` mutates. Cartesia and `sarvam` were the only two with a non-empty intersection and no invalidation; `respeecher` reaches the same result by swapping pools; the rest either invalidate already or send their settings in the per-request body. Sarvam has several open PRs on it already so I have left that one alone.
