### PR TITLE
perf: skip discarded trace payload construction

### DIFF
--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -245,6 +245,8 @@ class LLMStream(ABC):
         self._event_aiter, monitor_aiter = self._tee_aiter
         self._current_attempt_has_error = False
         self._provider_request_ids: list[str] = []
+        self._llm_request_span: trace.Span | None = None
+        self._record_content = False
         self._metrics_task = asyncio.create_task(
             self._metrics_monitor_task(monitor_aiter), name="LLM._metrics_task"
         )
@@ -257,13 +259,15 @@ class LLMStream(ABC):
             with tracer.start_as_current_span(
                 self._llm_request_span_name, end_on_exit=False
             ) as span:
+                # Enabling capture later must not emit a partial response.
+                self._record_content = (
+                    span.is_recording() and gen_ai_telemetry.capture_content_enabled()
+                )
                 self._record_genai_request(span)
                 await self._main_task()
 
         self._task = asyncio.create_task(_traceable_main_task(), name="LLM._main_task")
         self._task.add_done_callback(lambda _: self._event_ch.close())
-
-        self._llm_request_span: trace.Span | None = None
 
     @abstractmethod
     async def _run(self) -> None: ...
@@ -278,7 +282,7 @@ class LLMStream(ABC):
             stream=True,
             output_type=trace_types.GenAIOutputType.TEXT,
         )
-        if span.is_recording() and gen_ai_telemetry.capture_content_enabled():
+        if self._record_content:
             gen_ai_telemetry.set_content_attributes(
                 span,
                 system_instructions=gen_ai_telemetry.to_system_instructions(self._chat_ctx),
@@ -379,12 +383,7 @@ class LLMStream(ABC):
                 completion_start_time = datetime.now(timezone.utc).isoformat()
 
             if ev.delta:
-                if (
-                    ev.delta.content
-                    and self._llm_request_span is not None
-                    and self._llm_request_span.is_recording()
-                    and gen_ai_telemetry.capture_content_enabled()
-                ):
+                if ev.delta.content and self._record_content:
                     response_content += ev.delta.content
                 if ev.delta.tool_calls:
                     tool_calls.extend(ev.delta.tool_calls)
@@ -436,7 +435,7 @@ class LLMStream(ABC):
                 finish_reasons=[finish_reason],
                 time_to_first_chunk=ttft if ttft >= 0 else None,
             )
-            if self._llm_request_span.is_recording() and gen_ai_telemetry.capture_content_enabled():
+            if self._record_content and gen_ai_telemetry.capture_content_enabled():
                 gen_ai_telemetry.set_content_attributes(
                     self._llm_request_span,
                     output_messages=gen_ai_telemetry.to_output_messages(

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -379,7 +379,12 @@ class LLMStream(ABC):
                 completion_start_time = datetime.now(timezone.utc).isoformat()
 
             if ev.delta:
-                if ev.delta.content:
+                if (
+                    ev.delta.content
+                    and self._llm_request_span is not None
+                    and self._llm_request_span.is_recording()
+                    and gen_ai_telemetry.capture_content_enabled()
+                ):
                     response_content += ev.delta.content
                 if ev.delta.tool_calls:
                     tool_calls.extend(ev.delta.tool_calls)

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -278,12 +278,13 @@ class LLMStream(ABC):
             stream=True,
             output_type=trace_types.GenAIOutputType.TEXT,
         )
-        gen_ai_telemetry.set_content_attributes(
-            span,
-            system_instructions=gen_ai_telemetry.to_system_instructions(self._chat_ctx),
-            input_messages=gen_ai_telemetry.to_input_messages(self._chat_ctx),
-            tool_definitions=gen_ai_telemetry.to_tool_definitions(self._tools),
-        )
+        if span.is_recording() and gen_ai_telemetry.capture_content_enabled():
+            gen_ai_telemetry.set_content_attributes(
+                span,
+                system_instructions=gen_ai_telemetry.to_system_instructions(self._chat_ctx),
+                input_messages=gen_ai_telemetry.to_input_messages(self._chat_ctx),
+                tool_definitions=gen_ai_telemetry.to_tool_definitions(self._tools),
+            )
 
     async def _main_task(self) -> None:
         self._llm_request_span = trace.get_current_span()
@@ -430,14 +431,15 @@ class LLMStream(ABC):
                 finish_reasons=[finish_reason],
                 time_to_first_chunk=ttft if ttft >= 0 else None,
             )
-            gen_ai_telemetry.set_content_attributes(
-                self._llm_request_span,
-                output_messages=gen_ai_telemetry.to_output_messages(
-                    text=response_content,
-                    function_calls=tool_calls,
-                    finish_reason=finish_reason,
-                ),
-            )
+            if self._llm_request_span.is_recording() and gen_ai_telemetry.capture_content_enabled():
+                gen_ai_telemetry.set_content_attributes(
+                    self._llm_request_span,
+                    output_messages=gen_ai_telemetry.to_output_messages(
+                        text=response_content,
+                        function_calls=tool_calls,
+                        finish_reason=finish_reason,
+                    ),
+                )
             if completion_start_time:
                 self._llm_request_span.set_attribute(
                     trace_types.ATTR_LANGFUSE_COMPLETION_START_TIME, f'"{completion_start_time}"'

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -435,7 +435,7 @@ class LLMStream(ABC):
                 finish_reasons=[finish_reason],
                 time_to_first_chunk=ttft if ttft >= 0 else None,
             )
-            if self._record_content and gen_ai_telemetry.capture_content_enabled():
+            if self._record_content:
                 gen_ai_telemetry.set_content_attributes(
                     self._llm_request_span,
                     output_messages=gen_ai_telemetry.to_output_messages(

--- a/livekit-agents/livekit/agents/voice/generation.py
+++ b/livekit-agents/livekit/agents/voice/generation.py
@@ -192,20 +192,23 @@ async def _llm_inference_task(
     text_ch, function_ch = data.text_ch, data.function_ch
     tools = tool_ctx.flatten()
 
-    attrs: dict[str, Any] = {
-        trace_types.ATTR_CHAT_CTX: json.dumps(
-            chat_ctx.to_dict(
-                exclude_audio=True,
-                exclude_image=True,
-                exclude_timestamp=True,
-                exclude_metrics=True,
-            )
-        ),
-        trace_types.ATTR_FUNCTION_TOOLS: list(tool_ctx.function_tools.keys()),
-        trace_types.ATTR_PROVIDER_TOOLS: [type(tool).__name__ for tool in tool_ctx.provider_tools],
-        trace_types.ATTR_TOOL_SETS: [type(tool_set).__name__ for tool_set in tool_ctx.toolsets],
-    }
-    current_span.set_attributes(attrs)
+    if current_span.is_recording():
+        attrs: dict[str, Any] = {
+            trace_types.ATTR_CHAT_CTX: json.dumps(
+                chat_ctx.to_dict(
+                    exclude_audio=True,
+                    exclude_image=True,
+                    exclude_timestamp=True,
+                    exclude_metrics=True,
+                )
+            ),
+            trace_types.ATTR_FUNCTION_TOOLS: list(tool_ctx.function_tools.keys()),
+            trace_types.ATTR_PROVIDER_TOOLS: [
+                type(tool).__name__ for tool in tool_ctx.provider_tools
+            ],
+            trace_types.ATTR_TOOL_SETS: [type(tool_set).__name__ for tool_set in tool_ctx.toolsets],
+        }
+        current_span.set_attributes(attrs)
 
     # the GenAI inference attributes belong to the nested `llm_request` span, which is the
     # provider call the convention describes — setting them here as well would make a
@@ -391,17 +394,18 @@ def _record_uninstrumented_inference(
     gen_ai_telemetry.set_response_attributes(
         span, finish_reasons=[finish_reason], time_to_first_chunk=data.ttft
     )
-    gen_ai_telemetry.set_content_attributes(
-        span,
-        system_instructions=gen_ai_telemetry.to_system_instructions(chat_ctx),
-        input_messages=gen_ai_telemetry.to_input_messages(chat_ctx),
-        tool_definitions=gen_ai_telemetry.to_tool_definitions(tools),
-        output_messages=gen_ai_telemetry.to_output_messages(
-            text=data.generated_text,
-            function_calls=data.generated_functions,
-            finish_reason=finish_reason,
-        ),
-    )
+    if span.is_recording() and gen_ai_telemetry.capture_content_enabled():
+        gen_ai_telemetry.set_content_attributes(
+            span,
+            system_instructions=gen_ai_telemetry.to_system_instructions(chat_ctx),
+            input_messages=gen_ai_telemetry.to_input_messages(chat_ctx),
+            tool_definitions=gen_ai_telemetry.to_tool_definitions(tools),
+            output_messages=gen_ai_telemetry.to_output_messages(
+                text=data.generated_text,
+                function_calls=data.generated_functions,
+                finish_reason=finish_reason,
+            ),
+        )
     if usage is not None:
         gen_ai_telemetry.set_usage_attributes(span, usage)
 

--- a/tests/test_llm_telemetry.py
+++ b/tests/test_llm_telemetry.py
@@ -76,6 +76,14 @@ class _UsageLLMStream(llm.LLMStream):
         )
 
 
+class _CaptureToggleLLMStream(_UsageLLMStream):
+    capture_content_during_run: bool = False
+
+    async def _run(self) -> None:
+        gen_ai.set_capture_content(self.capture_content_during_run)
+        await super()._run()
+
+
 class _ResponseContentProbe(str):
     was_accumulated: bool = False
 
@@ -159,6 +167,45 @@ async def test_llm_span_reports_cached_input_tokens(
             "finish_reason": "stop",
         }
     ]
+
+
+@pytest.mark.parametrize(
+    ("capture_at_start", "capture_during_run"),
+    [
+        (False, True),
+        (True, False),
+    ],
+)
+async def test_llm_stream_capture_requires_enablement_at_start_and_completion(
+    span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+    capture_at_start: bool,
+    capture_during_run: bool,
+) -> None:
+    chat_ctx = llm.ChatContext.empty()
+    chat_ctx.add_message(role="user", content="hello")
+    gen_ai.set_capture_content(capture_at_start)
+    try:
+        monkeypatch.setattr(
+            _CaptureToggleLLMStream, "capture_content_during_run", capture_during_run
+        )
+        stream = _CaptureToggleLLMStream(
+            _UsageLLM(),
+            chat_ctx=chat_ctx,
+            tools=[],
+            conn_options=DEFAULT_API_CONNECT_OPTIONS,
+        )
+        response = await stream.collect()
+    finally:
+        gen_ai.set_capture_content(True)
+
+    assert response.text == "hello"
+    spans = [span for span in span_exporter.get_finished_spans() if span.name == "llm_request"]
+    assert len(spans) == 1
+    assert (trace_types.ATTR_GEN_AI_INPUT_MESSAGES in spans[0].attributes) is capture_at_start
+    assert (trace_types.ATTR_GEN_AI_OUTPUT_MESSAGES in spans[0].attributes) is (
+        capture_at_start and capture_during_run
+    )
 
 
 async def test_llm_stream_skips_content_builders_when_capture_is_disabled(

--- a/tests/test_llm_telemetry.py
+++ b/tests/test_llm_telemetry.py
@@ -52,11 +52,15 @@ class _UsageLLM(llm.LLM):
 
 
 class _UsageLLMStream(llm.LLMStream):
+    _response_content: str = "hello"
+
     async def _run(self) -> None:
         self._event_ch.send_nowait(
             llm.ChatChunk(
                 id="request-id",
-                delta=llm.ChoiceDelta(role="assistant", content="hello"),
+                delta=llm.ChoiceDelta.model_construct(
+                    role="assistant", content=self._response_content
+                ),
             )
         )
         self._event_ch.send_nowait(
@@ -70,6 +74,14 @@ class _UsageLLMStream(llm.LLMStream):
                 ),
             )
         )
+
+
+class _ResponseContentProbe(str):
+    was_accumulated: bool = False
+
+    def __radd__(self, other: object) -> str:
+        self.was_accumulated = True
+        return f"{other}{self}"
 
 
 def _custom_llm_node(
@@ -156,10 +168,14 @@ async def test_llm_stream_skips_content_builders_when_capture_is_disabled(
     _forbid_content_builders(monkeypatch)
     gen_ai.set_capture_content(False)
     try:
+        content = _ResponseContentProbe("hello")
+        monkeypatch.setattr(_UsageLLMStream, "_response_content", content)
         response = await _UsageLLM().chat(chat_ctx=llm.ChatContext.empty()).collect()
     finally:
         gen_ai.set_capture_content(True)
 
+    assert not content.was_accumulated
+    assert response.text == "hello"
     assert response.usage is not None
     assert response.usage.prompt_tokens == 100
     spans = [span for span in span_exporter.get_finished_spans() if span.name == "llm_request"]
@@ -176,8 +192,12 @@ async def test_llm_stream_skips_content_builders_for_nonrecording_span(
 ) -> None:
     _forbid_content_builders(monkeypatch)
 
+    content = _ResponseContentProbe("hello")
+    monkeypatch.setattr(_UsageLLMStream, "_response_content", content)
     response = await _UsageLLM().chat(chat_ctx=llm.ChatContext.empty()).collect()
 
+    assert not content.was_accumulated
+    assert response.text == "hello"
     assert response.usage is not None
     assert response.usage.prompt_tokens == 100
 

--- a/tests/test_llm_telemetry.py
+++ b/tests/test_llm_telemetry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Iterator
 from typing import Any
 
@@ -7,15 +8,18 @@ import pytest
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.sampling import ALWAYS_OFF
 
 from livekit.agents import llm
-from livekit.agents.telemetry import set_tracer_provider, tracer
+from livekit.agents.telemetry import gen_ai, set_tracer_provider, trace_types, tracer
 from livekit.agents.types import (
     DEFAULT_API_CONNECT_OPTIONS,
     NOT_GIVEN,
     APIConnectOptions,
     NotGivenOr,
 )
+from livekit.agents.voice import generation
+from livekit.agents.voice.io import ModelSettings
 
 pytestmark = [pytest.mark.unit, pytest.mark.no_concurrent]
 
@@ -68,6 +72,14 @@ class _UsageLLMStream(llm.LLMStream):
         )
 
 
+def _custom_llm_node(
+    chat_ctx: llm.ChatContext,
+    tools: list[llm.Tool],
+    model_settings: ModelSettings,
+) -> str:
+    return "hello"
+
+
 @pytest.fixture
 def span_exporter() -> Iterator[InMemorySpanExporter]:
     original_provider = tracer._tracer_provider
@@ -82,12 +94,39 @@ def span_exporter() -> Iterator[InMemorySpanExporter]:
         provider.shutdown()
 
 
+@pytest.fixture
+def nonrecording_tracer_provider() -> Iterator[None]:
+    original_provider = tracer._tracer_provider
+    provider = TracerProvider(sampler=ALWAYS_OFF)
+    set_tracer_provider(provider)
+    try:
+        yield
+    finally:
+        set_tracer_provider(original_provider)
+        provider.shutdown()
+
+
+def _forbid_content_builders(monkeypatch: pytest.MonkeyPatch) -> None:
+    def unexpected_builder(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("content payload builder was called")
+
+    for name in (
+        "to_system_instructions",
+        "to_input_messages",
+        "to_output_messages",
+        "to_tool_definitions",
+    ):
+        monkeypatch.setattr(gen_ai, name, unexpected_builder)
+
+
 async def test_llm_span_reports_cached_input_tokens(
     span_exporter: InMemorySpanExporter,
 ) -> None:
     model = _UsageLLM()
+    chat_ctx = llm.ChatContext.empty()
+    chat_ctx.add_message(role="user", content="hello")
 
-    response = await model.chat(chat_ctx=llm.ChatContext()).collect()
+    response = await model.chat(chat_ctx=chat_ctx).collect()
 
     assert response.usage is not None
     assert response.usage.prompt_cached_tokens == 80
@@ -98,3 +137,93 @@ async def test_llm_span_reports_cached_input_tokens(
     # both spellings: the registry one for the convention, and the unofficial one Langfuse
     # and Datadog key on. The realtime path emits both, so the two paths now agree.
     assert spans[0].attributes["gen_ai.usage.input_cached_tokens"] == 80
+    assert json.loads(spans[0].attributes["gen_ai.input.messages"]) == [
+        {"role": "user", "parts": [{"type": "text", "content": "hello"}]}
+    ]
+    assert json.loads(spans[0].attributes["gen_ai.output.messages"]) == [
+        {
+            "role": "assistant",
+            "parts": [{"type": "text", "content": "hello"}],
+            "finish_reason": "stop",
+        }
+    ]
+
+
+async def test_llm_stream_skips_content_builders_when_capture_is_disabled(
+    span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _forbid_content_builders(monkeypatch)
+    gen_ai.set_capture_content(False)
+    try:
+        response = await _UsageLLM().chat(chat_ctx=llm.ChatContext.empty()).collect()
+    finally:
+        gen_ai.set_capture_content(True)
+
+    assert response.usage is not None
+    assert response.usage.prompt_tokens == 100
+    spans = [span for span in span_exporter.get_finished_spans() if span.name == "llm_request"]
+    assert len(spans) == 1
+    assert spans[0].attributes[trace_types.ATTR_GEN_AI_REQUEST_MODEL] == "test-model"
+    assert spans[0].attributes[trace_types.ATTR_GEN_AI_USAGE_INPUT_TOKENS] == 100
+    assert trace_types.ATTR_GEN_AI_INPUT_MESSAGES not in spans[0].attributes
+    assert trace_types.ATTR_GEN_AI_OUTPUT_MESSAGES not in spans[0].attributes
+
+
+async def test_llm_stream_skips_content_builders_for_nonrecording_span(
+    nonrecording_tracer_provider: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _forbid_content_builders(monkeypatch)
+
+    response = await _UsageLLM().chat(chat_ctx=llm.ChatContext.empty()).collect()
+
+    assert response.usage is not None
+    assert response.usage.prompt_tokens == 100
+
+
+async def test_llm_node_skips_payloads_for_nonrecording_span(
+    nonrecording_tracer_provider: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _forbid_content_builders(monkeypatch)
+
+    def unexpected_to_dict(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("chat context was serialized")
+
+    monkeypatch.setattr(llm.ChatContext, "to_dict", unexpected_to_dict)
+
+    task, data = generation.perform_llm_inference(
+        node=_custom_llm_node,
+        chat_ctx=llm.ChatContext.empty(),
+        tool_ctx=llm.ToolContext([]),
+        model_settings=ModelSettings(),
+    )
+
+    assert await task is True
+    assert data.generated_text == "hello"
+
+
+async def test_llm_node_preserves_noncontent_attributes_when_capture_is_disabled(
+    span_exporter: InMemorySpanExporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _forbid_content_builders(monkeypatch)
+    gen_ai.set_capture_content(False)
+    try:
+        task, _ = generation.perform_llm_inference(
+            node=_custom_llm_node,
+            chat_ctx=llm.ChatContext.empty(),
+            tool_ctx=llm.ToolContext([]),
+            model_settings=ModelSettings(),
+        )
+        assert await task is True
+    finally:
+        gen_ai.set_capture_content(True)
+
+    spans = [span for span in span_exporter.get_finished_spans() if span.name == "llm_node"]
+    assert len(spans) == 1
+    assert trace_types.ATTR_CHAT_CTX in spans[0].attributes
+    assert spans[0].attributes[trace_types.ATTR_GEN_AI_OPERATION_NAME] == "chat"
+    assert trace_types.ATTR_GEN_AI_INPUT_MESSAGES not in spans[0].attributes
+    assert trace_types.ATTR_GEN_AI_OUTPUT_MESSAGES not in spans[0].attributes


### PR DESCRIPTION
Tracing builds large chat and GenAI payloads before OpenTelemetry decides to discard them. Check span recording and content capture first, while retaining legacy chat context, recorded content, and non-content metrics.

A 1,000-message sampled-out `llm_node` drops from 4.1 ms to 84 µs locally.

Addresses AGT-3452

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-5.6

> can you investigate linear AGT 3452?
>
> sounds good, let's fix that with a draft PR first.

</details>
