### PR TITLE
fix: drop unused audio forwarding buffer

### DIFF
--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -566,7 +566,6 @@ async def _text_forwarding_task(
 
 @dataclass
 class _AudioOutput:
-    audio: list[rtc.AudioFrame]
     first_frame_fut: asyncio.Future[float]
     """Future that will be set with the timestamp of the first frame's capture"""
 
@@ -590,7 +589,6 @@ def perform_audio_forwarding(
     reconcile_playout_pause: Callable[[], None],
 ) -> tuple[asyncio.Task[None], _AudioOutput]:
     out = _AudioOutput(
-        audio=[],
         first_frame_fut=asyncio.Future(),
         captured_segments_before=audio_output.captured_playout_segments,
     )
@@ -631,7 +629,6 @@ async def _audio_forwarding_task(
         reconcile_playout_pause()
 
         async for frame in tts_output:
-            out.audio.append(frame)
             if out.started_forwarding_at is None:
                 out.started_forwarding_at = time.time()
 

--- a/tests/test_playback_started_attribution.py
+++ b/tests/test_playback_started_attribution.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import time
+import weakref
 from collections.abc import AsyncIterable
 
 import pytest
@@ -89,6 +91,38 @@ async def _drive_forwarding(
         tts_output=_source(),
         reconcile_playout_pause=lambda: None,
     )
+
+
+@pytest.mark.parametrize("output_sample_rate", [None, 16000])
+async def test_forwarding_result_does_not_retain_consumed_audio(
+    output_sample_rate: int | None,
+) -> None:
+    audio_output = FakeAudioOutput(sample_rate=output_sample_rate)
+    frames: weakref.WeakSet[rtc.AudioFrame] = weakref.WeakSet()
+
+    async def _source() -> AsyncIterable[rtc.AudioFrame]:
+        for _ in range(3000):
+            frame = rtc.AudioFrame.create(
+                sample_rate=48000, num_channels=1, samples_per_channel=960
+            )
+            frames.add(frame)
+            yield frame
+
+    task, out = perform_audio_forwarding(
+        audio_output=audio_output,
+        tts_output=_source(),
+        reconcile_playout_pause=lambda: None,
+    )
+    try:
+        await task
+        await asyncio.sleep(0)
+        gc.collect()
+
+        assert audio_output._pushed_duration == pytest.approx(60.0)
+        assert not frames
+        assert out.first_frame_fut.done()
+    finally:
+        audio_output.clear_buffer()
 
 
 async def test_own_playback_started_resolves_first_frame_fut() -> None:

--- a/tests/test_playout_launch_pause.py
+++ b/tests/test_playout_launch_pause.py
@@ -168,7 +168,6 @@ async def test_audio_forwarding_reconciles_playout_pause_before_first_frame() ->
         yield frame
 
     out = _AudioOutput(
-        audio=[],
         first_frame_fut=asyncio.Future(),
         captured_segments_before=0,
     )


### PR DESCRIPTION
Audio forwarding kept every consumed frame in `_AudioOutput.audio`, which has no readers. Remove that retention so consumed frames can be released while forwarding results remain alive.

A synthetic 60-second, 48 kHz mono stream now retains 0 PCM bytes in the result, down from 5,760,000. Weak-reference regression tests cover direct forwarding and resampling.

Validation: 50 focused tests and `make check` pass.

Addresses AGT-3447

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-6

> can you investigate linear AGT-3447

> okay, let's open a draft PR drop the buffer (if we don't use it at all)

</details>
