### PR TITLE
fix: close temporary speech stream adapters

### DIFF
--- a/livekit-agents/livekit/agents/stt/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/stt/fallback_adapter.py
@@ -61,6 +61,7 @@ class FallbackAdapter(
         if len(stt) < 1:
             raise ValueError("At least one STT instance must be provided.")
 
+        owned_stream_adapters: list[STT] = []
         non_streaming_stt = [t for t in stt if not t.capabilities.streaming]
         if non_streaming_stt:
             if vad is None:
@@ -72,9 +73,13 @@ class FallbackAdapter(
                 )
             from ..stt import StreamAdapter
 
-            stt = [
-                StreamAdapter(stt=t, vad=vad) if not t.capabilities.streaming else t for t in stt
-            ]
+            adapted_stt: list[STT] = []
+            for stt_instance in stt:
+                if not stt_instance.capabilities.streaming:
+                    stt_instance = StreamAdapter(stt=stt_instance, vad=vad)
+                    owned_stream_adapters.append(stt_instance)
+                adapted_stt.append(stt_instance)
+            stt = adapted_stt
 
         # Use the primary STT's aligned_transcript if all providers support it, since
         # the SDK only checks truthiness, not the specific granularity.
@@ -94,6 +99,7 @@ class FallbackAdapter(
         )
 
         self._stt_instances = stt
+        self._owned_stream_adapters = owned_stream_adapters
         self._attempt_timeout = attempt_timeout
         self._max_retry_per_stt = max_retry_per_stt
         self._retry_interval = retry_interval
@@ -310,6 +316,9 @@ class FallbackAdapter(
 
         for stt in self._stt_instances:
             stt.off("metrics_collected", self._on_metrics_collected)
+
+        for stream_adapter in self._owned_stream_adapters:
+            await stream_adapter.aclose()
 
     def _on_metrics_collected(self, *args: Any, **kwargs: Any) -> None:
         self.emit("metrics_collected", *args, **kwargs)

--- a/livekit-agents/livekit/agents/tts/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/tts/fallback_adapter.py
@@ -325,16 +325,17 @@ class FallbackSynthesizeStream(SynthesizeStream):
         recovering: bool = False,
     ) -> AsyncGenerator[SynthesizedAudio, None]:
         # If TTS doesn't support streaming, wrap it with StreamAdapter
+        temporary_adapter: StreamAdapter | None = None
         if tts.capabilities.streaming:
             stream = tts.stream(conn_options=conn_options)
         else:
             from .. import tokenize
 
-            wrapped_tts = StreamAdapter(
+            temporary_adapter = StreamAdapter(
                 tts=tts,
                 sentence_tokenizer=tokenize.blingfire.SentenceTokenizer(retain_format=True),
             )
-            stream = wrapped_tts.stream(conn_options=conn_options)
+            stream = temporary_adapter.stream(conn_options=conn_options)
 
         @utils.log_exceptions(logger=logger)
         async def _forward_input_task() -> None:
@@ -382,7 +383,11 @@ class FallbackSynthesizeStream(SynthesizeStream):
             raise
         finally:
             _capture_started_time()
-            await utils.aio.cancel_and_wait(input_task)
+            try:
+                await utils.aio.cancel_and_wait(input_task)
+            finally:
+                if temporary_adapter is not None:
+                    await temporary_adapter.aclose()
 
     async def _run(self, output_emitter: AudioEmitter) -> None:
         start_time = time.time()

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -570,9 +570,10 @@ class Agent:
 
             expressive_active = activity._resolve_expressive_options() is not None
             wrapped_tts = activity.tts
+            temporary_adapter: tts.StreamAdapter | None = None
 
             if not activity.tts.capabilities.streaming:
-                wrapped_tts = tts.StreamAdapter(
+                temporary_adapter = tts.StreamAdapter(
                     tts=wrapped_tts,
                     sentence_tokenizer=tokenize.blingfire.SentenceTokenizer(
                         retain_format=True,
@@ -580,29 +581,34 @@ class Agent:
                         xml_aware=expressive_active,
                     ),
                 )
+                wrapped_tts = temporary_adapter
 
-            # Mark whether expressive is active for this synthesis, synchronously
-            # just before stream() snapshots it. Doing it here (the single synthesis
-            # choke point for both generate_reply and say()) scopes it to this turn
-            # rather than leaving stale state on the instance. The provider's chunk
-            # defaults then drive the TTS's input tokenizer.
-            activity.tts._set_expressive(expressive_active)
+            try:
+                # Mark whether expressive is active for this synthesis, synchronously
+                # just before stream() snapshots it. Doing it here (the single synthesis
+                # choke point for both generate_reply and say()) scopes it to this turn
+                # rather than leaving stale state on the instance. The provider's chunk
+                # defaults then drive the TTS's input tokenizer.
+                activity.tts._set_expressive(expressive_active)
 
-            conn_options = activity.session.conn_options.tts_conn_options
-            async with wrapped_tts.stream(conn_options=conn_options) as stream:
+                conn_options = activity.session.conn_options.tts_conn_options
+                async with wrapped_tts.stream(conn_options=conn_options) as stream:
 
-                async def _forward_input() -> None:
-                    async for chunk in text:
-                        stream.push_text(chunk)
+                    async def _forward_input() -> None:
+                        async for chunk in text:
+                            stream.push_text(chunk)
 
-                    stream.end_input()
+                        stream.end_input()
 
-                forward_task = asyncio.create_task(_forward_input())
-                try:
-                    async for ev in stream:
-                        yield ev.frame
-                finally:
-                    await utils.aio.cancel_and_wait(forward_task)
+                    forward_task = asyncio.create_task(_forward_input())
+                    try:
+                        async for ev in stream:
+                            yield ev.frame
+                    finally:
+                        await utils.aio.cancel_and_wait(forward_task)
+            finally:
+                if temporary_adapter is not None:
+                    await temporary_adapter.aclose()
 
         @staticmethod
         async def transcription_node(

--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -491,6 +491,7 @@ class Agent:
             assert activity.stt is not None, "stt_node called but no STT node is available"
 
             wrapped_stt = activity.stt
+            temporary_adapter: stt.StreamAdapter | None = None
 
             if not activity.stt.capabilities.streaming:
                 if not activity.vad:
@@ -499,36 +500,41 @@ class Agent:
                         "Or manually wrap your STT in a stt.StreamAdapter"
                     )
 
-                wrapped_stt = stt.StreamAdapter(stt=wrapped_stt, vad=activity.vad)
+                temporary_adapter = stt.StreamAdapter(stt=wrapped_stt, vad=activity.vad)
+                wrapped_stt = temporary_adapter
 
-            conn_options = activity.session.conn_options.stt_conn_options
-            async with wrapped_stt.stream(conn_options=conn_options) as stream:
-                _audio_input_started_at: float = (
-                    activity._audio_recognition._input_started_at
-                    if activity._audio_recognition is not None
-                    and activity._audio_recognition._input_started_at is not None
-                    else (
-                        activity.session._recorder_io.recording_started_at
-                        if activity.session._recorder_io
-                        and activity.session._recorder_io.recording_started_at
-                        else activity.session._started_at
-                        if activity.session._started_at
-                        else time.time()
+            try:
+                conn_options = activity.session.conn_options.stt_conn_options
+                async with wrapped_stt.stream(conn_options=conn_options) as stream:
+                    _audio_input_started_at: float = (
+                        activity._audio_recognition._input_started_at
+                        if activity._audio_recognition is not None
+                        and activity._audio_recognition._input_started_at is not None
+                        else (
+                            activity.session._recorder_io.recording_started_at
+                            if activity.session._recorder_io
+                            and activity.session._recorder_io.recording_started_at
+                            else activity.session._started_at
+                            if activity.session._started_at
+                            else time.time()
+                        )
                     )
-                )
-                stream.start_time_offset = time.time() - _audio_input_started_at
+                    stream.start_time_offset = time.time() - _audio_input_started_at
 
-                @utils.log_exceptions(logger=logger)
-                async def _forward_input() -> None:
-                    async for frame in audio:
-                        stream.push_frame(frame)
+                    @utils.log_exceptions(logger=logger)
+                    async def _forward_input() -> None:
+                        async for frame in audio:
+                            stream.push_frame(frame)
 
-                forward_task = asyncio.create_task(_forward_input())
-                try:
-                    async for event in stream:
-                        yield event
-                finally:
-                    await utils.aio.cancel_and_wait(forward_task)
+                    forward_task = asyncio.create_task(_forward_input())
+                    try:
+                        async for event in stream:
+                            yield event
+                    finally:
+                        await utils.aio.cancel_and_wait(forward_task)
+            finally:
+                if temporary_adapter is not None:
+                    await temporary_adapter.aclose()
 
         @staticmethod
         async def llm_node(

--- a/tests/test_agent_stt_node.py
+++ b/tests/test_agent_stt_node.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents import Agent, AgentSession, stt
+
+from .fake_llm import FakeLLM
+from .fake_stt import FakeSTT
+from .fake_vad import FakeVAD
+
+pytestmark = pytest.mark.unit
+
+
+class _NonStreamingFakeSTT(FakeSTT):
+    def __init__(self) -> None:
+        super().__init__()
+        self._capabilities = stt.STTCapabilities(streaming=False, interim_results=False)
+        self.close_count = 0
+
+    async def aclose(self) -> None:
+        self.close_count += 1
+
+
+def _metrics_listener_count(stt_impl: stt.STT) -> int:
+    return len(stt_impl._events.get("metrics_collected", set()))
+
+
+async def test_temporary_stream_adapter_is_closed_with_session() -> None:
+    stt_impl = _NonStreamingFakeSTT()
+    baseline = _metrics_listener_count(stt_impl)
+    agent = Agent(
+        instructions="test",
+        llm=FakeLLM(),
+        stt=stt_impl,
+        vad=FakeVAD(),
+    )
+    session = AgentSession(
+        vad=None,
+        turn_handling={"turn_detection": None},
+        session_close_transcript_timeout=0.0,
+    )
+
+    await session.start(agent)
+    try:
+        assert _metrics_listener_count(stt_impl) > baseline
+    finally:
+        await session.aclose()
+
+    assert _metrics_listener_count(stt_impl) == baseline
+    assert stt_impl.close_count == 0

--- a/tests/test_agent_tts_node.py
+++ b/tests/test_agent_tts_node.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from livekit.agents import (
+    Agent,
+    AgentSession,
+    APIConnectionError,
+    APIConnectOptions,
+    ModelSettings,
+    tts,
+)
+from livekit.agents.metrics import TTSMetrics
+from livekit.agents.voice.agent_session import SessionConnectOptions
+
+from .fake_llm import FakeLLM
+from .fake_tts import FakeTTS
+
+pytestmark = pytest.mark.unit
+
+
+class _NonStreamingFakeTTS(FakeTTS):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._capabilities = tts.TTSCapabilities(streaming=False)
+        self.close_count = 0
+
+    async def aclose(self) -> None:
+        self.close_count += 1
+
+
+async def _text() -> AsyncIterator[str]:
+    yield "hello world."
+
+
+async def _start_agent(tts_impl: tts.TTS) -> tuple[AgentSession, Agent]:
+    agent = Agent(instructions="test", llm=FakeLLM(), tts=tts_impl)
+    session = AgentSession(
+        vad=None,
+        turn_handling={"turn_detection": None},
+        conn_options=SessionConnectOptions(
+            tts_conn_options=APIConnectOptions(max_retry=0, timeout=120.0)
+        ),
+    )
+    await session.start(agent)
+    return session, agent
+
+
+async def _consume_tts_node(agent: Agent) -> int:
+    frame_count = 0
+    async for _ in Agent.default.tts_node(agent, _text(), ModelSettings()):
+        frame_count += 1
+    return frame_count
+
+
+def _metrics_listener_count(tts_impl: tts.TTS) -> int:
+    return len(tts_impl._events.get("metrics_collected", set()))
+
+
+async def test_temporary_stream_adapter_is_closed_after_each_turn() -> None:
+    tts_impl = _NonStreamingFakeTTS(fake_audio_duration=0.01)
+    session, agent = await _start_agent(tts_impl)
+    metrics: list[TTSMetrics] = []
+    tts_impl.on("metrics_collected", metrics.append)
+    baseline = _metrics_listener_count(tts_impl)
+
+    try:
+        for _ in range(3):
+            assert await _consume_tts_node(agent) > 0
+            assert _metrics_listener_count(tts_impl) == baseline
+
+        assert len(metrics) == 3
+        assert tts_impl.close_count == 0
+    finally:
+        await session.aclose()
+
+
+async def test_temporary_stream_adapter_is_closed_after_synthesis_failure() -> None:
+    tts_impl = _NonStreamingFakeTTS(
+        fake_audio_duration=0.01,
+        fake_exception=APIConnectionError("probe failure"),
+    )
+    session, agent = await _start_agent(tts_impl)
+    baseline = _metrics_listener_count(tts_impl)
+
+    try:
+        with pytest.raises(APIConnectionError, match="probe failure"):
+            await _consume_tts_node(agent)
+
+        assert _metrics_listener_count(tts_impl) == baseline
+        assert tts_impl.close_count == 0
+    finally:
+        await session.aclose()
+
+
+async def test_temporary_stream_adapter_is_closed_after_cancellation() -> None:
+    tts_impl = _NonStreamingFakeTTS(fake_timeout=60.0, fake_audio_duration=0.01)
+    session, agent = await _start_agent(tts_impl)
+    baseline = _metrics_listener_count(tts_impl)
+    consumer = asyncio.create_task(_consume_tts_node(agent))
+
+    try:
+        await asyncio.wait_for(anext(tts_impl.synthesize_ch), timeout=5.0)
+        consumer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await consumer
+
+        assert _metrics_listener_count(tts_impl) == baseline
+        assert tts_impl.close_count == 0
+    finally:
+        consumer.cancel()
+        await asyncio.gather(consumer, return_exceptions=True)
+        await session.aclose()

--- a/tests/test_stt_fallback.py
+++ b/tests/test_stt_fallback.py
@@ -20,6 +20,7 @@ from livekit.agents.utils.aio.channel import ChanEmpty
 from livekit.agents.utils.audio import AudioBuffer
 
 from .fake_stt import FakeSTT
+from .fake_vad import FakeVAD
 
 pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
@@ -71,6 +72,33 @@ class _NamedSTT(FakeSTT):
     @property
     def provider(self) -> str:
         return self._provider_name
+
+
+class _NonStreamingSTT(FakeSTT):
+    def __init__(self) -> None:
+        super().__init__()
+        self._capabilities = STTCapabilities(streaming=False, interim_results=False)
+        self.close_count = 0
+
+    async def aclose(self) -> None:
+        self.close_count += 1
+
+
+def _metrics_listener_count(stt: STT) -> int:
+    return len(stt._events.get("metrics_collected", set()))
+
+
+async def test_aclose_closes_automatically_created_stream_adapters() -> None:
+    stt = _NonStreamingSTT()
+    baseline = _metrics_listener_count(stt)
+    fallback = FallbackAdapter([stt], vad=FakeVAD())
+
+    assert _metrics_listener_count(stt) == baseline + 1
+
+    await fallback.aclose()
+
+    assert _metrics_listener_count(stt) == baseline
+    assert stt.close_count == 0
 
 
 async def test_reports_active_instance_model_and_provider() -> None:

--- a/tests/test_tts_fallback.py
+++ b/tests/test_tts_fallback.py
@@ -66,6 +66,73 @@ class _NamedTTS(FakeTTS):
         return self._provider_name
 
 
+def _metrics_listener_count(tts_impl: TTS) -> int:
+    return len(tts_impl._events.get("metrics_collected", set()))
+
+
+def _set_non_streaming(tts_impl: FakeTTS) -> FakeTTS:
+    tts_impl._capabilities.streaming = False
+    return tts_impl
+
+
+async def test_stream_closes_temporary_adapter_after_each_request() -> None:
+    non_streaming_tts = _set_non_streaming(FakeTTS(fake_audio_duration=1.0))
+    fallback_adapter = FallbackAdapterTester([non_streaming_tts, FakeTTS(fake_audio_duration=1.0)])
+    baseline = _metrics_listener_count(non_streaming_tts)
+
+    try:
+        for _ in range(3):
+            async with fallback_adapter.stream() as stream:
+                stream.push_text("hello test")
+                stream.end_input()
+                assert [frame async for frame in stream]
+
+            assert _metrics_listener_count(non_streaming_tts) == baseline
+    finally:
+        await fallback_adapter.aclose()
+
+
+async def test_stream_closes_temporary_adapter_after_failure_and_recovery() -> None:
+    non_streaming_tts = _set_non_streaming(
+        FakeTTS(fake_exception=APIConnectionError("primary failed"))
+    )
+    fallback_adapter = FallbackAdapterTester(
+        [non_streaming_tts, FakeTTS(fake_audio_duration=1.0)],
+        max_retry_per_tts=0,
+    )
+    baseline = _metrics_listener_count(non_streaming_tts)
+
+    try:
+        async with fallback_adapter.stream() as stream:
+            stream.push_text("hello test")
+            stream.end_input()
+            assert [frame async for frame in stream]
+
+        recovery_task = fallback_adapter._status[0].recovering_stream_task
+        assert recovery_task is not None
+        await recovery_task
+        assert _metrics_listener_count(non_streaming_tts) == baseline
+    finally:
+        await fallback_adapter.aclose()
+
+
+async def test_stream_closes_temporary_adapter_after_cancellation() -> None:
+    non_streaming_tts = _set_non_streaming(FakeTTS(fake_audio_duration=1.0))
+    fallback_adapter = FallbackAdapterTester([non_streaming_tts, FakeTTS(fake_audio_duration=1.0)])
+    baseline = _metrics_listener_count(non_streaming_tts)
+    stream = fallback_adapter.stream()
+
+    try:
+        stream.push_text("hello test")
+        stream.flush()
+        await asyncio.wait_for(non_streaming_tts.synthesize_ch.recv(), timeout=1.0)
+        await stream.aclose()
+        assert _metrics_listener_count(non_streaming_tts) == baseline
+    finally:
+        await stream.aclose()
+        await fallback_adapter.aclose()
+
+
 async def test_reports_active_instance_model_and_provider() -> None:
     fake1 = _NamedTTS(
         model="primary-model",


### PR DESCRIPTION
Automatic stream adaptation retained wrappers through their providers' metrics listener sets. Close owner-created wrappers when their turn, activity, or fallback lifecycle ends. Listener counts now return to baseline after success, failure, recovery, cancellation, and fallback shutdown. Configured providers remain reusable.

Addresses AGT-3451

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> please investigate AGT-3451
>
> yes, let's close that temp wrapper and create a draft PR
>
> we don't have to do this for stt fallback adapter?

</details>