### PR TITLE
feat(telemetry): one agent_turn span per speech handle

### DIFF
--- a/livekit-agents/livekit/agents/telemetry/trace_types.py
+++ b/livekit-agents/livekit/agents/telemetry/trace_types.py
@@ -107,7 +107,12 @@ ATTR_CALLBACK_NAME = "lk.callback.name"
 
 # agent turn
 ATTR_AGENT_TURN_ID = "lk.generation_id"
+"""On ``agent_turn``: the latest generation (LLM step) of the speech; each step is also a
+``generation`` event carrying its own id."""
 ATTR_AGENT_PARENT_TURN_ID = "lk.parent_generation_id"
+ATTR_GENERATION_COUNT = "lk.generation_count"
+"""On ``agent_turn``: how many generations (LLM steps) the speech took; more than one means
+tool calls were executed before the final reply."""
 ATTR_USER_INPUT = "lk.pii.user_input"
 ATTR_INSTRUCTIONS = "lk.pii.instructions"
 ATTR_SPEECH_INTERRUPTED = "lk.interrupted"

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -303,6 +303,16 @@ def _agent_turn(
         yield span
 
 
+def _continue_discarded_turn(discarded: SpeechHandle | None, successor: SpeechHandle) -> None:
+    """A preemptive generation discarded for ``successor`` (a newer attempt, or the real reply
+    after the transcript changed) hands its open ``agent_turn`` over, so one turn shows the
+    wasted generation and the one that answered. Module-level like ``_record_queue_wait``."""
+    if discarded is None or discarded is successor:
+        return
+    if (carry := discarded._take_agent_turn()) is not None:
+        successor._continue_agent_turn(carry, discarded=discarded)
+
+
 def _record_queue_wait(speech_handle: SpeechHandle) -> None:
     """Stamp how long the speech sat in the queue on its agent_turn span.
 
@@ -2558,6 +2568,13 @@ class AgentActivity(RecognitionHooks):
         ):
             return
 
+        # a newer attempt supersedes the current one; if one is created below it continues the
+        # discarded attempt's agent_turn (the cancelled speech only ends once the loop runs)
+        discarded = (
+            self._preemptive_generation.speech_handle
+            if self._preemptive_generation is not None
+            else None
+        )
         self._cancel_preemptive_generation()
 
         if (
@@ -2585,6 +2602,7 @@ class AgentActivity(RecognitionHooks):
             schedule_speech=False,
             input_details=InputDetails(modality="audio"),
         )
+        _continue_discarded_turn(discarded, speech_handle)
 
         self._preemptive_generation = _PreemptiveGeneration(
             speech_handle=speech_handle,
@@ -2822,6 +2840,7 @@ class AgentActivity(RecognitionHooks):
             return
 
         speech_handle: SpeechHandle | None = None
+        discarded_preemptive: SpeechHandle | None = None
         if preemptive := self._preemptive_generation:
             # make sure the on_user_turn_completed didn't change some request parameters
             # otherwise invalidate the preemptive generation
@@ -2851,6 +2870,7 @@ class AgentActivity(RecognitionHooks):
                     "preemptive generation invalidated after `on_user_turn_completed` because "
                     "the transcript, chat context, tools, or tool choice changed",
                 )
+                discarded_preemptive = preemptive.speech_handle
                 preemptive.speech_handle._cancel()
 
             self._preemptive_generation = None
@@ -2863,6 +2883,8 @@ class AgentActivity(RecognitionHooks):
                 chat_ctx=temp_mutable_chat_ctx,
                 input_details=InputDetails(modality="audio"),
             )
+            # the invalidated preemptive attempt answered this same turn: one agent_turn
+            _continue_discarded_turn(discarded_preemptive, speech_handle)
 
         if self._user_turn_completed_atask != asyncio.current_task():
             # If a new user turn has already started, interrupt this one since it's now outdated

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -6,7 +6,7 @@ import contextvars
 import heapq
 import json
 import time
-from collections.abc import AsyncGenerator, AsyncIterable, Coroutine
+from collections.abc import AsyncGenerator, AsyncIterable, Coroutine, Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -245,9 +245,62 @@ def _record_interruption(speech_handle: SpeechHandle) -> None:
     if not speech_handle.interrupted or speech_handle._agent_turn_context is None:
         return
     span = trace.get_current_span(context=speech_handle._agent_turn_context)
+    if not span.is_recording():
+        return
     span.set_attribute(
         trace_types.ATTR_INTERRUPTION_SOURCE, speech_handle._interrupt_source or "programmatic"
     )
+
+
+@contextlib.contextmanager
+def _agent_turn(
+    speech_handle: SpeechHandle,
+    *,
+    root_context: otel_context.Context | None,
+    agent_label: str,
+) -> Iterator[trace.Span]:
+    """The speech's ``agent_turn`` span, made current for one generation.
+
+    One speech handle is one agent turn, however many LLM steps it takes: the follow-up
+    generation after a tool call runs in a new task but continues the open span instead of
+    opening a second turn. Each generation is a ``generation`` event on the span, whose
+    ``lk.generation_id`` names the latest one and ``lk.generation_count`` how many there were.
+    The span ends with the speech (``SpeechHandle._mark_done``), not with the step.
+
+    Module-level for the same reason as ``_record_queue_wait``."""
+    span = speech_handle._agent_turn_span
+    if span is None:
+        span = tracer.start_span(
+            "agent_turn",
+            context=root_context,
+            attributes={trace_types.ATTR_SPEECH_ID: speech_handle.id},
+        )
+        # an agent turn is the convention's `invoke_agent`: the framework running the agent
+        # in-process, with the inference and tool spans nested underneath
+        gen_ai_telemetry.set_agent_attributes(
+            span,
+            operation=trace_types.GenAIOperationName.INVOKE_AGENT,
+            agent_name=agent_label,
+        )
+        speech_handle._agent_turn_span = span
+        speech_handle._agent_turn_context = trace.set_span_in_context(span)
+        speech_handle._agent_turn_started_at = time.perf_counter()
+        speech_handle._agent_turn_agent_name = agent_label
+
+    generation_attrs: dict[str, Any] = {
+        trace_types.ATTR_AGENT_TURN_ID: speech_handle._generation_id
+    }
+    if parent_id := speech_handle._parent_generation_id:
+        generation_attrs[trace_types.ATTR_AGENT_PARENT_TURN_ID] = parent_id
+    span.add_event("generation", generation_attrs)
+    span.set_attributes(
+        {
+            trace_types.ATTR_AGENT_TURN_ID: speech_handle._generation_id,
+            trace_types.ATTR_GENERATION_COUNT: speech_handle._num_steps,
+        }
+    )
+    with tracer.use_span(span, end_on_exit=False):
+        yield span
 
 
 def _record_queue_wait(speech_handle: SpeechHandle) -> None:
@@ -259,7 +312,8 @@ def _record_queue_wait(speech_handle: SpeechHandle) -> None:
     ) is None or speech_handle._agent_turn_context is None:
         return  # no agent_turn span yet: never fall back to whatever span is current
     span = trace.get_current_span(context=speech_handle._agent_turn_context)
-    span.set_attribute(trace_types.ATTR_SPEECH_QUEUE_WAIT, queue_wait)
+    if span.is_recording():
+        span.set_attribute(trace_types.ATTR_SPEECH_QUEUE_WAIT, queue_wait)
 
 
 # NOTE: AgentActivity isn't exposed to the public API
@@ -3024,35 +3078,19 @@ class AgentActivity(RecognitionHooks):
         model_settings: ModelSettings,
         _previous_user_metrics: llm.MetricsReport | None = None,
     ) -> None:
-        with tracer.start_as_current_span(
-            "agent_turn", context=self._session._root_span_context
-        ) as current_span:
-            current_span.set_attribute(trace_types.ATTR_AGENT_TURN_ID, speech_handle._generation_id)
-            if parent_id := speech_handle._parent_generation_id:
-                current_span.set_attribute(trace_types.ATTR_AGENT_PARENT_TURN_ID, parent_id)
-            # an agent turn is the convention's `invoke_agent`: the framework running the
-            # agent in-process, with the inference and tool spans nested underneath
-            gen_ai_telemetry.set_agent_attributes(
-                current_span,
-                operation=trace_types.GenAIOperationName.INVOKE_AGENT,
-                agent_name=self._agent.label,
+        with _agent_turn(
+            speech_handle,
+            root_context=self._session._root_span_context,
+            agent_label=self._agent.label,
+        ):
+            await self._tts_task_impl(
+                speech_handle=speech_handle,
+                text=text,
+                audio=audio,
+                add_to_chat_ctx=add_to_chat_ctx,
+                model_settings=model_settings,
+                _previous_user_metrics=_previous_user_metrics,
             )
-            speech_handle._agent_turn_context = otel_context.get_current()
-            turn_started_at = time.perf_counter()
-
-            try:
-                await self._tts_task_impl(
-                    speech_handle=speech_handle,
-                    text=text,
-                    audio=audio,
-                    add_to_chat_ctx=add_to_chat_ctx,
-                    model_settings=model_settings,
-                    _previous_user_metrics=_previous_user_metrics,
-                )
-            finally:
-                otel_metrics.record_invoke_agent_duration(
-                    time.perf_counter() - turn_started_at, agent_name=self._agent.label
-                )
 
     async def _tts_task_impl(
         self,
@@ -3328,36 +3366,20 @@ class AgentActivity(RecognitionHooks):
         instructions: str | Instructions | None = None,
         _previous_user_metrics: llm.MetricsReport | None = None,
     ) -> None:
-        with tracer.start_as_current_span(
-            "agent_turn", context=self._session._root_span_context
-        ) as current_span:
-            current_span.set_attribute(trace_types.ATTR_AGENT_TURN_ID, speech_handle._generation_id)
-            if parent_id := speech_handle._parent_generation_id:
-                current_span.set_attribute(trace_types.ATTR_AGENT_PARENT_TURN_ID, parent_id)
-            # an agent turn is the convention's `invoke_agent`: the framework running the
-            # agent in-process, with the inference and tool spans nested underneath
-            gen_ai_telemetry.set_agent_attributes(
-                current_span,
-                operation=trace_types.GenAIOperationName.INVOKE_AGENT,
-                agent_name=self._agent.label,
+        with _agent_turn(
+            speech_handle,
+            root_context=self._session._root_span_context,
+            agent_label=self._agent.label,
+        ):
+            await self._pipeline_reply_task_impl(
+                speech_handle=speech_handle,
+                chat_ctx=chat_ctx,
+                tools=tools,
+                model_settings=model_settings,
+                new_message=new_message,
+                instructions=instructions,
+                _previous_user_metrics=_previous_user_metrics,
             )
-            speech_handle._agent_turn_context = otel_context.get_current()
-            turn_started_at = time.perf_counter()
-
-            try:
-                await self._pipeline_reply_task_impl(
-                    speech_handle=speech_handle,
-                    chat_ctx=chat_ctx,
-                    tools=tools,
-                    model_settings=model_settings,
-                    new_message=new_message,
-                    instructions=instructions,
-                    _previous_user_metrics=_previous_user_metrics,
-                )
-            finally:
-                otel_metrics.record_invoke_agent_duration(
-                    time.perf_counter() - turn_started_at, agent_name=self._agent.label
-                )
 
     async def _pipeline_reply_task_impl(
         self,
@@ -4120,22 +4142,11 @@ class AgentActivity(RecognitionHooks):
         model_settings: ModelSettings,
         instructions: str | None = None,
     ) -> None:
-        with tracer.start_as_current_span(
-            "agent_turn", context=self._session._root_span_context
-        ) as current_span:
-            current_span.set_attribute(trace_types.ATTR_AGENT_TURN_ID, speech_handle._generation_id)
-            if parent_id := speech_handle._parent_generation_id:
-                current_span.set_attribute(trace_types.ATTR_AGENT_PARENT_TURN_ID, parent_id)
-            # an agent turn is the convention's `invoke_agent`: the framework running the
-            # agent in-process, with the inference and tool spans nested underneath
-            gen_ai_telemetry.set_agent_attributes(
-                current_span,
-                operation=trace_types.GenAIOperationName.INVOKE_AGENT,
-                agent_name=self._agent.label,
-            )
-            speech_handle._agent_turn_context = otel_context.get_current()
-            turn_started_at = time.perf_counter()
-
+        with _agent_turn(
+            speech_handle,
+            root_context=self._session._root_span_context,
+            agent_label=self._agent.label,
+        ):
             inference_span = tracer.start_span("realtime_inference")
             try:
                 await self._realtime_generation_task_impl(
@@ -4147,9 +4158,6 @@ class AgentActivity(RecognitionHooks):
                 )
             finally:
                 inference_span.end()
-                otel_metrics.record_invoke_agent_duration(
-                    time.perf_counter() - turn_started_at, agent_name=self._agent.label
-                )
 
     async def _realtime_generation_task_impl(
         self,

--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -385,9 +385,8 @@ class SpeechHandle:
         self, carry: tuple[trace.Span, float | None, str | None], *, discarded: SpeechHandle
     ) -> None:
         """Adopt the ``agent_turn`` taken from ``discarded`` (see ``_take_agent_turn``)."""
+        # adopted even when sampled out: the duration metric still needs the start time
         span, started_at, agent_name = carry
-        if not span.is_recording():
-            return
         span.add_event(
             "preemptive_generation_discarded", {trace_types.ATTR_SPEECH_ID: discarded.id}
         )

--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Generator, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from opentelemetry import context as otel_context
+from opentelemetry import context as otel_context, trace
 
 from .. import llm, utils
 from ..log import logger
@@ -57,7 +57,12 @@ class SpeechHandle:
         self._tasks: list[asyncio.Task] = []
         self._chat_items: list[llm.ChatItem] = []
         self._num_steps = 1
+        # one agent_turn span for the whole speech, however many generations (LLM steps) it
+        # takes; opened by the first reply task, ended with the speech in _mark_done
+        self._agent_turn_span: trace.Span | None = None
         self._agent_turn_context: otel_context.Context | None = None
+        self._agent_turn_started_at: float | None = None
+        self._agent_turn_agent_name: str | None = None
         self._scheduled_at: float | None = None
         self._authorized_at: float | None = None
         self._interrupt_source: InterruptionSource | None = None  # first interrupt's cause
@@ -349,6 +354,7 @@ class SpeechHandle:
             if error is not None:
                 self._error = error
             self._done_fut.set_result(None)
+        self._end_agent_turn(error)
 
         if self._generations:
             self._mark_generation_done()
@@ -356,6 +362,22 @@ class SpeechHandle:
         if self._interrupt_timeout_handle is not None:
             self._interrupt_timeout_handle.cancel()
             self._interrupt_timeout_handle = None
+
+    def _end_agent_turn(self, error: BaseException | None) -> None:
+        """Close the speech's ``agent_turn`` span: the speech is done, whatever step it was on."""
+        span, self._agent_turn_span = self._agent_turn_span, None
+        if span is None or not span.is_recording():
+            return
+        from ..telemetry import otel_metrics, utils as trace_utils
+
+        if isinstance(error, Exception):
+            trace_utils.record_exception(span, error)
+        if self._agent_turn_started_at is not None and self._agent_turn_agent_name is not None:
+            otel_metrics.record_invoke_agent_duration(
+                time.perf_counter() - self._agent_turn_started_at,
+                agent_name=self._agent_turn_agent_name,
+            )
+        span.end()
 
     def _mark_scheduled(self) -> None:
         if self._scheduled_at is None:

--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -355,7 +355,8 @@ class SpeechHandle:
             if error is not None:
                 self._error = error
             self._done_fut.set_result(None)
-        self._end_agent_turn(error)
+        # a pipeline LLM failure is stored on the handle before the tasks finish
+        self._end_agent_turn(error if error is not None else self._error)
 
         if self._generations:
             self._mark_generation_done()
@@ -399,17 +400,20 @@ class SpeechHandle:
     def _end_agent_turn(self, error: BaseException | None) -> None:
         """Close the speech's ``agent_turn`` span: the speech is done, whatever step it was on."""
         span, self._agent_turn_span = self._agent_turn_span, None
-        if span is None or not span.is_recording():
+        if span is None:
             return
         from ..telemetry import otel_metrics, utils as trace_utils
 
-        if isinstance(error, Exception):
-            trace_utils.record_exception(span, error)
+        # the duration metric does not depend on the span being sampled in
         if self._agent_turn_started_at is not None and self._agent_turn_agent_name is not None:
             otel_metrics.record_invoke_agent_duration(
                 time.perf_counter() - self._agent_turn_started_at,
                 agent_name=self._agent_turn_agent_name,
             )
+        if not span.is_recording():
+            return
+        if isinstance(error, Exception):
+            trace_utils.record_exception(span, error)
         span.end()
 
     def _mark_scheduled(self) -> None:

--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -11,6 +11,7 @@ from opentelemetry import context as otel_context, trace
 
 from .. import llm, utils
 from ..log import logger
+from ..telemetry import trace_types
 
 INTERRUPTION_TIMEOUT = 5.0  # seconds
 
@@ -362,6 +363,38 @@ class SpeechHandle:
         if self._interrupt_timeout_handle is not None:
             self._interrupt_timeout_handle.cancel()
             self._interrupt_timeout_handle = None
+
+    def _take_agent_turn(self) -> tuple[trace.Span, float | None, str | None] | None:
+        """Detach this speech's open ``agent_turn`` so a successor can continue it.
+
+        Used when a preemptive generation is discarded for another speech answering the same
+        user turn: the wasted generation stays visible under the one turn instead of becoming
+        a turn of its own. After this the speech ends without touching the span."""
+        span = self._agent_turn_span
+        if span is None:
+            return None
+        carry = (span, self._agent_turn_started_at, self._agent_turn_agent_name)
+        self._agent_turn_span = None
+        self._agent_turn_context = None
+        self._agent_turn_started_at = None
+        self._agent_turn_agent_name = None
+        return carry
+
+    def _continue_agent_turn(
+        self, carry: tuple[trace.Span, float | None, str | None], *, discarded: SpeechHandle
+    ) -> None:
+        """Adopt the ``agent_turn`` taken from ``discarded`` (see ``_take_agent_turn``)."""
+        span, started_at, agent_name = carry
+        if not span.is_recording():
+            return
+        span.add_event(
+            "preemptive_generation_discarded", {trace_types.ATTR_SPEECH_ID: discarded.id}
+        )
+        span.set_attribute(trace_types.ATTR_SPEECH_ID, self.id)
+        self._agent_turn_span = span
+        self._agent_turn_context = trace.set_span_in_context(span)
+        self._agent_turn_started_at = started_at
+        self._agent_turn_agent_name = agent_name
 
     def _end_agent_turn(self, error: BaseException | None) -> None:
         """Close the speech's ``agent_turn`` span: the speech is done, whatever step it was on."""

--- a/tests/test_agent_turn_span.py
+++ b/tests/test_agent_turn_span.py
@@ -1,0 +1,127 @@
+"""One ``agent_turn`` span per speech handle.
+
+A reply that calls a tool runs two generations (LLM steps) in two tasks; they used to be two
+``agent_turn`` spans linked only by ``lk.parent_generation_id``. The speech handle now owns a
+single span for its whole life: each generation is an event on it, tool and inference spans
+nest under it, and it ends with the speech."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import pytest
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from livekit.agents import Agent, RunContext, function_tool
+from livekit.agents.llm import FunctionToolCall
+from livekit.agents.telemetry import set_tracer_provider, trace_types, tracer
+
+from .fake_session import FakeActions, create_session, run_session
+
+pytestmark = [pytest.mark.unit, pytest.mark.no_concurrent]
+
+
+@pytest.fixture
+def span_exporter() -> Iterator[InMemorySpanExporter]:
+    original_provider = tracer._tracer_provider
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        set_tracer_provider(original_provider)
+        provider.shutdown()
+
+
+def _spans(exporter: InMemorySpanExporter, name: str) -> list[ReadableSpan]:
+    return [s for s in exporter.get_finished_spans() if s.name == name]
+
+
+def _children(
+    exporter: InMemorySpanExporter, parent: ReadableSpan, name: str
+) -> list[ReadableSpan]:
+    return [
+        s
+        for s in _spans(exporter, name)
+        if s.parent is not None and s.parent.span_id == parent.context.span_id
+    ]
+
+
+class _WeatherAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="You are a helpful assistant.")
+
+    @function_tool
+    async def get_weather(self, context: RunContext, location: str) -> str:
+        return f"sunny in {location}"
+
+
+async def test_tool_call_is_one_agent_turn(span_exporter: InMemorySpanExporter) -> None:
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.0, "What's the weather in Tokyo?")
+    actions.add_llm(
+        content="",
+        tool_calls=[
+            FunctionToolCall(name="get_weather", arguments='{"location": "Tokyo"}', call_id="1")
+        ],
+    )
+    actions.add_llm(content="It is sunny in Tokyo.", input="sunny in Tokyo")
+    actions.add_tts(1.0)
+
+    session = create_session(actions, speed_factor=2.0)
+    await asyncio.wait_for(run_session(session, _WeatherAgent(), drain_delay=1.0), timeout=60)
+
+    [root] = _spans(span_exporter, "agent_session")
+    turns = _spans(span_exporter, "agent_turn")
+    assert len(turns) == 1, [(t.attributes or {}).get(trace_types.ATTR_SPEECH_ID) for t in turns]
+    [turn] = turns
+    assert turn.parent is not None and turn.parent.span_id == root.context.span_id
+
+    attrs = turn.attributes or {}
+    speech_id = attrs[trace_types.ATTR_SPEECH_ID]
+    assert attrs[trace_types.ATTR_GENERATION_COUNT] == 2
+    assert attrs[trace_types.ATTR_AGENT_TURN_ID] == f"{speech_id}_2"
+    generations = [e for e in turn.events if e.name == "generation"]
+    assert [(e.attributes or {})[trace_types.ATTR_AGENT_TURN_ID] for e in generations] == [
+        f"{speech_id}_1",
+        f"{speech_id}_2",
+    ]
+    assert trace_types.ATTR_AGENT_PARENT_TURN_ID not in (generations[0].attributes or {})
+    assert (generations[1].attributes or {})[trace_types.ATTR_AGENT_PARENT_TURN_ID] == (
+        f"{speech_id}_1"
+    )
+
+    # both generations' inference, the tool between them, and the speech all nest under it
+    assert len(_children(span_exporter, turn, "llm_node")) == 2
+    [tool] = _children(span_exporter, turn, "function_tool")
+    [tts] = _children(span_exporter, turn, "tts_node")
+    [speaking] = _children(span_exporter, turn, "agent_speaking")
+    assert tool.start_time < tts.start_time
+    # and the turn covers everything, ending with the speech rather than with the first step
+    for child in (tool, tts, speaking):
+        assert child.end_time is not None and turn.end_time is not None
+        assert turn.start_time <= child.start_time and child.end_time <= turn.end_time
+
+
+async def test_plain_reply_is_one_generation(span_exporter: InMemorySpanExporter) -> None:
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 1.5, "Hello", stt_delay=0.1)
+    actions.add_llm("Hi there", ttft=0.1, duration=0.2)
+    actions.add_tts(0.5, ttfb=0.1, duration=0.2)
+
+    session = create_session(actions, speed_factor=2.0)
+    await asyncio.wait_for(
+        run_session(session, Agent(instructions="test"), drain_delay=1.0), timeout=60
+    )
+
+    [turn] = _spans(span_exporter, "agent_turn")
+    attrs = turn.attributes or {}
+    assert attrs[trace_types.ATTR_GENERATION_COUNT] == 1
+    assert attrs[trace_types.ATTR_AGENT_TURN_ID] == f"{attrs[trace_types.ATTR_SPEECH_ID]}_1"
+    assert len([e for e in turn.events if e.name == "generation"]) == 1
+    assert trace_types.ATTR_AGENT_PARENT_TURN_ID not in attrs

--- a/tests/test_agent_turn_span.py
+++ b/tests/test_agent_turn_span.py
@@ -11,6 +11,7 @@ import asyncio
 from collections.abc import Iterator
 
 import pytest
+from opentelemetry import trace
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -125,3 +126,42 @@ async def test_plain_reply_is_one_generation(span_exporter: InMemorySpanExporter
     assert attrs[trace_types.ATTR_AGENT_TURN_ID] == f"{attrs[trace_types.ATTR_SPEECH_ID]}_1"
     assert len([e for e in turn.events if e.name == "generation"]) == 1
     assert trace_types.ATTR_AGENT_PARENT_TURN_ID not in attrs
+
+
+def test_discarded_preemptive_generation_hands_its_turn_to_the_successor(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """A preemptive attempt discarded for the real reply (or a newer attempt) must not leave a
+    second agent_turn behind: the successor continues the span, the discarded speech ends
+    without touching it."""
+    from livekit.agents.voice.agent_activity import _agent_turn, _continue_discarded_turn
+    from livekit.agents.voice.speech_handle import SpeechHandle
+
+    root = tracer.start_span("agent_session")
+    root_ctx = trace.set_span_in_context(root)
+    attempt = SpeechHandle.create(allow_interruptions=True)
+    with _agent_turn(attempt, root_context=root_ctx, agent_label="a"):
+        pass  # the attempt's first generation ran here
+
+    reply = SpeechHandle.create(allow_interruptions=True)
+    _continue_discarded_turn(attempt, reply)
+    attempt._mark_done()  # the cancelled attempt finishes: the span must survive it
+    assert _spans(span_exporter, "agent_turn") == []
+
+    with _agent_turn(reply, root_context=root_ctx, agent_label="a"):
+        pass
+    reply._mark_done()
+    root.end()
+
+    [turn] = _spans(span_exporter, "agent_turn")
+    attrs = turn.attributes or {}
+    assert attrs[trace_types.ATTR_SPEECH_ID] == reply.id
+    assert attrs[trace_types.ATTR_GENERATION_COUNT] == 1  # the reply's own step count
+    events = [e.name for e in turn.events]
+    assert events == ["generation", "preemptive_generation_discarded", "generation"]
+    [discarded] = [e for e in turn.events if e.name == "preemptive_generation_discarded"]
+    assert (discarded.attributes or {})[trace_types.ATTR_SPEECH_ID] == attempt.id
+
+    # nothing to hand over: a plain successor is untouched
+    _continue_discarded_turn(None, reply)
+    _continue_discarded_turn(reply, reply)

--- a/tests/test_agent_turn_span.py
+++ b/tests/test_agent_turn_span.py
@@ -165,3 +165,42 @@ def test_discarded_preemptive_generation_hands_its_turn_to_the_successor(
     # nothing to hand over: a plain successor is untouched
     _continue_discarded_turn(None, reply)
     _continue_discarded_turn(reply, reply)
+
+
+def test_llm_failure_stored_on_the_handle_fails_the_turn(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """The pipeline stores an LLM failure on the handle and marks it done without one; the
+    turn must still end as failed."""
+    from opentelemetry.trace import StatusCode
+
+    from livekit.agents.voice.agent_activity import _agent_turn
+    from livekit.agents.voice.speech_handle import SpeechHandle
+
+    handle = SpeechHandle.create(allow_interruptions=True)
+    with _agent_turn(handle, root_context=None, agent_label="a"):
+        handle._error = RuntimeError("llm down")
+    handle._mark_done()
+
+    [turn] = _spans(span_exporter, "agent_turn")
+    assert turn.status.status_code == StatusCode.ERROR
+    assert [e.name for e in turn.events if e.name == "exception"] == ["exception"]
+
+
+def test_turn_duration_metric_is_recorded_when_the_span_is_sampled_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from unittest.mock import MagicMock
+
+    from livekit.agents.telemetry import otel_metrics
+    from livekit.agents.voice.speech_handle import SpeechHandle
+
+    record = MagicMock()
+    monkeypatch.setattr(otel_metrics, "record_invoke_agent_duration", record)
+    handle = SpeechHandle.create(allow_interruptions=True)
+    handle._agent_turn_span = trace.NonRecordingSpan(trace.INVALID_SPAN_CONTEXT)
+    handle._agent_turn_started_at = 1.0
+    handle._agent_turn_agent_name = "a"
+    handle._mark_done()
+    record.assert_called_once()
+    assert record.call_args.kwargs == {"agent_name": "a"}

--- a/tests/test_agent_turn_span.py
+++ b/tests/test_agent_turn_span.py
@@ -204,3 +204,22 @@ def test_turn_duration_metric_is_recorded_when_the_span_is_sampled_out(
     handle._mark_done()
     record.assert_called_once()
     assert record.call_args.kwargs == {"agent_name": "a"}
+
+
+def test_sampled_out_turn_is_still_handed_to_the_successor() -> None:
+    """The successor adopts a non-recording turn too, so the duration metric keeps the
+    discarded attempt's start time."""
+    from livekit.agents.voice.agent_activity import _continue_discarded_turn
+    from livekit.agents.voice.speech_handle import SpeechHandle
+
+    attempt = SpeechHandle.create(allow_interruptions=True)
+    attempt._agent_turn_span = trace.NonRecordingSpan(trace.INVALID_SPAN_CONTEXT)
+    attempt._agent_turn_started_at = 1.0
+    attempt._agent_turn_agent_name = "a"
+
+    reply = SpeechHandle.create(allow_interruptions=True)
+    _continue_discarded_turn(attempt, reply)
+    assert attempt._agent_turn_span is None
+    assert reply._agent_turn_span is not None
+    assert reply._agent_turn_started_at == 1.0
+    assert reply._agent_turn_agent_name == "a"

--- a/tests/test_trace_types_pii.py
+++ b/tests/test_trace_types_pii.py
@@ -62,6 +62,7 @@ SAFE_KEYS = frozenset(
         "lk.deployment_id",
         "lk.session_options",
         "lk.generation_id",
+        "lk.generation_count",
         "lk.parent_generation_id",
         "lk.interrupted",
         # llm node (tool *names* / schemas, not payloads)


### PR DESCRIPTION
## What

A reply that calls a tool runs two generations (LLM steps) in two tasks. They were two `agent_turn` spans linked only by `lk.parent_generation_id`, so one response rendered as two turns. A speech handle is now exactly one `agent_turn`.

## How

- The speech handle owns the span. The first reply task (pipeline, realtime, or `say`) opens `agent_turn` under `agent_session`; the follow-up generation after a tool call runs in a new task but continues the open span instead of opening a second one. It ends with the speech in `SpeechHandle._mark_done`, whichever step that was on, recording the speech's error (redaction-aware) and the `gen_ai.invoke_agent.duration` metric for the whole turn.
- Each generation is a `generation` event on the span with its `lk.generation_id` and `lk.parent_generation_id`. On the span itself `lk.generation_id` names the latest generation and the new `lk.generation_count` how many there were (more than one means tools ran before the final reply). `lk.speech_id` is set at creation.
- Every step's `llm_node`, `function_tool`, `tts_node`, `realtime_inference` and `agent_speaking` nest under the one turn.
- A preemptive generation discarded for a successor answering the same user turn (a newer attempt, or the real reply after `on_user_turn_completed` changed the transcript) hands its open `agent_turn` to that successor: the wasted generation stays visible under the one turn with a `preemptive_generation_discarded` event, and `lk.speech_id` follows the speech that answered. An attempt cancelled with no successor yet (the user resumed) still ends as its own turn. The queue-wait and interruption helpers tolerate a span already ended with the speech.

```
agent_turn  (lk.speech_id, lk.generation_count=2; events: generation ×2)
├─ llm_node          generation 1: the tool call
├─ function_tool
├─ llm_node          generation 2: the reply
├─ tts_node
└─ agent_speaking
```

## Tests

`tests/test_agent_turn_span.py`: a tool-calling reply through the fake session yields one `agent_turn` with two `generation` events, both `llm_node`s, the tool and the speech inside it, and the turn outlasting the last child; a plain reply is one generation. Existing coverage (`test_coverage_spans`, `test_eou_wait_span`, `test_agent_session`) passes unchanged.

Stacked on #7137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
