### PR TITLE
fix(openai): don't replace a TTS prewarm that is still in flight

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/tts.py
@@ -230,7 +230,11 @@ class TTS(tts.TTS):
             except Exception:
                 pass
 
-        self._prewarm_task = asyncio.create_task(_prewarm())
+        # Don't replace a prewarm still in flight: the old task would lose its only reference,
+        # and aclose() cancels just the latest one, so it could still be using the client after
+        # close. utils.ConnectionPool.prewarm guards the same way.
+        if self._prewarm_task is None or self._prewarm_task.done():
+            self._prewarm_task = asyncio.create_task(_prewarm())
 
     async def aclose(self) -> None:
         if self._prewarm_task:

--- a/tests/test_plugin_openai_tts.py
+++ b/tests/test_plugin_openai_tts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import io
 import json
@@ -102,3 +103,27 @@ async def test_stream_format_requested_per_model(model: str, expected: str) -> N
     await _synthesize(_tts(handler, model=model))
 
     assert requests[0]["stream_format"] == expected
+
+
+async def test_a_second_prewarm_does_not_replace_one_still_in_flight() -> None:
+    """aclose() cancels only the task it holds, so a replaced prewarm outlives the close."""
+    release = asyncio.Event()
+    in_flight = asyncio.Semaphore(0)
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        in_flight.release()
+        await release.wait()
+        return httpx.Response(200, content=b"", headers={"content-type": "text/plain"})
+
+    tts = _tts(handler, model="gpt-4o-mini-tts")
+    tts.prewarm()
+    first = tts._prewarm_task
+    await in_flight.acquire()  # the first request is genuinely open
+    tts.prewarm()
+
+    await tts.aclose()
+    try:
+        assert first is not None and first.done(), "a prewarm task outlived aclose()"
+    finally:
+        release.set()
+        await asyncio.gather(first, return_exceptions=True)


### PR DESCRIPTION
## Problem

`TTS.prewarm()` assigns `_prewarm_task` unconditionally, so a second call while the first request
is still open drops the only reference to the running task. `aclose()` cancels the task it is
holding at the time, so the replaced one keeps running after close, still using the client that
`aclose()` then closes.

This is reachable through normal use: `AgentActivity` prewarms when it starts and again when a TTS
is set, so a session that hands off between agents prewarms the same instance once per handoff.

RUF006 does not catch it. The task is assigned, and the problem is that the assignment replaces a
live one.

## Changes

`prewarm()` now starts a warm-up only when there is no previous task or it has finished. That is
the guard `soniox`, `inworld`, `LLM.prewarm` and `utils.ConnectionPool.prewarm` already use.

Nothing else changes: it still fires a single warm-up request, and `aclose()` is untouched.
`palabra` has the same unconditional assignment and is deliberately left alone, because its
`aclose()` sets the closed flag before cancelling and `_ensure_session` refuses while holding the
same lock, so its orphaned task cannot open a session.

## Testing

The new test in `tests/test_plugin_openai_tts.py` holds a prewarm request open, calls `prewarm()`
again, then closes. It fails on main because a task is still running when `aclose()` returns.

`pytest --unit --audio_eot`: 2546 passed, 5 skipped, against 2545 on unmodified main.
`ruff check` and `ruff format --check` (992 files) clean, `scripts/check_types.py` reports no
issues in 650 source files. All at `c6939a5b8`.