### PR TITLE
chore: isolate ruff dependencies in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          cache-suffix: ruff
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,18 @@ jobs:
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
-      - name: Install the project
-        run: uv sync --all-extras --dev
+      - name: Install Ruff
+        run: uv sync --locked --only-group lint
 
       - name: Ruff
-        run: uv run ruff check --output-format=github .
+        run: uv run --no-sync ruff check --output-format=github .
         continue-on-error: true
         id: ruff-check
 
       - name: Check format
-        run: uv run ruff format --check .
+        run: uv run --no-sync ruff format --check .
         continue-on-error: true
         id: ruff-format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ dev = [
     "mypy",
     "scikit-learn",
     "pytest>=9.0.3,<9.1",
-    "ruff",
+    { include-group = "lint" },
     "pytest-asyncio>=0.25.3",
     "pytest-asyncio-concurrent==0.5.2",
     "jiwer>=3.1.0",
@@ -101,6 +101,7 @@ dev = [
     "playwright>=1.58.0",
 ]
 docs = ["pdoc3", "setuptools", "beautifulsoup4", "markdownify"]
+lint = ["ruff"]
 typing = [
     # .pyi stubs, never used at runtime
     "pandas-stubs>=3.0.3.260530",

--- a/uv.lock
+++ b/uv.lock
@@ -119,6 +119,7 @@ docs = [
     { name = "pdoc3" },
     { name = "setuptools" },
 ]
+lint = [{ name = "ruff" }]
 typing = [
     { name = "pandas-stubs", specifier = ">=3.0.3.260530" },
     { name = "scipy-stubs", specifier = ">=1.17.1.5" },


### PR DESCRIPTION
Install only locked Ruff for lint and format checks, retain Ruff in dev installs, and give it a separate cache. Python 3.12 satisfies the workspace requirement.

CI medians from three cache-hit runs per version on `ubuntu-latest`:

| Metric | Before | After |
| --- | ---: | ---: |
| Ruff job | 24 s | 10 s (58% less) |
| Dependency setup | 9.726 s | 0.047 s |
| Installed packages | 308 | 1 |
| Restored cache | 539.6 MiB | 10.2 MiB |

Ruff and both type-check jobs pass.

Addresses AGT-3449

<details>
<summary>CI measurement evidence</summary>

Before: `d8607e6711bf9770bfd7e5476f79ab63e6a451a6`. After: `1b24fcf4f7a295297d75674b65b39c6cbf1801dd`.

| Version | CI attempt | Job time | Dependency setup |
| --- | --- | ---: | ---: |
| Before | [2](https://github.com/livekit/agents/actions/runs/33932000959/job/101392725495) | 24 s | 9.726 s |
| Before | [3](https://github.com/livekit/agents/actions/runs/33932000959/job/101393087918) | 24 s | 10.010 s |
| Before | [4](https://github.com/livekit/agents/actions/runs/33932000959/job/101393259197) | 26 s | 8.612 s |
| After | [2](https://github.com/livekit/agents/actions/runs/33998515742/job/101393326296) | 10 s | 0.048 s |
| After | [3](https://github.com/livekit/agents/actions/runs/33998515742/job/101393471525) | 8 s | 0.047 s |
| After | [4](https://github.com/livekit/agents/actions/runs/33998515742/job/101393589176) | 11 s | 0.043 s |

Job times use GitHub's job start/completion timestamps and exclude queue time. Dependency setup uses log timestamps from the `uv sync` step start to the next step start. Cache sizes are compressed archives reported by setup-uv.

All six runs use uv 0.12.10 and Ruff 0.15.22, pass lint and format checks, and report 992 formatted files. Python is 3.12.3 before and 3.12.14 after. These measurements compare the full workflow configurations; runner timing varies.

The [first run with the isolated cache](https://github.com/livekit/agents/actions/runs/33998515742/job/101393121588) had a cache miss and took 11 seconds, with 0.600 seconds for dependency setup. It is excluded from the medians.

</details>

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-6

> Can you take a look at this repo and find optimization opportunities, and rank them by effort and impact? (low effort, high impact first)

> let's create linear tickets for these optimization opportunities. And start working on number 3 now.

> okay, let's measure this in CI and report the before and after in the PR description.

</details>
