### PR TITLE
fix(deepgram): redact the API key from rejected TTS handshakes

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts.py
@@ -126,13 +126,26 @@ class TTS(tts.TTS):
         }
         if self._opts.bit_rate is not None:
             config["bit_rate"] = self._opts.bit_rate
-        ws = await asyncio.wait_for(
-            session.ws_connect(
-                _to_deepgram_url(config, self._opts.base_url, websocket=True),
-                headers={"Authorization": f"Token {self._opts.api_key}"},
-            ),
-            timeout,
-        )
+        try:
+            ws = await asyncio.wait_for(
+                session.ws_connect(
+                    _to_deepgram_url(config, self._opts.base_url, websocket=True),
+                    headers={"Authorization": f"Token {self._opts.api_key}"},
+                ),
+                timeout,
+            )
+        except asyncio.TimeoutError:
+            raise APIConnectionError("failed to connect to deepgram") from None
+        except aiohttp.ClientResponseError as e:
+            # RequestInfo carries the request headers, so chaining this error or
+            # formatting it puts the API key in the exception repr (#6739).
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except Exception as e:
+            raise APIConnectionError(
+                f"failed to connect to deepgram ({type(e).__name__})"
+            ) from None
         ws_headers = {
             k: v for k, v in ws._response.headers.items() if k.startswith("dg-") or k == "Date"
         }

--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts_v2.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/tts_v2.py
@@ -158,13 +158,26 @@ class TTSv2(tts.TTS):
             "sample_rate": self._opts.sample_rate,
             "mip_opt_out": self._opts.mip_opt_out,
         }
-        ws = await asyncio.wait_for(
-            session.ws_connect(
-                _to_deepgram_url(config, self._opts.base_url, websocket=True),
-                headers={"Authorization": f"Token {self._opts.api_key}"},
-            ),
-            timeout,
-        )
+        try:
+            ws = await asyncio.wait_for(
+                session.ws_connect(
+                    _to_deepgram_url(config, self._opts.base_url, websocket=True),
+                    headers={"Authorization": f"Token {self._opts.api_key}"},
+                ),
+                timeout,
+            )
+        except asyncio.TimeoutError:
+            raise APIConnectionError("failed to connect to deepgram") from None
+        except aiohttp.ClientResponseError as e:
+            # RequestInfo carries the request headers, so chaining this error or
+            # formatting it puts the API key in the exception repr (#6739).
+            raise APIStatusError(
+                message=e.message, status_code=e.status, request_id=None, body=None
+            ) from None
+        except Exception as e:
+            raise APIConnectionError(
+                f"failed to connect to deepgram ({type(e).__name__})"
+            ) from None
         ws_headers = {
             k: v for k, v in ws._response.headers.items() if k.startswith("dg-") or k == "Date"
         }

--- a/tests/test_ws_handshake_credential_redaction.py
+++ b/tests/test_ws_handshake_credential_redaction.py
@@ -78,3 +78,39 @@ async def test_xai_tts_redacts_api_key_from_handshake_error():
         await tts._connect_ws(timeout=5.0, opts=tts._opts)
 
     _assert_redacted(exc_info.value)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_deepgram_tts_redacts_api_key_from_handshake_error():
+    from livekit.plugins.deepgram import TTS
+
+    tts = TTS(
+        api_key=SECRET_API_KEY,
+        http_session=_session_raising(
+            _handshake_error("api.deepgram.com", "Authorization", f"Token {SECRET_API_KEY}")
+        ),
+    )
+
+    with pytest.raises(APIStatusError) as exc_info:
+        await tts._connect_ws(timeout=5.0)
+
+    _assert_redacted(exc_info.value)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_deepgram_flux_tts_redacts_api_key_from_handshake_error():
+    from livekit.plugins.deepgram import TTSv2
+
+    tts = TTSv2(
+        api_key=SECRET_API_KEY,
+        http_session=_session_raising(
+            _handshake_error("api.deepgram.com", "Authorization", f"Token {SECRET_API_KEY}")
+        ),
+    )
+
+    with pytest.raises(APIStatusError) as exc_info:
+        await tts._connect_ws(timeout=5.0)
+
+    _assert_redacted(exc_info.value)


### PR DESCRIPTION
## Problem

#7032 converted a rejected websocket upgrade into `APIStatusError` in six files, because
`WSServerHandshakeError` carries `RequestInfo` and its headers hold the credential. It covered both
directions where a plugin had both, `xai/stt.py` and `xai/tts.py`, but in this plugin only the two
STT paths. `TTS._connect_ws` and `TTSv2._connect_ws` await `session.ws_connect(...)` with no
handler at all, and `ConnectionPool.connection()` does not wrap connect errors, so a 401 leaves the
plugin as a raw `aiohttp.WSServerHandshakeError`.

The credential is in that exception's **repr**, though not its str: `__str__` is status, message and
url, while `__repr__` includes `request_info`, whose headers carry `Authorization: Token <key>`.
And `except APIStatusError` around a Deepgram TTS call does not catch a 401, unlike every other
error path here, including `ChunkedStream`'s own handler a few lines below.

## Changes

Both `_connect_ws` methods get the handler `stt.py` already uses: `APIConnectionError` on timeout,
`APIStatusError` built from `e.message` and `e.status` on `ClientResponseError`, and
`APIConnectionError` naming the type on anything else, each raised `from None`. No new imports.

`rime/tts.py` has the same shape and is left for its own PR.

## Testing

Two cases added to `tests/test_ws_handshake_credential_redaction.py`, which already guards this for
Deepgram STT and xAI, so they run in `unit-tests` with the rest of it. Each builds a synthetic 401
upgrade over a mock session and asserts an `APIStatusError` carrying status 401, with no key in its
str or repr and no `__cause__`. Restore either `_connect_ws` to its current form and its test sees
the raw `WSServerHandshakeError` instead.

`pytest --unit --audio_eot`: 2576 passed, 5 skipped, against 2574 on unmodified main.
`ruff check` and `ruff format --check` (994 files) clean. At `4d03f505c`.