### PR TITLE
fix(tests): run the deepgram handshake redaction check in CI

### DIFF
--- a/tests/test_ws_handshake_credential_redaction.py
+++ b/tests/test_ws_handshake_credential_redaction.py
@@ -44,24 +44,27 @@ def _assert_redacted(err: APIStatusError) -> None:
     assert err.__cause__ is None
 
 
-@pytest.mark.plugin("deepgram")
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_deepgram_stt_redacts_api_key_from_handshake_error():
     from livekit.plugins.deepgram import STT
 
-    stt = STT(api_key=SECRET_API_KEY)
-    stream = stt.stream()
-    stream._session = _session_raising(
-        _handshake_error("api.deepgram.com", "Authorization", f"Token {SECRET_API_KEY}")
+    stt = STT(
+        api_key=SECRET_API_KEY,
+        http_session=_session_raising(
+            _handshake_error("api.deepgram.com", "Authorization", f"Token {SECRET_API_KEY}")
+        ),
     )
+    stream = stt.stream()
 
     with pytest.raises(APIStatusError) as exc_info:
         await stream._connect_ws()
 
+    await stream.aclose()
     _assert_redacted(exc_info.value)
 
 
-@pytest.mark.plugin("xai")
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_xai_tts_redacts_api_key_from_handshake_error():
     from livekit.plugins.xai import TTS


### PR DESCRIPTION
## Problem

`test_deepgram_stt_redacts_api_key_from_handshake_error`, added in #7032 for #6739 and #7031,
errors before it reaches an assertion. `stt.stream()` resolves the http session, so it raises
`RuntimeError: Attempted to use an http session outside of a job context` and the mock session
lands one line too late.

The error is the same with #7032's handler in place and without it, so the test cannot currently
tell a working redaction from a removed one.

It has stayed unnoticed because nothing selects its category. `--plugin` appears in no workflow:
`unit-tests` runs the root `make unit-tests`, which is `--unit --audio_eot`; the plugin matrix runs
`tests/make test`, which is `--tts` under docker; `--realtime`, `--stt` and `--evals` have their
own jobs. `tests/Makefile` has a second `unit-tests` target that does include `--plugin`, but no
workflow calls it.

## Changes

- Pass the raising session to `STT(...)` rather than assigning `stream._session` afterwards. That
  kwarg is the escape hatch the `http_context` error message itself recommends.
- `await stream.aclose()`, without which the run stops in `conftest.fail_on_leaked_tasks` on a
  pending `STT._metrics_task`.
- Mark both tests in the module `unit` instead of `plugin(...)`. They build a synthetic
  `WSServerHandshakeError` over a `MagicMock` session and reach no provider, which is what
  `pyproject.toml` defines `unit` as; twelve `tests/test_plugin_*.py` modules are already marked
  that way for the same reason.

Only the test file changes.

## Testing

Without #7032's handler the fixed test sees a raw `WSServerHandshakeError` where it expects a
redacted `APIStatusError`. With the handler in place both tests pass. That difference is the signal
the test was written to give and did not.

`pytest --unit --audio_eot`: 2559 passed, 5 skipped, against 2557 on unmodified main.
`ruff check` and `ruff format --check` (993 files) clean. At `e527e231e`.