### PR TITLE
fix(google): keep the realtime tool result across a session restart

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -524,6 +524,10 @@ class RealtimeSession(llm.RealtimeSession):
             else None
         )
 
+        # calls this session emitted and has not answered yet. an unanswered call blocks
+        # the model, so their results must survive a session restart.
+        self._pending_tool_call_ids: set[str] = set()
+
         self._in_user_activity = False
         self._session_lock = asyncio.Lock()
         self._num_retries = 0
@@ -544,17 +548,28 @@ class RealtimeSession(llm.RealtimeSession):
     def _mark_restart_needed(self, on_error: bool = False) -> None:
         if not self._session_should_close.is_set():
             self._session_should_close.set()
-            # reset the msg_ch, do not send messages from previous session
-            if not on_error:
-                while not self._msg_ch.empty():
-                    msg = self._msg_ch.recv_nowait()
-                    if isinstance(msg, types.LiveClientContent) and msg.turn_complete is True:
-                        logger.warning(
-                            "discarding client content for turn completion, may cause generate_reply timeout",
-                            extra={"lk.pii.content": str(msg)},
-                        )
+            # reset the msg_ch, do not send messages from previous session. tool responses
+            # are the exception: the model stalls on a call it never gets an answer to, and
+            # the reconnect replays the chat ctx without function calls, so they are moved
+            # over to the new channel and go out once the new session is up.
+            carried: list[ClientEvents] = []
+            while not self._msg_ch.empty():
+                msg = self._msg_ch.recv_nowait()
+                if isinstance(msg, types.LiveClientToolResponse):
+                    carried.append(msg)
+                elif (
+                    not on_error
+                    and isinstance(msg, types.LiveClientContent)
+                    and msg.turn_complete is True
+                ):
+                    logger.warning(
+                        "discarding client content for turn completion, may cause generate_reply timeout",
+                        extra={"lk.pii.content": str(msg)},
+                    )
 
             self._msg_ch = utils.aio.Chan[ClientEvents]()
+            for msg in carried:
+                self._msg_ch.send_nowait(msg)
 
     def update_options(
         self,
@@ -655,6 +670,18 @@ class RealtimeSession(llm.RealtimeSession):
         )
         async with self._session_lock:
             if not self._active_session:
+                # mid-restart: the reconnect replays the chat ctx without function calls, so
+                # queue the results of the calls we still owe an answer to for the new session.
+                self._send_tool_results(
+                    llm.ChatContext(
+                        [
+                            item
+                            for item in chat_ctx.items
+                            if item.type == "function_call_output"
+                            and item.call_id in self._pending_tool_call_ids
+                        ]
+                    )
+                )
                 self._chat_ctx = chat_ctx
                 return
 
@@ -670,11 +697,7 @@ class RealtimeSession(llm.RealtimeSession):
                 append_ctx.items.append(item)
 
         if append_ctx.items:
-            # vertex drops `scheduling`, and Gemini reads it only on NON_BLOCKING tools
-            supports_silent_scheduling = (
-                not self._opts.vertexai and self._opts.tool_behavior == types.Behavior.NON_BLOCKING
-            )
-            if not supports_silent_scheduling and (
+            if not self._supports_silent_scheduling and (
                 silenced := [
                     item.name
                     for item in append_ctx.items
@@ -688,12 +711,6 @@ class RealtimeSession(llm.RealtimeSession):
                     extra={"functions": silenced},
                 )
 
-            tool_results = get_tool_results_for_realtime(
-                append_ctx,
-                vertexai=self._opts.vertexai,
-                tool_response_scheduling=self._opts.tool_response_scheduling,
-                supports_silent_scheduling=supports_silent_scheduling,
-            )
             if self._realtime_model.capabilities.mutable_chat_context:
                 turns_dict, _ = append_ctx.copy(exclude_function_call=True).to_provider_format(
                     format="google", inject_dummy_user_message=False
@@ -703,8 +720,7 @@ class RealtimeSession(llm.RealtimeSession):
                     self._send_client_event(
                         types.LiveClientContent(turns=turns, turn_complete=False)
                     )
-            if tool_results:
-                self._send_client_event(tool_results)
+            self._send_tool_results(append_ctx)
 
         # since we don't have a view of the history on the server side, we'll assume
         # the current state is accurate. this isn't perfect because removals aren't done.
@@ -725,6 +741,11 @@ class RealtimeSession(llm.RealtimeSession):
     @property
     def tools(self) -> llm.ToolContext:
         return self._tools.copy()
+
+    @property
+    def _supports_silent_scheduling(self) -> bool:
+        # vertex drops `scheduling`, and Gemini reads it only on NON_BLOCKING tools
+        return not self._opts.vertexai and self._opts.tool_behavior == types.Behavior.NON_BLOCKING
 
     @property
     def _manual_activity_detection(self) -> bool:
@@ -763,6 +784,22 @@ class RealtimeSession(llm.RealtimeSession):
     def _send_client_event(self, event: ClientEvents) -> None:
         with contextlib.suppress(utils.aio.channel.ChanClosed):
             self._msg_ch.send_nowait(event)
+
+    def _send_tool_results(self, chat_ctx: llm.ChatContext) -> None:
+        """Queue the tool responses held in `chat_ctx`, marking those calls answered."""
+        tool_results = get_tool_results_for_realtime(
+            chat_ctx,
+            vertexai=self._opts.vertexai,
+            tool_response_scheduling=self._opts.tool_response_scheduling,
+            supports_silent_scheduling=self._supports_silent_scheduling,
+        )
+        if not tool_results:
+            return
+
+        for item in chat_ctx.items:
+            if item.type == "function_call_output":
+                self._pending_tool_call_ids.discard(item.call_id)
+        self._send_client_event(tool_results)
 
     def generate_reply(
         self,
@@ -1488,9 +1525,11 @@ class RealtimeSession(llm.RealtimeSession):
         for fnc_call in tool_call.function_calls or []:
             arguments = json.dumps(fnc_call.args)
 
+            call_id = fnc_call.id or utils.shortuuid("fnc-call-")
+            self._pending_tool_call_ids.add(call_id)
             gen.function_ch.send_nowait(
                 llm.FunctionCall(
-                    call_id=fnc_call.id or utils.shortuuid("fnc-call-"),
+                    call_id=call_id,
                     name=fnc_call.name,
                     arguments=arguments,
                 )

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -1076,6 +1076,17 @@ class RealtimeSession(llm.RealtimeSession):
             finally:
                 await self._close_active_session()
 
+    def _requeue_tool_response(self, msg: ClientEvents) -> None:
+        """Hand a dequeued but undelivered tool response back to the next session.
+
+        The model stalls on a call it is never given an answer to, so it must not be lost
+        when the socket goes away mid-send. This lands on the channel the restart swapped
+        in, or -- when the restart has not been marked yet -- on the one it is about to
+        drain in `_mark_restart_needed`.
+        """
+        if isinstance(msg, types.LiveClientToolResponse):
+            self._send_client_event(msg)
+
     async def _send_task(self, session: AsyncSession) -> None:
         try:
             async for msg in self._msg_ch:
@@ -1083,6 +1094,9 @@ class RealtimeSession(llm.RealtimeSession):
                     if self._session_should_close.is_set() or (
                         not self._active_session or self._active_session != session
                     ):
+                        # acquiring the lock yields, so the restart may land after this msg
+                        # was dequeued and before it was sent
+                        self._requeue_tool_response(msg)
                         break
                 if isinstance(msg, types.LiveClientContent):
                     await session.send_client_content(
@@ -1090,7 +1104,11 @@ class RealtimeSession(llm.RealtimeSession):
                         turn_complete=msg.turn_complete if msg.turn_complete is not None else True,
                     )
                 elif isinstance(msg, types.LiveClientToolResponse) and msg.function_responses:
-                    await session.send_tool_response(function_responses=msg.function_responses)
+                    try:
+                        await session.send_tool_response(function_responses=msg.function_responses)
+                    except BaseException:
+                        self._requeue_tool_response(msg)
+                        raise
                 elif isinstance(msg, types.LiveClientRealtimeInput):
                     if msg.audio:
                         await session.send_realtime_input(audio=msg.audio)

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -527,3 +527,65 @@ def test_gemini_api_scheduling_does_not_warn(
         RealtimeModel(tool_response_scheduling=types.FunctionResponseScheduling.SILENT)
 
     assert not any("tool_response_scheduling is not supported" in r.message for r in caplog.records)
+
+
+async def test_tool_result_survives_a_session_restart(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`update_tools()` restarts the socket; the answer owed must reach the new session.
+
+    Gemini holds the turn open until every call it emitted is answered, and the reconnect
+    replays the chat ctx without function calls, so a result dropped here hangs the turn
+    for good (issue #6479).
+    """
+    async with _make_connected_session(monkeypatch) as session:
+        session._start_new_generation()
+        session._handle_tool_calls(_tool_call())
+        await _drain_sent(session)
+
+        chat_ctx = session.chat_ctx.copy()
+        chat_ctx.items.append(_tool_output())
+        await session.update_chat_ctx(chat_ctx)
+
+        # the restart swaps the channel out from under the queued, not-yet-sent response
+        session._mark_restart_needed()
+
+        responses = [
+            m for m in await _drain_sent(session) if isinstance(m, types.LiveClientToolResponse)
+        ]
+        assert len(responses) == 1, "the queued tool response is carried to the new channel"
+        assert responses[0].function_responses[0].id == "fc_1"  # type: ignore[index]
+
+
+async def test_tool_result_produced_while_disconnected_is_queued(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A result finishing between the two sockets still goes out on the new one."""
+    async with _make_connected_session(monkeypatch) as session:
+        session._start_new_generation()
+        session._handle_tool_calls(_tool_call())
+        await _drain_sent(session)
+
+        session._active_session = None  # the old socket is closed, the new one is not up yet
+
+        chat_ctx = session.chat_ctx.copy()
+        chat_ctx.items.append(_tool_output())
+        await session.update_chat_ctx(chat_ctx)
+
+        responses = [
+            m for m in await _drain_sent(session) if isinstance(m, types.LiveClientToolResponse)
+        ]
+        assert len(responses) == 1, "the answer we owe is queued for the reconnected session"
+        assert responses[0].function_responses[0].id == "fc_1"  # type: ignore[index]
+
+
+async def test_historical_tool_outputs_are_not_replayed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only calls this session emitted and left unanswered are replayed while disconnected."""
+    async with _make_connected_session(monkeypatch) as session:
+        session._active_session = None
+
+        chat_ctx = session.chat_ctx.copy()
+        chat_ctx.items.append(_tool_output(call_id="fc_old"))
+        await session.update_chat_ctx(chat_ctx)
+
+        assert not [
+            m for m in await _drain_sent(session) if isinstance(m, types.LiveClientToolResponse)
+        ]

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -589,3 +589,63 @@ async def test_historical_tool_outputs_are_not_replayed(monkeypatch: pytest.Monk
         assert not [
             m for m in await _drain_sent(session) if isinstance(m, types.LiveClientToolResponse)
         ]
+
+
+async def test_in_flight_tool_result_is_requeued_on_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool response already pulled off the channel still reaches the next session.
+
+    `_send_task` takes `_session_lock` after dequeueing, so a restart can land in that
+    gap; the response is neither on the channel for the carry loop to find nor on the
+    wire, and Gemini would wait on it forever.
+    """
+    async with _make_connected_session(monkeypatch) as session:
+        socket = session._active_session
+        assert socket is not None
+
+        # hold the lock so the send task parks right after it dequeues, before it sends
+        await session._session_lock.acquire()
+        send_task = asyncio.create_task(session._send_task(socket))
+        session._send_client_event(
+            types.LiveClientToolResponse(function_responses=[types.FunctionResponse(id="fc_1")])
+        )
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert session._msg_ch.empty(), "the send task should have dequeued the response"
+
+        session._mark_restart_needed()
+        session._session_lock.release()
+        await send_task
+
+        responses = [
+            m for m in await _drain_sent(session) if isinstance(m, types.LiveClientToolResponse)
+        ]
+        assert len(responses) == 1, "the in-flight response is handed to the new session once"
+        assert responses[0].function_responses[0].id == "fc_1"  # type: ignore[index]
+
+
+async def test_tool_result_is_requeued_when_the_send_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A send that dies with the socket keeps the response for the reconnected session."""
+
+    class _FailingSocket:
+        async def send_tool_response(self, **kwargs: object) -> None:
+            raise ConnectionResetError("socket went away")
+
+    async with _make_connected_session(monkeypatch) as session:
+        socket = _FailingSocket()
+        session._active_session = socket  # type: ignore[assignment]
+        session._send_client_event(
+            types.LiveClientToolResponse(function_responses=[types.FunctionResponse(id="fc_1")])
+        )
+
+        await session._send_task(socket)  # type: ignore[arg-type]
+        assert session._session_should_close.is_set(), "the failure restarts the session"
+
+        responses = [
+            m for m in await _drain_sent(session) if isinstance(m, types.LiveClientToolResponse)
+        ]
+        assert len(responses) == 1, "the response survives the failed send"
+        assert responses[0].function_responses[0].id == "fc_1"  # type: ignore[index]


### PR DESCRIPTION
`update_tools()` restarts the Gemini Live socket mid-turn, and two orderings dropped the function result owed to the model:

- `_mark_restart_needed()` swapped `_msg_ch` for a fresh channel and discarded everything queued on it, including an unsent `LiveClientToolResponse`.
- `update_chat_ctx()` returned early while `_active_session` was `None` — the window between the old socket closing and the new one connecting — leaving the result in `_chat_ctx` only. The reconnect replays that with `exclude_function_call=True`, which drops `function_call_output` too.

Gemini holds the turn open until every call it emitted is answered, so either path hangs the conversation for good.

**Fix:** carry queued tool responses over to the new channel on restart, and track the call ids this session emitted but has not answered (`_pending_tool_call_ids`, matching the existing sets in the Phonic and AWS realtime plugins) so a result produced while disconnected is queued for the reconnected session. Filtering by id keeps a handoff's historical outputs from being replayed as stray tool responses.

Sending a tool response on the reconnected socket is not new behavior — when the restart is marked before the result arrives, that is already what happens today. This only closes the two orderings where the response is dropped instead.

Three tests in `tests/test_plugin_google_realtime.py`; the two regression ones fail on `main`.

Fixes #6479

The second half of #6479 (generation-completion handling for newer Live preview models) is already resolved on `main` — `generation_complete` closes the output streams, `_is_new_generation()` gates stray `model_turn` frames, and the model-name check now only computes the `mutable_chat_context` capability once at construction. #6785 (answer every tool call) fixes the agent layer so every call produces exactly one output, but not its delivery across a socket restart, which is what this addresses. Supersedes #6481.