### PR TITLE
fix(voice): fail remote session requests when transport closes

### DIFF
--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -980,7 +980,6 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
         self._started = False
         self._pending_requests: dict[str, asyncio.Future[agent_pb.SessionResponse]] = {}
         self._recv_task: asyncio.Task[None] | None = None
-        self._recv_error: Exception | None = None
 
     @classmethod
     def from_room(cls, room: rtc.Room, agent_identity: str) -> RemoteSession:
@@ -991,7 +990,6 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
         if self._started:
             return
         self._started = True
-        self._recv_error = None
         await self._transport.start()
         self._recv_task = asyncio.create_task(self._recv_loop())
 
@@ -1020,15 +1018,12 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
                         self.emit(event_field, msg.event)
         except asyncio.CancelledError:
             pass
-        except Exception as e:
+        except Exception:
             logger.warning("error processing session message", exc_info=True)
-            self._recv_error = e
         finally:
             for future in self._pending_requests.values():
                 if not future.done():
-                    error = RuntimeError("remote session transport closed")
-                    error.__cause__ = self._recv_error
-                    future.set_exception(error)
+                    future.set_exception(RuntimeError("remote session transport closed"))
             self._pending_requests.clear()
 
     def _dispatch_response(self, response: agent_pb.SessionResponse) -> None:
@@ -1042,7 +1037,7 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
         timeout: float = 60.0,
     ) -> agent_pb.SessionResponse:
         if self._recv_task is None or self._recv_task.done():
-            raise RuntimeError("remote session transport closed") from self._recv_error
+            raise RuntimeError("remote session transport closed")
 
         req_type = request.WhichOneof("request")
         future: asyncio.Future[agent_pb.SessionResponse] = asyncio.Future()
@@ -1060,6 +1055,8 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
             raise
         finally:
             self._pending_requests.pop(request.request_id, None)
+            if future.done() and not future.cancelled():
+                future.exception()
 
         if resp.error:
             raise RuntimeError(f"session request {req_type} failed: {resp.error}")
@@ -1088,6 +1085,8 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
                 if asyncio.get_event_loop().time() >= deadline:
                     raise TimeoutError("wait_for_ready timed out") from None
             except Exception as e:
+                if self._recv_task is None or self._recv_task.done():
+                    raise
                 # the transport reports that it is not up yet instead of dropping
                 # the ping, and that state is exactly what this call polls
                 # through. The request timeout paced the retries before; pace

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -980,6 +980,7 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
         self._started = False
         self._pending_requests: dict[str, asyncio.Future[agent_pb.SessionResponse]] = {}
         self._recv_task: asyncio.Task[None] | None = None
+        self._recv_error: Exception | None = None
 
     @classmethod
     def from_room(cls, room: rtc.Room, agent_identity: str) -> RemoteSession:
@@ -990,6 +991,7 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
         if self._started:
             return
         self._started = True
+        self._recv_error = None
         await self._transport.start()
         self._recv_task = asyncio.create_task(self._recv_loop())
 
@@ -1018,8 +1020,16 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
                         self.emit(event_field, msg.event)
         except asyncio.CancelledError:
             pass
-        except Exception:
+        except Exception as e:
             logger.warning("error processing session message", exc_info=True)
+            self._recv_error = e
+        finally:
+            for future in self._pending_requests.values():
+                if not future.done():
+                    error = RuntimeError("remote session transport closed")
+                    error.__cause__ = self._recv_error
+                    future.set_exception(error)
+            self._pending_requests.clear()
 
     def _dispatch_response(self, response: agent_pb.SessionResponse) -> None:
         future = self._pending_requests.pop(response.request_id, None)
@@ -1031,6 +1041,9 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
         request: agent_pb.SessionRequest,
         timeout: float = 60.0,
     ) -> agent_pb.SessionResponse:
+        if self._recv_task is None or self._recv_task.done():
+            raise RuntimeError("remote session transport closed") from self._recv_error
+
         req_type = request.WhichOneof("request")
         future: asyncio.Future[agent_pb.SessionResponse] = asyncio.Future()
         self._pending_requests[request.request_id] = future
@@ -1040,15 +1053,13 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
             await self._transport.send_message(msg)
             resp = await asyncio.wait_for(future, timeout=timeout)
         except asyncio.TimeoutError:
-            self._pending_requests.pop(request.request_id, None)
             logger.warning(
                 "remote session request timed out",
                 extra={"request_id": request.request_id, "type": req_type, "timeout": timeout},
             )
             raise
-        except Exception:
+        finally:
             self._pending_requests.pop(request.request_id, None)
-            raise
 
         if resp.error:
             raise RuntimeError(f"session request {req_type} failed: {resp.error}")

--- a/livekit-agents/livekit/agents/voice/remote_session.py
+++ b/livekit-agents/livekit/agents/voice/remote_session.py
@@ -1036,7 +1036,9 @@ class RemoteSession(rtc.EventEmitter[RemoteSessionEventTypes]):
         request: agent_pb.SessionRequest,
         timeout: float = 60.0,
     ) -> agent_pb.SessionResponse:
-        if self._recv_task is None or self._recv_task.done():
+        if self._recv_task is None:
+            raise RuntimeError("remote session not started")
+        if self._recv_task.done():
             raise RuntimeError("remote session transport closed")
 
         req_type = request.WhichOneof("request")

--- a/tests/test_remote_session.py
+++ b/tests/test_remote_session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import logging
 from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock
@@ -83,6 +84,17 @@ class _ControllableTransport(SessionTransport):
         if self.receive_error is not None:
             raise self.receive_error
         raise StopAsyncIteration
+
+
+class _SendFailsAfterDisconnectTransport(_ControllableTransport):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fail_send = asyncio.Event()
+
+    async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
+        self.sent.set()
+        await self.fail_send.wait()
+        raise RuntimeError("send failed")
 
 
 def _make_mock_session() -> MagicMock:
@@ -181,7 +193,7 @@ async def test_request_after_transport_eof_fails_immediately():
 
 
 @pytest.mark.asyncio
-async def test_receive_error_fails_pending_request_immediately():
+async def test_receive_error_fails_pending_request_without_exposing_cause():
     transport = _ControllableTransport()
     client = RemoteSession(transport)
     await client.start()
@@ -195,9 +207,66 @@ async def test_receive_error_fails_pending_request_immediately():
         with pytest.raises(RuntimeError, match="remote session transport closed") as exc_info:
             await asyncio.wait_for(request_task, timeout=1.0)
 
-        assert exc_info.value.__cause__ is transport.receive_error
+        assert exc_info.value.__cause__ is None
         assert not client._pending_requests
     finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_ready_fails_immediately_after_transport_eof():
+    transport = _ControllableTransport()
+    client = RemoteSession(transport)
+    await client.start()
+
+    transport.disconnect.set()
+    assert client._recv_task is not None
+    await client._recv_task
+
+    try:
+        with pytest.raises(RuntimeError, match="remote session transport closed"):
+            await asyncio.wait_for(
+                client.wait_for_ready(timeout=10.0, retry_interval=1.0), timeout=0.5
+            )
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_receive_and_send_failures_do_not_leak_future_exception():
+    transport = _SendFailsAfterDisconnectTransport()
+    client = RemoteSession(transport)
+    await client.start()
+
+    loop = asyncio.get_running_loop()
+    original_handler = loop.get_exception_handler()
+    unhandled: list[dict[str, object]] = []
+    loop.set_exception_handler(lambda _loop, context: unhandled.append(context))
+
+    request_task = asyncio.create_task(client.run("hello"))
+    await transport.sent.wait()
+    pending_future = next(iter(client._pending_requests.values()))
+    transport.disconnect.set()
+    assert client._recv_task is not None
+    await client._recv_task
+    transport.fail_send.set()
+
+    try:
+        with pytest.raises(RuntimeError, match="send failed"):
+            await request_task
+
+        del pending_future
+        del request_task
+        gc.collect()
+        await asyncio.sleep(0)
+
+        assert not [
+            context
+            for context in unhandled
+            if context.get("message") == "Future exception was never retrieved"
+        ]
+    finally:
+        loop.set_exception_handler(original_handler)
         await client.aclose()
 
 

--- a/tests/test_remote_session.py
+++ b/tests/test_remote_session.py
@@ -157,6 +157,14 @@ async def test_cancelled_request_is_removed_from_pending_requests():
 
 
 @pytest.mark.asyncio
+async def test_request_before_start_reports_session_not_started():
+    client = RemoteSession(_ControllableTransport())
+
+    with pytest.raises(RuntimeError, match="remote session not started"):
+        await client.run("hello")
+
+
+@pytest.mark.asyncio
 async def test_transport_eof_fails_pending_request_immediately():
     transport = _ControllableTransport()
     client = RemoteSession(transport)

--- a/tests/test_remote_session.py
+++ b/tests/test_remote_session.py
@@ -58,6 +58,33 @@ class PairedTransport(SessionTransport):
             raise StopAsyncIteration from None
 
 
+class _ControllableTransport(SessionTransport):
+    """A transport whose receive side terminates when the test asks it to."""
+
+    def __init__(self) -> None:
+        self.sent = asyncio.Event()
+        self.disconnect = asyncio.Event()
+        self.receive_error: Exception | None = None
+
+    async def start(self) -> None:
+        pass
+
+    async def send_message(self, msg: agent_pb.AgentSessionMessage) -> None:
+        self.sent.set()
+
+    async def close(self) -> None:
+        self.disconnect.set()
+
+    def __aiter__(self) -> AsyncIterator[agent_pb.AgentSessionMessage]:
+        return self
+
+    async def __anext__(self) -> agent_pb.AgentSessionMessage:
+        await self.disconnect.wait()
+        if self.receive_error is not None:
+            raise self.receive_error
+        raise StopAsyncIteration
+
+
 def _make_mock_session() -> MagicMock:
     session = MagicMock()
     session.on = MagicMock()
@@ -96,6 +123,82 @@ def _make_mock_session() -> MagicMock:
     session.usage = usage
 
     return session
+
+
+@pytest.mark.asyncio
+async def test_cancelled_request_is_removed_from_pending_requests():
+    transport = _ControllableTransport()
+    client = RemoteSession(transport)
+    await client.start()
+
+    request_task = asyncio.create_task(client.run("hello"))
+    await transport.sent.wait()
+    request_task.cancel()
+
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await request_task
+
+        assert not client._pending_requests
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_transport_eof_fails_pending_request_immediately():
+    transport = _ControllableTransport()
+    client = RemoteSession(transport)
+    await client.start()
+
+    request_task = asyncio.create_task(client.run("hello"))
+    await transport.sent.wait()
+    transport.disconnect.set()
+
+    try:
+        with pytest.raises(RuntimeError, match="remote session transport closed"):
+            await asyncio.wait_for(request_task, timeout=1.0)
+
+        assert not client._pending_requests
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_after_transport_eof_fails_immediately():
+    transport = _ControllableTransport()
+    client = RemoteSession(transport)
+    await client.start()
+
+    transport.disconnect.set()
+    assert client._recv_task is not None
+    await client._recv_task
+
+    try:
+        with pytest.raises(RuntimeError, match="remote session transport closed"):
+            await asyncio.wait_for(client.run("hello"), timeout=1.0)
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_receive_error_fails_pending_request_immediately():
+    transport = _ControllableTransport()
+    client = RemoteSession(transport)
+    await client.start()
+
+    request_task = asyncio.create_task(client.run("hello"))
+    await transport.sent.wait()
+    transport.receive_error = RuntimeError("receive failed")
+    transport.disconnect.set()
+
+    try:
+        with pytest.raises(RuntimeError, match="remote session transport closed") as exc_info:
+            await asyncio.wait_for(request_task, timeout=1.0)
+
+        assert exc_info.value.__cause__ is transport.receive_error
+        assert not client._pending_requests
+    finally:
+        await client.aclose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- fail in-flight RemoteSession requests when the receive transport terminates
- reject new requests after the receive loop has stopped
- always remove cancelled and timed-out requests from the pending request map
- preserve receive errors as the cause of the connection-closed error

## Why

RemoteSession requests currently remain pending when the transport reaches EOF or its receive loop fails. Callers therefore wait for the full request timeout, which is 60 seconds by default.

Cancelling a caller also leaves its cancelled Future in `_pending_requests` because `asyncio.CancelledError` is not caught by `except Exception`.

## Test plan

- `python -m pytest tests/test_remote_session.py -q`
- `python -m ruff check livekit-agents/livekit/agents/voice/remote_session.py tests/test_remote_session.py`
- `python -m ruff format --check livekit-agents/livekit/agents/voice/remote_session.py tests/test_remote_session.py`
- `python -m mypy --platform linux -p livekit.agents.voice.remote_session`