### PR TITLE
feat(soniox): map TTS character timestamps to aligned transcripts

### DIFF
--- a/livekit-plugins/livekit-plugins-soniox/README.md
+++ b/livekit-plugins/livekit-plugins-soniox/README.md
@@ -54,6 +54,8 @@ session = AgentSession(
 
 The TTS supports real-time streaming from LLM - text chunks are tokenized and sent to Soniox as words are formed, enabling low-latency speech synthesis.
 
+Soniox also returns character-level audio timestamps, which the plugin forwards as an aligned transcript so an interrupted turn records the text that was actually spoken rather than a speaking-rate estimate. It is on by default; pass `return_timestamps=False` to turn it off.
+
 ## More information and reference
 
 Explore integration details and find comprehensive examples:

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -674,18 +674,15 @@ def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> N
     starts: list[float] | None = timestamps.get("character_start_times_seconds")
     ends: list[float] | None = timestamps.get("character_end_times_seconds")
     if not (chars and starts and ends and len(chars) == len(starts) == len(ends)):
-        # These characters cannot be trusted, so they are skipped - but the gap
-        # falls in the middle of a word. Publish what is already whole, drop the
-        # prefix left in the buffer, and wait for a word boundary: joining the
-        # two sides would invent a word ("bro" + "ps" reads as "brops"), and
-        # keeping either side alone would publish a fragment as a word of its
-        # own. The word the gap swallowed is lost either way.
+        # Only the timings are unusable here - these characters were still
+        # spoken, so none of the text is dropped. They are kept with the word
+        # they interrupted and handed over untimed once a boundary closes the
+        # region: joining the two sides of the gap would invent a word ("bro" +
+        # "ps" reads as "brops") and publishing either side alone would make a
+        # word of a fragment, but carrying the whole stretch untimed does
+        # neither. The synchronizer estimates across untimed text, so this
+        # stretch loses its precision and the reply keeps its words.
         logger.warning("Soniox TTS sent malformed timestamps for a frame, timing its text by rate")
-        # Only the timings are unusable - the characters were still spoken. Keep
-        # them, along with the word they were breaking, and hand them over
-        # untimed once the region closes: the synchronizer estimates across
-        # untimed text, so the reply stays whole and only this stretch of it
-        # loses precision.
         _emit_timed_words(stream)
         stream.pending_untimed += stream.char_text + "".join(chars or [])
         stream.char_text = ""
@@ -731,7 +728,13 @@ def _publish_untimed(stream: _StreamData) -> None:
         return
 
     stream.produced_output = True
-    stream.emitter.push_timed_transcript(TimedString(text=stream.pending_untimed))
+    untimed = TimedString(text=stream.pending_untimed)
+    if not stream.emitted_any:
+        # this is the stream's first text, so it carries the separator that
+        # opened it - leaving it for a later word would move the whitespace
+        stream.emitted_any = True
+        untimed = _with_leading_separator(untimed, stream.sent_text)
+    stream.emitter.push_timed_transcript(untimed)
     stream.pending_untimed = ""
 
 

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -313,6 +313,7 @@ class SynthesizeStream(tts.SynthesizeStream):
         self._stream_id: str = ""
         self._connection: _Connection | None = None
         self._cancelled = asyncio.Event()
+        self._timeline = _Timeline()
 
     async def aclose(self) -> None:
         """Close the stream, signalling cancel to the server if still active.
@@ -345,6 +346,9 @@ class SynthesizeStream(tts.SynthesizeStream):
         sentences are ever sent, so every rotation lands on a natural boundary.
         """
         request_id = utils.shortuuid()
+        # a retry restarts _run against a brand new emitter, so the timeline
+        # starts over with it
+        self._timeline = _Timeline()
 
         output_emitter.initialize(
             request_id=request_id,
@@ -455,9 +459,17 @@ class SynthesizeStream(tts.SynthesizeStream):
         self._stream_id = stream_id = utils.shortuuid()
 
         waiter: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        # baseline is the "no audio emitted yet" watermark the retry check
+        # compares against; the timeline may already run past it, so the
+        # timestamp offset takes whichever is further along.
         baseline = output_emitter.pushed_duration()
         connection.register_stream(
-            stream_id, output_emitter, waiter, opts=self._opts, time_offset=baseline
+            stream_id,
+            output_emitter,
+            waiter,
+            opts=self._opts,
+            time_offset=max(baseline, self._timeline.end),
+            timeline=self._timeline,
         )
         return _ActiveStream(
             connection=connection,
@@ -578,6 +590,13 @@ _OutboundMsg = _StartConfig | _SendText | _CancelStream
 
 
 @dataclass
+class _Timeline:
+    """How far this segment's aligned transcript has reached, across streams."""
+
+    end: float = 0.0
+
+
+@dataclass
 class _StreamData:
     emitter: tts.AudioEmitter
     waiter: asyncio.Future[None]
@@ -595,6 +614,12 @@ class _StreamData:
     char_text: str = ""
     char_starts: list[float] = field(default_factory=list)
     char_ends: list[float] = field(default_factory=list)
+    timeline: _Timeline = field(default_factory=_Timeline)
+    # Text handed to this stream. Soniox times its own preprocessed text, which
+    # has the leading whitespace normalised away; this is where the separator
+    # between two rotated streams is recovered from.
+    sent_text: str = ""
+    emitted_any: bool = False
 
 
 def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> None:
@@ -612,6 +637,10 @@ def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> N
         stream.char_starts += [start + offset] * len(char)
         stream.char_ends += [start + offset] * (len(char) - 1) + [end + offset]
     stream.char_text += "".join(chars)
+    # Where the next stream has to start from: pushed_duration() alone would
+    # place it too early, since it counts neither audio still queued in the
+    # emitter nor the tail frame the emitter holds back.
+    stream.timeline.end = max(stream.timeline.end, ends[-1] + offset)
 
     _emit_timed_words(stream)
 
@@ -622,11 +651,35 @@ def _emit_timed_words(stream: _StreamData, *, flush: bool = False) -> None:
         stream.char_text, stream.char_starts, stream.char_ends, flush=flush
     )
     if timed_words:
+        if not stream.emitted_any:
+            stream.emitted_any = True
+            timed_words[0] = _with_leading_separator(timed_words[0], stream.sent_text)
         stream.emitter.push_timed_transcript(timed_words)
 
     keep = len(stream.char_text)
     stream.char_starts = stream.char_starts[len(stream.char_starts) - keep :]
     stream.char_ends = stream.char_ends[len(stream.char_ends) - keep :]
+
+
+def _with_leading_separator(word: TimedString, sent_text: str) -> TimedString:
+    """Restore the whitespace that opened *sent_text* but not the aligned transcript.
+
+    A reply is spread over several streams, and the sentence tokenizer hands
+    each one its leading separator (" Then, after a long pause..."), which
+    Soniox normalises away before timing the text. Without it the last word of
+    one stream runs into the first word of the next - "one sentence.Then". The
+    separator comes from the text this stream was actually given, so scripts
+    that do not space their sentences are left alone.
+    """
+    separator = sent_text[: len(sent_text) - len(sent_text.lstrip())]
+    if not separator or str(word).startswith(separator):
+        return word
+
+    return TimedString(
+        text=separator + str(word),
+        start_time=word.start_time,
+        end_time=word.end_time,
+    )
 
 
 def _to_timed_words(
@@ -641,25 +694,36 @@ def _to_timed_words(
     ``start_times`` and ``end_times`` hold one entry per character of *text*.
     The trailing word is held back until *flush*, since the characters that
     finish it may still arrive on a later frame.
+
+    The returned strings tile *text* without gaps - each one runs to the start
+    of the next word, so separators ride along with the word before them. The
+    SDK concatenates these chunks back into the reply that reaches chat history
+    and the transcript sinks, so dropping the separators would run the words
+    together. Timings still describe the word itself, not the separator.
     """
     if not text:
         return [], ""
 
     words = split_words(text, ignore_punctuation=False, split_character=True)
-    if not flush:
-        words = words[:-1]
-    if not words:
+    emitted = len(words) if flush else len(words) - 1
+    if emitted <= 0:
         return [], text
 
-    timed_words = [
-        TimedString(
-            text=text[start:end],
-            start_time=start_times[start],
-            end_time=end_times[end - 1],
+    timed_words: list[TimedString] = []
+    cursor = 0
+    for index in range(emitted):
+        _, start, end = words[index]
+        stop = words[index + 1][1] if index + 1 < len(words) else len(text)
+        timed_words.append(
+            TimedString(
+                text=text[cursor:stop],
+                start_time=start_times[start],
+                end_time=end_times[end - 1],
+            )
         )
-        for _, start, end in words
-    ]
-    return timed_words, "" if flush else text[words[-1][2] :]
+        cursor = stop
+
+    return timed_words, text[cursor:]
 
 
 class _Connection:
@@ -741,6 +805,7 @@ class _Connection:
         *,
         opts: _TTSOptions,
         time_offset: float = 0.0,
+        timeline: _Timeline | None = None,
     ) -> None:
         """Register a new stream and queue its config message."""
         if self._closed:
@@ -753,7 +818,11 @@ class _Connection:
 
         # Server starts a per-stream timeout on _StartConfig receipt; we queue it lazily in send_text.
         self._streams[stream_id] = _StreamData(
-            emitter=emitter, waiter=waiter, opts=opts, time_offset=time_offset
+            emitter=emitter,
+            waiter=waiter,
+            opts=opts,
+            time_offset=time_offset,
+            timeline=timeline if timeline is not None else _Timeline(),
         )
 
     def unregister_stream(self, stream_id: str) -> None:
@@ -779,6 +848,7 @@ class _Connection:
                 self._streams.pop(stream_id, None)
                 return
 
+        stream.sent_text += text
         if not stream.config_sent:
             stream.config_sent = True
             self._input_queue.send_nowait(_StartConfig(stream_id=stream_id, opts=stream.opts))

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -648,9 +648,11 @@ class _StreamData:
     # duration it is exact, counting output the emitter has accepted but not yet
     # turned into frames.
     produced_output: bool = False
-    # Set when a frame had to be skipped: characters are dropped until a word
-    # boundary, so the tail of the word the gap broke is never published alone.
+    # Set when a frame had to be skipped. Its characters are still spoken, so
+    # they are held here with the broken word either side of them and published
+    # without timings once a word boundary makes the region safe to close.
     resync_pending: bool = False
+    pending_untimed: str = ""
 
 
 def _is_word_boundary(char: str) -> bool:
@@ -678,12 +680,14 @@ def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> N
         # two sides would invent a word ("bro" + "ps" reads as "brops"), and
         # keeping either side alone would publish a fragment as a word of its
         # own. The word the gap swallowed is lost either way.
-        logger.warning("Soniox TTS sent malformed timestamps, skipping the frame's characters")
-        # The word held back is complete after all when nothing could have
-        # continued it - one CJK character is already a word - so publish it
-        # rather than lose it; otherwise it is the broken half and is dropped.
-        held = stream.char_text
-        _emit_timed_words(stream, flush=bool(held) and _is_word_boundary(held[-1]))
+        logger.warning("Soniox TTS sent malformed timestamps for a frame, timing its text by rate")
+        # Only the timings are unusable - the characters were still spoken. Keep
+        # them, along with the word they were breaking, and hand them over
+        # untimed once the region closes: the synchronizer estimates across
+        # untimed text, so the reply stays whole and only this stretch of it
+        # loses precision.
+        _emit_timed_words(stream)
+        stream.pending_untimed += stream.char_text + "".join(chars or [])
         stream.char_text = ""
         stream.char_starts.clear()
         stream.char_ends.clear()
@@ -693,10 +697,13 @@ def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> N
     if stream.resync_pending:
         boundary = next((i for i, char in enumerate(chars) if _is_word_boundary(char)), None)
         if boundary is None:
-            return  # still inside the word the gap broke
-        # A separator is consumed, since the last published word already carries
-        # one; a character that is a word in itself is kept.
+            stream.pending_untimed += "".join(chars)  # still inside the broken word
+            return
+        # A separator closes the untimed region and goes with it; a character
+        # that is a word in itself starts the timed text again.
         resume = boundary + 1 if chars[boundary].isspace() else boundary
+        stream.pending_untimed += "".join(chars[:resume])
+        _publish_untimed(stream)
         chars, starts, ends = chars[resume:], starts[resume:], ends[resume:]
         stream.resync_pending = False
         if not chars:
@@ -713,8 +720,26 @@ def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> N
     _emit_timed_words(stream)
 
 
+def _publish_untimed(stream: _StreamData) -> None:
+    """Hand over text whose timings were lost, so the reply itself stays whole.
+
+    ``TimedString`` carries no timings here, which the synchronizer reads as
+    "estimate across this" - the behaviour aligned transcripts replace, applied
+    to the stretch that has no timings rather than to the whole turn.
+    """
+    if not stream.pending_untimed:
+        return
+
+    stream.produced_output = True
+    stream.emitter.push_timed_transcript(TimedString(text=stream.pending_untimed))
+    stream.pending_untimed = ""
+
+
 def _emit_timed_words(stream: _StreamData, *, flush: bool = False) -> None:
     """Push every word the buffered characters now complete, keeping the rest."""
+    if flush:
+        _publish_untimed(stream)
+
     timed_words, stream.char_text = _to_timed_words(
         stream.char_text, stream.char_starts, stream.char_ends, flush=flush
     )

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -653,6 +653,19 @@ class _StreamData:
     resync_pending: bool = False
 
 
+def _is_word_boundary(char: str) -> bool:
+    """Whether *char* starts a word rather than continuing the one before it.
+
+    Whitespace ends a word, and scripts written without spaces - CJK, Thai -
+    give every character a word of its own. Asking ``split_words`` keeps that
+    judgement identical to the one ``_to_timed_words`` makes, instead of
+    assuming every reply is space-delimited.
+    """
+    if char.isspace():
+        return True
+    return len(split_words("a" + char, ignore_punctuation=False, split_character=True)) > 1
+
+
 def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> None:
     """Fold one frame's character timings into the stream's aligned transcript."""
     chars: list[str] | None = timestamps.get("characters")
@@ -666,7 +679,11 @@ def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> N
         # keeping either side alone would publish a fragment as a word of its
         # own. The word the gap swallowed is lost either way.
         logger.warning("Soniox TTS sent malformed timestamps, skipping the frame's characters")
-        _emit_timed_words(stream)
+        # The word held back is complete after all when nothing could have
+        # continued it - one CJK character is already a word - so publish it
+        # rather than lose it; otherwise it is the broken half and is dropped.
+        held = stream.char_text
+        _emit_timed_words(stream, flush=bool(held) and _is_word_boundary(held[-1]))
         stream.char_text = ""
         stream.char_starts.clear()
         stream.char_ends.clear()
@@ -674,11 +691,13 @@ def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> N
         return
 
     if stream.resync_pending:
-        boundary = next((i for i, char in enumerate(chars) if char.isspace()), None)
+        boundary = next((i for i, char in enumerate(chars) if _is_word_boundary(char)), None)
         if boundary is None:
             return  # still inside the word the gap broke
-        # drop the separator too: the last published word already carries one
-        chars, starts, ends = chars[boundary + 1 :], starts[boundary + 1 :], ends[boundary + 1 :]
+        # A separator is consumed, since the last published word already carries
+        # one; a character that is a word in itself is kept.
+        resume = boundary + 1 if chars[boundary].isspace() else boundary
+        chars, starts, ends = chars[resume:], starts[resume:], ends[resume:]
         stream.resync_pending = False
         if not chars:
             return

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -656,6 +656,17 @@ def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> N
     starts: list[float] | None = timestamps.get("character_start_times_seconds")
     ends: list[float] | None = timestamps.get("character_end_times_seconds")
     if not (chars and starts and ends and len(chars) == len(starts) == len(ends)):
+        # These characters cannot be trusted, so they are skipped - but the
+        # buffer holds a word this frame was going to finish, and letting the
+        # next frame land on it would join the two sides of the gap into a word
+        # nobody spoke ("bro" + "ps" reads as "brops") and publish it with
+        # plausible timings. Publish what is already whole and drop the rest so
+        # the gap stays a boundary.
+        logger.warning("Soniox TTS sent malformed timestamps, skipping the frame's characters")
+        _emit_timed_words(stream)
+        stream.char_text = ""
+        stream.char_starts.clear()
+        stream.char_ends.clear()
         return
 
     offset = stream.time_offset

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -717,30 +717,28 @@ def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> N
     _emit_timed_words(stream)
 
 
-def _publish_untimed(stream: _StreamData, *, final: bool = False) -> None:
+def _publish_untimed(stream: _StreamData) -> None:
     """Hand over text whose timings were lost, so the reply itself stays whole.
 
-    The characters have no timings of their own, but the region does: it opens
-    where the last published word ended. The synchronizer spreads text across
-    such an interval at an estimated rate - the behaviour aligned transcripts
-    replace, applied to the stretch that lost its timings rather than to the
-    whole turn.
+    The characters have no timings of their own, but the region's start is
+    known: it opens where the last published word ended. That anchors the text
+    before it, and the synchronizer spreads this text at an estimated rate up
+    to whatever timed word comes next.
 
-    It only spreads text it can bound, though, and text left unbounded is never
-    reached: ``accumulate_to`` stops where the rate curve stops, so captions
-    would halt there. Nothing timed follows a *final* region, so that one is
-    closed off with the audio emitted by the time the stream ends.
+    Nothing is claimed about where the region ends, because nothing here knows.
+    The synchronizer stops trusting annotations once playback passes the last
+    one and estimates from there, then releases whatever is left when playback
+    completes - so an unbounded tail still reaches the viewer. Closing it on a
+    guess would be worse than leaving it open: the guess would have to come
+    from the emitter's duration, which lags the audio it has been handed, and
+    the tail would be spread over an interval shorter than the speech it
+    describes - captions running ahead of the voice.
     """
     if not stream.pending_untimed:
         return
 
     stream.produced_output = True
-    start = stream.timeline.end
-    untimed = TimedString(
-        text=stream.pending_untimed,
-        start_time=start,
-        end_time=max(stream.emitter.pushed_duration(), start) if final else NOT_GIVEN,
-    )
+    untimed = TimedString(text=stream.pending_untimed, start_time=stream.timeline.end)
     if not stream.emitted_any:
         # this is the stream's first text, so it carries the separator that
         # opened it - leaving it for a later word would move the whitespace
@@ -753,7 +751,7 @@ def _publish_untimed(stream: _StreamData, *, final: bool = False) -> None:
 def _emit_timed_words(stream: _StreamData, *, flush: bool = False) -> None:
     """Push every word the buffered characters now complete, keeping the rest."""
     if flush:
-        _publish_untimed(stream, final=True)
+        _publish_untimed(stream)
 
     timed_words, stream.char_text = _to_timed_words(
         stream.char_text, stream.char_starts, stream.char_ends, flush=flush

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -665,16 +665,6 @@ def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> N
         stream.char_starts += [start + offset] * len(char)
         stream.char_ends += [start + offset] * (len(char) - 1) + [end + offset]
     stream.char_text += "".join(chars)
-    # Where the next stream has to start from: pushed_duration() alone would
-    # place it too early, since it counts neither audio still queued in the
-    # emitter nor the tail frame the emitter holds back.
-    #
-    # Moving the shared timeline is as unrepeatable as publishing a word, even
-    # when these characters finish none: a replacement would start from the
-    # advanced value, past audio this attempt never produced. Either way the
-    # stream is spent and must not be replayed.
-    stream.produced_output = True
-    stream.timeline.end = max(stream.timeline.end, ends[-1] + offset)
 
     _emit_timed_words(stream)
 
@@ -690,6 +680,17 @@ def _emit_timed_words(stream: _StreamData, *, flush: bool = False) -> None:
             timed_words[0] = _with_leading_separator(timed_words[0], stream.sent_text)
         stream.produced_output = True
         stream.emitter.push_timed_transcript(timed_words)
+
+        # Where a rotated stream has to start from: pushed_duration() alone
+        # would place it too early, counting neither audio still queued in the
+        # emitter nor the tail frame it holds back. Only published words move
+        # it, so a stream that goes on to be replayed leaves nothing behind for
+        # its replacement to inherit - characters still buffered as a
+        # possibly-incomplete word have not been spoken for yet. A stream that
+        # ends cleanly flushes them, which is when they count.
+        last_end = timed_words[-1].end_time
+        if is_given(last_end):
+            stream.timeline.end = max(stream.timeline.end, last_end)
 
     keep = len(stream.char_text)
     stream.char_starts = stream.char_starts[len(stream.char_starts) - keep :]

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -299,7 +299,6 @@ class _ActiveStream:
     waiter: asyncio.Future[None]
     data: _StreamData
     opened_at: float
-    baseline: float  # emitter duration at open; audio beyond it belongs to this stream
     attempt: int = 0
     texts: list[str] = field(default_factory=list)
 
@@ -460,17 +459,15 @@ class SynthesizeStream(tts.SynthesizeStream):
         self._stream_id = stream_id = utils.shortuuid()
 
         waiter: asyncio.Future[None] = asyncio.get_event_loop().create_future()
-        # baseline is the "no audio emitted yet" watermark the retry check
-        # compares against; the timeline may already run past it, so the
-        # timestamp offset takes whichever is further along.
-        baseline = output_emitter.pushed_duration()
+        # The emitter's duration lags the audio it has been handed, so the
+        # timeline - which counts every timestamp received - can already run
+        # past it; this stream starts from whichever is further along.
         data = connection.register_stream(
             stream_id,
             output_emitter,
             waiter,
             opts=self._opts,
-            time_offset=max(baseline, self._timeline.end),
-            audio_baseline=baseline,
+            time_offset=max(output_emitter.pushed_duration(), self._timeline.end),
             timeline=self._timeline,
         )
         return _ActiveStream(
@@ -479,7 +476,6 @@ class SynthesizeStream(tts.SynthesizeStream):
             waiter=waiter,
             data=data,
             opened_at=time.monotonic(),
-            baseline=baseline,
             attempt=attempt,
         )
 
@@ -501,14 +497,12 @@ class SynthesizeStream(tts.SynthesizeStream):
         spoken), or a fresh stream with the batch replayed when it failed
         transiently.
 
-        Whether the stream may be replayed and whether its held-back words must
-        be released are the same question, answered once, here. A stream that
-        will not be replayed has said its piece: the audio the emitter accepted
-        is what the user hears, and dropping the words for it would leave that
-        speech out of the aligned transcript and out of an interrupted turn's
-        history. A replayable one has published nothing, so the replacement
-        cannot repeat it. Reading the watermark a second time could let the two
-        answers disagree, which is how words go missing.
+        A stream is replayable only while it has handed the emitter nothing.
+        ``produced_output`` says so exactly, where the emitter's own duration
+        only says so eventually: audio sits in the emitter unaccounted until it
+        becomes frames, and a stream judged replayable on that lag would repeat
+        speech the user is about to hear, and repeat the words already published
+        for it. Neither can be taken back.
         """
         failure: APIError | None = None
         replayable = False
@@ -522,11 +516,15 @@ class SynthesizeStream(tts.SynthesizeStream):
             replayable = (
                 failure is not None
                 and failure.retryable
-                and output_emitter.pushed_duration() == active.baseline
+                and not active.data.produced_output
                 and active.attempt < self._conn_options.max_retry
                 and not self._cancelled.is_set()
             )
             if not replayable:
+                # No more characters are coming, so the word held back as
+                # possibly-incomplete is as complete as it will get, and it
+                # describes audio already handed to the emitter. A replayable
+                # stream has nothing buffered to flush.
                 _emit_timed_words(active.data, flush=True)
             # release before any replay so only one stream is ever registered
             active.connection.unregister_stream(active.stream_id)
@@ -637,11 +635,11 @@ class _StreamData:
     # between two rotated streams is recovered from.
     sent_text: str = ""
     emitted_any: bool = False
-    # Emitter duration when this stream opened, and words not yet handed over.
-    # Until the emitter counts audio past the watermark the stream may still be
-    # replayed on a fresh stream_id, and pushed words cannot be taken back.
-    audio_baseline: float = 0.0
-    pending_words: list[TimedString] = field(default_factory=list)
+    # Audio or timed words handed to the emitter. Neither can be taken back, so
+    # this is what makes a stream unreplayable - and unlike the emitter's own
+    # duration it is exact, counting output the emitter has accepted but not yet
+    # turned into frames.
+    produced_output: bool = False
 
 
 def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> None:
@@ -676,12 +674,8 @@ def _emit_timed_words(stream: _StreamData, *, flush: bool = False) -> None:
         if not stream.emitted_any:
             stream.emitted_any = True
             timed_words[0] = _with_leading_separator(timed_words[0], stream.sent_text)
-        stream.pending_words += timed_words
-
-    # flush means the stream reached audio_end, so it will not be replayed
-    if stream.pending_words and (flush or stream.emitter.pushed_duration() > stream.audio_baseline):
-        stream.emitter.push_timed_transcript(stream.pending_words)
-        stream.pending_words = []
+        stream.produced_output = True
+        stream.emitter.push_timed_transcript(timed_words)
 
     keep = len(stream.char_text)
     stream.char_starts = stream.char_starts[len(stream.char_starts) - keep :]
@@ -832,7 +826,6 @@ class _Connection:
         *,
         opts: _TTSOptions,
         time_offset: float = 0.0,
-        audio_baseline: float = 0.0,
         timeline: _Timeline | None = None,
     ) -> _StreamData:
         """Register a new stream and queue its config message."""
@@ -841,7 +834,6 @@ class _Connection:
             waiter=waiter,
             opts=opts,
             time_offset=time_offset,
-            audio_baseline=audio_baseline,
             timeline=timeline if timeline is not None else _Timeline(),
         )
         if self._closed:
@@ -1008,6 +1000,7 @@ class _Connection:
 
                 audio_b64 = resp.get("audio")
                 if audio_b64:
+                    stream.produced_output = True
                     stream.emitter.push(base64.b64decode(audio_b64))
 
                 if resp.get("audio_end"):

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -35,8 +35,10 @@ from livekit.agents import (
     tts,
     utils,
 )
+from livekit.agents.tokenize.basic import split_words
 from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, NOT_GIVEN, NotGivenOr
 from livekit.agents.utils import is_given
+from livekit.agents.voice.io import TimedString
 
 from .log import logger
 
@@ -93,6 +95,7 @@ class TTS(tts.TTS):
         http_session: aiohttp.ClientSession | None = None,
         tokenizer: NotGivenOr[tokenize.SentenceTokenizer] = NOT_GIVEN,
         stream_idle_timeout: float = DEFAULT_STREAM_IDLE_TIMEOUT,
+        return_timestamps: bool = True,
     ) -> None:
         """Initialize instance of Soniox Text-to-Speech API service.
 
@@ -115,9 +118,16 @@ class TTS(tts.TTS):
                 stream is finalized; the next sentence starts a fresh stream. Prevents slow
                 LLM gaps from hitting the server's per-stream timeout (observed ~8-18s).
                 Defaults to 5.0.
+            return_timestamps (bool): Ask Soniox for character-level audio timestamps and
+                forward them as an aligned transcript, so an interrupted turn records the
+                text that was actually spoken instead of a speaking-rate estimate.
+                Defaults to True.
         """
         super().__init__(
-            capabilities=tts.TTSCapabilities(streaming=True),
+            capabilities=tts.TTSCapabilities(
+                streaming=True,
+                aligned_transcript=return_timestamps,
+            ),
             sample_rate=sample_rate,
             num_channels=NUM_CHANNELS,
         )
@@ -143,6 +153,7 @@ class TTS(tts.TTS):
             websocket_url=websocket_url,
             api_key=api_key,
             stream_idle_timeout=stream_idle_timeout,
+            return_timestamps=return_timestamps,
         )
         self._session = http_session
         self._sentence_tokenizer = (
@@ -444,13 +455,16 @@ class SynthesizeStream(tts.SynthesizeStream):
         self._stream_id = stream_id = utils.shortuuid()
 
         waiter: asyncio.Future[None] = asyncio.get_event_loop().create_future()
-        connection.register_stream(stream_id, output_emitter, waiter, opts=self._opts)
+        baseline = output_emitter.pushed_duration()
+        connection.register_stream(
+            stream_id, output_emitter, waiter, opts=self._opts, time_offset=baseline
+        )
         return _ActiveStream(
             connection=connection,
             stream_id=stream_id,
             waiter=waiter,
             opened_at=time.monotonic(),
-            baseline=output_emitter.pushed_duration(),
+            baseline=baseline,
             attempt=attempt,
         )
 
@@ -539,6 +553,7 @@ class _TTSOptions:
     websocket_url: str
     api_key: str
     stream_idle_timeout: float
+    return_timestamps: bool
 
 
 @dataclass
@@ -572,6 +587,79 @@ class _StreamData:
     # This flag is how recv loop tells them apart.
     cancel_sent: bool = False
     config_sent: bool = False
+    # Soniox times characters from this stream's own first sample, but the
+    # emitter's timeline spans every stream of the segment, so each timestamp is
+    # shifted by the audio already emitted when this stream opened.
+    time_offset: float = 0.0
+    # Characters received but not yet emitted as a complete word.
+    char_text: str = ""
+    char_starts: list[float] = field(default_factory=list)
+    char_ends: list[float] = field(default_factory=list)
+
+
+def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> None:
+    """Fold one frame's character timings into the stream's aligned transcript."""
+    chars: list[str] | None = timestamps.get("characters")
+    starts: list[float] | None = timestamps.get("character_start_times_seconds")
+    ends: list[float] | None = timestamps.get("character_end_times_seconds")
+    if not (chars and starts and ends and len(chars) == len(starts) == len(ends)):
+        return
+
+    offset = stream.time_offset
+    for char, start, end in zip(chars, starts, ends, strict=False):
+        # Soniox documents one entry per codepoint; pad anyway so the timing
+        # arrays stay index-aligned with char_text whatever arrives.
+        stream.char_starts += [start + offset] * len(char)
+        stream.char_ends += [start + offset] * (len(char) - 1) + [end + offset]
+    stream.char_text += "".join(chars)
+
+    _emit_timed_words(stream)
+
+
+def _emit_timed_words(stream: _StreamData, *, flush: bool = False) -> None:
+    """Push every word the buffered characters now complete, keeping the rest."""
+    timed_words, stream.char_text = _to_timed_words(
+        stream.char_text, stream.char_starts, stream.char_ends, flush=flush
+    )
+    if timed_words:
+        stream.emitter.push_timed_transcript(timed_words)
+
+    keep = len(stream.char_text)
+    stream.char_starts = stream.char_starts[len(stream.char_starts) - keep :]
+    stream.char_ends = stream.char_ends[len(stream.char_ends) - keep :]
+
+
+def _to_timed_words(
+    text: str,
+    start_times: list[float],
+    end_times: list[float],
+    *,
+    flush: bool = False,
+) -> tuple[list[TimedString], str]:
+    """Split *text* into timed words and return them with the text left over.
+
+    ``start_times`` and ``end_times`` hold one entry per character of *text*.
+    The trailing word is held back until *flush*, since the characters that
+    finish it may still arrive on a later frame.
+    """
+    if not text:
+        return [], ""
+
+    words = split_words(text, ignore_punctuation=False, split_character=True)
+    if not flush:
+        words = words[:-1]
+    if not words:
+        return [], text
+
+    timed_words = [
+        TimedString(
+            text=text[start:end],
+            start_time=start_times[start],
+            end_time=end_times[end - 1],
+        )
+        for _, start, end in words
+    ]
+    return timed_words, "" if flush else text[words[-1][2] :]
 
 
 class _Connection:
@@ -652,6 +740,7 @@ class _Connection:
         waiter: asyncio.Future[None],
         *,
         opts: _TTSOptions,
+        time_offset: float = 0.0,
     ) -> None:
         """Register a new stream and queue its config message."""
         if self._closed:
@@ -663,7 +752,9 @@ class _Connection:
             raise ValueError(f"stream_id {stream_id} already registered")
 
         # Server starts a per-stream timeout on _StartConfig receipt; we queue it lazily in send_text.
-        self._streams[stream_id] = _StreamData(emitter=emitter, waiter=waiter, opts=opts)
+        self._streams[stream_id] = _StreamData(
+            emitter=emitter, waiter=waiter, opts=opts, time_offset=time_offset
+        )
 
     def unregister_stream(self, stream_id: str) -> None:
         self._streams.pop(stream_id, None)
@@ -727,6 +818,8 @@ class _Connection:
                     }
                     if msg.opts.bitrate is not None:
                         config["bitrate"] = msg.opts.bitrate
+                    if msg.opts.return_timestamps:
+                        config["return_timestamps"] = True
                     await self._ws.send_str(json.dumps(config))
                 elif isinstance(msg, _SendText):
                     payload: dict[str, Any] = {"stream_id": msg.stream_id}
@@ -807,12 +900,20 @@ class _Connection:
                         )
                     continue
 
+                # Before the audio of the same frame: the emitter attaches
+                # pending timed words to the next frame it emits.
+                if timestamps := resp.get("timestamps"):
+                    _accumulate_timestamps(stream, timestamps)
+
                 audio_b64 = resp.get("audio")
                 if audio_b64:
                     stream.emitter.push(base64.b64decode(audio_b64))
 
                 if resp.get("audio_end"):
                     stream.audio_ended = True
+                    # The stream always ends on a sentence boundary, so the
+                    # trailing word is complete and safe to emit.
+                    _emit_timed_words(stream, flush=True)
                     # end_segment() is called from SynthesizeStream._run's finally
                     # block (covers cancel/error paths too).
 

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -717,18 +717,30 @@ def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> N
     _emit_timed_words(stream)
 
 
-def _publish_untimed(stream: _StreamData) -> None:
+def _publish_untimed(stream: _StreamData, *, final: bool = False) -> None:
     """Hand over text whose timings were lost, so the reply itself stays whole.
 
-    ``TimedString`` carries no timings here, which the synchronizer reads as
-    "estimate across this" - the behaviour aligned transcripts replace, applied
-    to the stretch that has no timings rather than to the whole turn.
+    The characters have no timings of their own, but the region does: it opens
+    where the last published word ended. The synchronizer spreads text across
+    such an interval at an estimated rate - the behaviour aligned transcripts
+    replace, applied to the stretch that lost its timings rather than to the
+    whole turn.
+
+    It only spreads text it can bound, though, and text left unbounded is never
+    reached: ``accumulate_to`` stops where the rate curve stops, so captions
+    would halt there. Nothing timed follows a *final* region, so that one is
+    closed off with the audio emitted by the time the stream ends.
     """
     if not stream.pending_untimed:
         return
 
     stream.produced_output = True
-    untimed = TimedString(text=stream.pending_untimed)
+    start = stream.timeline.end
+    untimed = TimedString(
+        text=stream.pending_untimed,
+        start_time=start,
+        end_time=max(stream.emitter.pushed_duration(), start) if final else NOT_GIVEN,
+    )
     if not stream.emitted_any:
         # this is the stream's first text, so it carries the separator that
         # opened it - leaving it for a later word would move the whitespace
@@ -741,7 +753,7 @@ def _publish_untimed(stream: _StreamData) -> None:
 def _emit_timed_words(stream: _StreamData, *, flush: bool = False) -> None:
     """Push every word the buffered characters now complete, keeping the rest."""
     if flush:
-        _publish_untimed(stream)
+        _publish_untimed(stream, final=True)
 
     timed_words, stream.char_text = _to_timed_words(
         stream.char_text, stream.char_starts, stream.char_ends, flush=flush

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -469,6 +469,7 @@ class SynthesizeStream(tts.SynthesizeStream):
             waiter,
             opts=self._opts,
             time_offset=max(baseline, self._timeline.end),
+            audio_baseline=baseline,
             timeline=self._timeline,
         )
         return _ActiveStream(
@@ -525,6 +526,11 @@ class SynthesizeStream(tts.SynthesizeStream):
         The framework never retries once any audio reached the user, so a
         transient failure would otherwise mute the rest of the reply. Replaying
         is safe only while the failed stream itself produced no audio.
+
+        The same watermark keeps the aligned transcript safe to replay: timed
+        words are held back until it moves (see ``_emit_timed_words``), so a
+        stream that can still be replayed has pushed none, and the replacement
+        cannot repeat them.
         """
         can_retry = (
             exc.retryable
@@ -620,6 +626,11 @@ class _StreamData:
     # between two rotated streams is recovered from.
     sent_text: str = ""
     emitted_any: bool = False
+    # Emitter duration when this stream opened, and words not yet handed over.
+    # Until the emitter counts audio past the watermark the stream may still be
+    # replayed on a fresh stream_id, and pushed words cannot be taken back.
+    audio_baseline: float = 0.0
+    pending_words: list[TimedString] = field(default_factory=list)
 
 
 def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> None:
@@ -654,7 +665,12 @@ def _emit_timed_words(stream: _StreamData, *, flush: bool = False) -> None:
         if not stream.emitted_any:
             stream.emitted_any = True
             timed_words[0] = _with_leading_separator(timed_words[0], stream.sent_text)
-        stream.emitter.push_timed_transcript(timed_words)
+        stream.pending_words += timed_words
+
+    # flush means the stream reached audio_end, so it will not be replayed
+    if stream.pending_words and (flush or stream.emitter.pushed_duration() > stream.audio_baseline):
+        stream.emitter.push_timed_transcript(stream.pending_words)
+        stream.pending_words = []
 
     keep = len(stream.char_text)
     stream.char_starts = stream.char_starts[len(stream.char_starts) - keep :]
@@ -805,6 +821,7 @@ class _Connection:
         *,
         opts: _TTSOptions,
         time_offset: float = 0.0,
+        audio_baseline: float = 0.0,
         timeline: _Timeline | None = None,
     ) -> None:
         """Register a new stream and queue its config message."""
@@ -822,6 +839,7 @@ class _Connection:
             waiter=waiter,
             opts=opts,
             time_offset=time_offset,
+            audio_baseline=audio_baseline,
             timeline=timeline if timeline is not None else _Timeline(),
         )
 

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -297,6 +297,7 @@ class _ActiveStream:
     connection: _Connection
     stream_id: str
     waiter: asyncio.Future[None]
+    data: _StreamData
     opened_at: float
     baseline: float  # emitter duration at open; audio beyond it belongs to this stream
     attempt: int = 0
@@ -463,7 +464,7 @@ class SynthesizeStream(tts.SynthesizeStream):
         # compares against; the timeline may already run past it, so the
         # timestamp offset takes whichever is further along.
         baseline = output_emitter.pushed_duration()
-        connection.register_stream(
+        data = connection.register_stream(
             stream_id,
             output_emitter,
             waiter,
@@ -476,6 +477,7 @@ class SynthesizeStream(tts.SynthesizeStream):
             connection=connection,
             stream_id=stream_id,
             waiter=waiter,
+            data=data,
             opened_at=time.monotonic(),
             baseline=baseline,
             attempt=attempt,
@@ -498,8 +500,18 @@ class SynthesizeStream(tts.SynthesizeStream):
         Returns None when the stream ended cleanly (everything sent was
         spoken), or a fresh stream with the batch replayed when it failed
         transiently.
+
+        Whether the stream may be replayed and whether its held-back words must
+        be released are the same question, answered once, here. A stream that
+        will not be replayed has said its piece: the audio the emitter accepted
+        is what the user hears, and dropping the words for it would leave that
+        speech out of the aligned transcript and out of an interrupted turn's
+        history. A replayable one has published nothing, so the replacement
+        cannot repeat it. Reading the watermark a second time could let the two
+        answers disagree, which is how words go missing.
         """
         failure: APIError | None = None
+        replayable = False
         try:
             await active.waiter
         except APIError as e:
@@ -507,11 +519,22 @@ class SynthesizeStream(tts.SynthesizeStream):
         except Exception as e:
             raise APIConnectionError() from e
         finally:
+            replayable = (
+                failure is not None
+                and failure.retryable
+                and output_emitter.pushed_duration() == active.baseline
+                and active.attempt < self._conn_options.max_retry
+                and not self._cancelled.is_set()
+            )
+            if not replayable:
+                _emit_timed_words(active.data, flush=True)
             # release before any replay so only one stream is ever registered
             active.connection.unregister_stream(active.stream_id)
 
         if failure is None:
             return None
+        if not replayable:
+            raise failure
         return await self._retry_stream(active, output_emitter, request_id, failure)
 
     async def _retry_stream(
@@ -524,23 +547,11 @@ class SynthesizeStream(tts.SynthesizeStream):
         """Replay the failed stream's sentences on a fresh stream_id.
 
         The framework never retries once any audio reached the user, so a
-        transient failure would otherwise mute the rest of the reply. Replaying
-        is safe only while the failed stream itself produced no audio.
-
-        The same watermark keeps the aligned transcript safe to replay: timed
-        words are held back until it moves (see ``_emit_timed_words``), so a
-        stream that can still be replayed has pushed none, and the replacement
-        cannot repeat them.
+        transient failure would otherwise mute the rest of the reply. Only
+        ``_settle_stream`` judges whether replaying is safe; by the time this
+        runs the stream is known to have produced no audio, and to have
+        published no timed words that the replacement could repeat.
         """
-        can_retry = (
-            exc.retryable
-            and output_emitter.pushed_duration() == active.baseline
-            and active.attempt < self._conn_options.max_retry
-            and not self._cancelled.is_set()
-        )
-        if not can_retry:
-            raise exc
-
         retry_interval = self._conn_options._interval_for_retry(active.attempt)
         logger.warning(
             "Soniox TTS stream failed: %s, retrying in %ss",
@@ -823,18 +834,9 @@ class _Connection:
         time_offset: float = 0.0,
         audio_baseline: float = 0.0,
         timeline: _Timeline | None = None,
-    ) -> None:
+    ) -> _StreamData:
         """Register a new stream and queue its config message."""
-        if self._closed:
-            if not waiter.done():
-                waiter.set_exception(APIConnectionError("Soniox TTS connection is closed"))
-            return
-
-        if stream_id in self._streams:
-            raise ValueError(f"stream_id {stream_id} already registered")
-
-        # Server starts a per-stream timeout on _StartConfig receipt; we queue it lazily in send_text.
-        self._streams[stream_id] = _StreamData(
+        data = _StreamData(
             emitter=emitter,
             waiter=waiter,
             opts=opts,
@@ -842,6 +844,17 @@ class _Connection:
             audio_baseline=audio_baseline,
             timeline=timeline if timeline is not None else _Timeline(),
         )
+        if self._closed:
+            if not waiter.done():
+                waiter.set_exception(APIConnectionError("Soniox TTS connection is closed"))
+            return data
+
+        if stream_id in self._streams:
+            raise ValueError(f"stream_id {stream_id} already registered")
+
+        # Server starts a per-stream timeout on _StartConfig receipt; we queue it lazily in send_text.
+        self._streams[stream_id] = data
+        return data
 
     def unregister_stream(self, stream_id: str) -> None:
         self._streams.pop(stream_id, None)

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -648,6 +648,9 @@ class _StreamData:
     # duration it is exact, counting output the emitter has accepted but not yet
     # turned into frames.
     produced_output: bool = False
+    # Set when a frame had to be skipped: characters are dropped until a word
+    # boundary, so the tail of the word the gap broke is never published alone.
+    resync_pending: bool = False
 
 
 def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> None:
@@ -656,18 +659,29 @@ def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> N
     starts: list[float] | None = timestamps.get("character_start_times_seconds")
     ends: list[float] | None = timestamps.get("character_end_times_seconds")
     if not (chars and starts and ends and len(chars) == len(starts) == len(ends)):
-        # These characters cannot be trusted, so they are skipped - but the
-        # buffer holds a word this frame was going to finish, and letting the
-        # next frame land on it would join the two sides of the gap into a word
-        # nobody spoke ("bro" + "ps" reads as "brops") and publish it with
-        # plausible timings. Publish what is already whole and drop the rest so
-        # the gap stays a boundary.
+        # These characters cannot be trusted, so they are skipped - but the gap
+        # falls in the middle of a word. Publish what is already whole, drop the
+        # prefix left in the buffer, and wait for a word boundary: joining the
+        # two sides would invent a word ("bro" + "ps" reads as "brops"), and
+        # keeping either side alone would publish a fragment as a word of its
+        # own. The word the gap swallowed is lost either way.
         logger.warning("Soniox TTS sent malformed timestamps, skipping the frame's characters")
         _emit_timed_words(stream)
         stream.char_text = ""
         stream.char_starts.clear()
         stream.char_ends.clear()
+        stream.resync_pending = True
         return
+
+    if stream.resync_pending:
+        boundary = next((i for i, char in enumerate(chars) if char.isspace()), None)
+        if boundary is None:
+            return  # still inside the word the gap broke
+        # drop the separator too: the last published word already carries one
+        chars, starts, ends = chars[boundary + 1 :], starts[boundary + 1 :], ends[boundary + 1 :]
+        stream.resync_pending = False
+        if not chars:
+            return
 
     offset = stream.time_offset
     for char, start, end in zip(chars, starts, ends, strict=False):

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -668,6 +668,12 @@ def _accumulate_timestamps(stream: _StreamData, timestamps: dict[str, Any]) -> N
     # Where the next stream has to start from: pushed_duration() alone would
     # place it too early, since it counts neither audio still queued in the
     # emitter nor the tail frame the emitter holds back.
+    #
+    # Moving the shared timeline is as unrepeatable as publishing a word, even
+    # when these characters finish none: a replacement would start from the
+    # advanced value, past audio this attempt never produced. Either way the
+    # stream is spent and must not be replayed.
+    stream.produced_output = True
     stream.timeline.end = max(stream.timeline.end, ends[-1] + offset)
 
     _emit_timed_words(stream)

--- a/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
+++ b/livekit-plugins/livekit-plugins-soniox/livekit/plugins/soniox/tts.py
@@ -432,6 +432,14 @@ class SynthesizeStream(tts.SynthesizeStream):
             if next_task is not None:
                 await utils.aio.gracefully_cancel(next_task)
             if active is not None:
+                # An interruption cancels this task outright, so the stream
+                # never settles: flush here too, or the word held back as
+                # possibly-incomplete is lost even though it was spoken. The
+                # buffer is empty unless the stream produced output, and a
+                # settled stream has already been cleared, so this cannot
+                # publish anything twice. It has to precede end_segment(),
+                # which closes the frame these words ride on.
+                _emit_timed_words(active.data, flush=True)
                 active.connection.unregister_stream(active.stream_id)
             output_emitter.end_segment()
             await utils.aio.gracefully_cancel(input_t)

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -26,7 +26,7 @@ from typing import Any
 import aiohttp
 import pytest
 
-from livekit.agents import APIStatusError
+from livekit.agents import APIStatusError, utils
 from livekit.agents.tts import AudioEmitter
 from livekit.agents.types import USERDATA_TIMED_TRANSCRIPT
 from livekit.agents.utils import is_given
@@ -733,3 +733,39 @@ async def test_recv_loop_marks_audio_as_produced_output() -> None:
     assert emitter.audio == [_SILENCE_PCM]
     assert data.produced_output is True
     assert emitter.timed_words == []
+
+
+async def test_interrupting_a_reply_keeps_the_last_spoken_word() -> None:
+    """An interruption publishes the word the buffer was still holding.
+
+    ``_to_timed_words`` holds the trailing word back in case more characters
+    complete it. ``aclose`` cancels ``_run`` outright, so the stream never
+    settles - and without a flush on that path the last word the user heard
+    never reaches the transcript.
+    """
+    fake = _FakeConnection(timestamps=True)
+    tts = soniox.TTS(api_key="fake-key")
+
+    async def _fake_current_connection(*, timeout: float) -> tuple[Any, float, bool]:
+        return fake, 0.0, True
+
+    tts._current_connection = _fake_current_connection  # type: ignore[method-assign]
+
+    stream = tts.stream()
+    words: list[TimedString] = []
+
+    async def _drain() -> None:
+        async for ev in stream:
+            words.extend(ev.frame.userdata.get(USERDATA_TIMED_TRANSCRIPT, []))
+
+    drain_t = asyncio.create_task(_drain())
+    try:
+        stream.push_text(SENTENCES[0])  # no end_input: the reply is cut short
+        await asyncio.sleep(0.1)
+        await stream.aclose()
+        await drain_t
+    finally:
+        await utils.aio.gracefully_cancel(drain_t)
+        await tts.aclose()
+
+    assert "".join(str(w) for w in words).strip() == SENTENCES[0].strip()

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -114,7 +114,6 @@ class _FakeConnection:
         *,
         opts: Any,
         time_offset: float = 0.0,
-        audio_baseline: float = 0.0,
         timeline: soniox_tts._Timeline | None = None,
     ) -> soniox_tts._StreamData:
         self.registered_ids.append(stream_id)
@@ -124,7 +123,6 @@ class _FakeConnection:
             waiter=waiter,
             opts=opts,
             time_offset=time_offset,
-            audio_baseline=audio_baseline,
             timeline=timeline if timeline is not None else soniox_tts._Timeline(),
         )
         self._streams[stream_id] = _StreamSlot(data)
@@ -133,6 +131,11 @@ class _FakeConnection:
 
     def unregister_stream(self, stream_id: str) -> None:
         self._streams.pop(stream_id, None)
+
+    def _push_audio(self, slot: _StreamSlot, audio: bytes) -> None:
+        # mirrors _recv_loop: audio handed over is audio the user will hear
+        slot.data.produced_output = True
+        slot.emitter.push(audio)
 
     def send_text(self, stream_id: str, text: str, *, text_end: bool = False) -> None:
         self.send_calls.append((stream_id, text, text_end))
@@ -151,13 +154,14 @@ class _FakeConnection:
             self._fail_on_send = None
             if self._emit_before_failure:
                 # One 10ms chunk fits entirely in the tail frame the emitter
-                # holds back, so pushed_duration() still reads the baseline
-                # while the timestamps for it have already been mapped.
+                # holds back, so pushed_duration() still reads the value it had
+                # when the stream opened, even though the audio is spoken for.
                 slot.data.sent_text += text
-                soniox_tts._accumulate_timestamps(
-                    slot.data, _character_timestamps(text.lstrip()[:20], 0.0)
-                )
-                slot.emitter.push(_SILENCE_PCM)
+                if self._timestamps:
+                    soniox_tts._accumulate_timestamps(
+                        slot.data, _character_timestamps(text.lstrip()[:20], 0.0)
+                    )
+                self._push_audio(slot, _SILENCE_PCM)
             if not slot.waiter.done():
                 slot.waiter.set_exception(
                     APIStatusError("transient", status_code=429, retryable=True)
@@ -165,7 +169,7 @@ class _FakeConnection:
             return
         if not self._timestamps:
             slot.data.sent_text += text
-            slot.emitter.push(_SILENCE_PCM)
+            self._push_audio(slot, _SILENCE_PCM)
             return
 
         # the server strips the separator that opens a stream, keeps the rest
@@ -174,7 +178,7 @@ class _FakeConnection:
 
         soniox_tts._accumulate_timestamps(slot.data, _character_timestamps(spoken, slot.cursor))
         slot.cursor += len(spoken) * _SECONDS_PER_CHAR
-        slot.emitter.push(_SILENCE_PCM * len(spoken))
+        self._push_audio(slot, _SILENCE_PCM * len(spoken))
 
     def cancel_stream(self, stream_id: str) -> None:
         slot = self._streams.get(stream_id)
@@ -558,9 +562,9 @@ async def test_rotation_offset_outruns_a_lagging_pushed_duration() -> None:
         active = await stream._open_stream(emitter, "req-1")  # type: ignore[arg-type]
 
         assert fake.time_offsets[-1] == pytest.approx(2.134)
-        # the retry watermark still tracks the emitter, not the timeline: it
-        # answers "has any audio been emitted since this stream opened?"
-        assert active.baseline == pytest.approx(2.090)
+        # replay is gated on what the stream handed the emitter, not on either
+        # clock, so a fresh stream starts replayable
+        assert active.data.produced_output is False
     finally:
         await stream.aclose()
         await tts.aclose()
@@ -605,20 +609,24 @@ async def test_timed_words_rebuild_the_reply_on_one_stream() -> None:
     assert "".join(str(w) for w in words) == "".join(SENTENCES)
 
 
-async def test_a_replayed_stream_does_not_duplicate_the_transcript() -> None:
-    """A stream that already mapped timestamps is never replayed in place.
+async def test_a_stream_that_published_words_is_never_replayed() -> None:
+    """A stream that handed the emitter anything is not replayed in place.
 
     ``push_timed_transcript`` cannot be taken back, so replaying such a stream
     onto the same emitter would leave the failed attempt's words queued in front
-    of the replay's and say everything twice. The audio watermark alone does not
-    notice: one 10ms chunk sits in the tail frame the emitter holds back, so
-    ``pushed_duration()`` still equals the baseline.
+    of the replay's and say everything twice. The emitter's own duration does
+    not notice in time: one 10ms chunk sits entirely in the tail frame it holds
+    back, so ``pushed_duration()`` still reads the value it had at open.
     """
     fake = _FakeConnection(timestamps=True, fail_on_send=1, emit_before_failure=True)
     words: list[TimedString] = []
-    await _synthesize(fake, timed_words=words)
+    with pytest.raises(APIStatusError):
+        await _synthesize(fake, timed_words=words)
 
-    assert "".join(str(w) for w in words) == "".join(SENTENCES)
+    # exactly one stream: the failure was not replayed
+    assert len(fake.registered_ids) == 1
+    spoken = "".join(str(w) for w in words)
+    assert spoken and spoken in "".join(SENTENCES)
 
 
 async def test_words_for_unreplayable_audio_are_released() -> None:
@@ -636,3 +644,92 @@ async def test_words_for_unreplayable_audio_are_released() -> None:
 
     # the first sentence was spoken before the failure, so it must be reported
     assert "".join(str(w) for w in words).strip() == SENTENCES[0].strip()
+
+
+async def test_cancelling_a_stream_keeps_the_words_it_spoke() -> None:
+    """An interruption publishes what the stream said, including the last word.
+
+    Cancellation rules out a replay, so the characters buffered as a
+    possibly-incomplete word are as complete as they will get and describe
+    audio the emitter already has. Dropping them with the stream would leave
+    that speech out of the interrupted turn's history.
+    """
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    fake = _FakeConnection(timestamps=True)
+    stream = tts.stream()
+    waiter: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+
+    try:
+        data = fake.register_stream("s1", emitter, waiter, opts=tts._opts)  # type: ignore[arg-type]
+        spoken = SENTENCES[0].strip()
+        data.sent_text = SENTENCES[0]
+        soniox_tts._accumulate_timestamps(data, _character_timestamps(spoken, 0.0))
+        assert data.produced_output is True
+
+        active = soniox_tts._ActiveStream(
+            connection=fake,  # type: ignore[arg-type]
+            stream_id="s1",
+            waiter=waiter,
+            data=data,
+            opened_at=0.0,
+        )
+        stream._cancelled.set()
+        waiter.set_result(None)
+
+        assert await stream._settle_stream(active, emitter, "req-1") is None  # type: ignore[arg-type]
+        assert "".join(str(w) for w in emitter.timed_words) == spoken
+    finally:
+        await stream.aclose()
+        await tts.aclose()
+
+
+async def test_a_stream_that_pushed_audio_is_never_replayed() -> None:
+    """Audio alone makes a stream unreplayable, before any word is complete.
+
+    A frame can carry too few characters to finish a word, so nothing is
+    published yet - but the audio is already the emitter's, and replaying the
+    stream would speak it twice.
+    """
+    fake = _FakeConnection(fail_on_send=1, emit_before_failure=True)
+    with pytest.raises(APIStatusError):
+        await _synthesize(fake)
+
+    assert len(fake.registered_ids) == 1
+
+
+async def test_recv_loop_marks_audio_as_produced_output() -> None:
+    """Audio handed to the emitter marks the stream, before any word completes.
+
+    This is what makes a stream unreplayable, and it has to be recorded on
+    receipt: the emitter's own duration will not show the audio until it turns
+    into frames, by which time a replay decision may already have been made.
+    """
+    stream_id = "stream-1"
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    conn = soniox_tts._Connection(tts._opts, session=None)  # type: ignore[arg-type]
+    data = soniox_tts._StreamData(
+        emitter=emitter,  # type: ignore[arg-type]
+        waiter=asyncio.get_event_loop().create_future(),
+        opts=tts._opts,
+    )
+    conn._streams[stream_id] = data
+    conn._ws = _FakeWebSocket(  # type: ignore[assignment]
+        [
+            _text_message(
+                {
+                    "stream_id": stream_id,
+                    "audio": base64.b64encode(_SILENCE_PCM).decode("ascii"),
+                }
+            ),
+            _text_message({"stream_id": stream_id, "terminated": True}),
+        ]
+    )
+
+    await conn._recv_loop()
+    await conn.aclose()
+
+    assert emitter.audio == [_SILENCE_PCM]
+    assert data.produced_output is True
+    assert emitter.timed_words == []

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -1026,12 +1026,14 @@ async def test_untimed_text_first_keeps_the_separator_in_place() -> None:
     assert "".join(str(w) for w in emitter.timed_words) == " Then, after all"
 
 
-async def test_an_untimed_tail_is_bounded_so_captions_reach_it() -> None:
-    """The last untimed region is closed off, since nothing timed follows it.
+async def test_an_untimed_tail_claims_no_end_it_cannot_know() -> None:
+    """The last region stays open, because nothing here knows where it ends.
 
-    The synchronizer builds its rate curve from timed points and reveals text
-    only as far as that curve goes. A tail left unbounded would sit past the
-    end of it, and the caption would stop short of words the agent spoke.
+    The synchronizer stops trusting annotations once playback passes the last
+    one, estimates from there, and releases the rest when playback completes,
+    so the tail still reaches the viewer. Closing it on the emitter's duration
+    would claim an end earlier than the speech, spreading the tail over too
+    short an interval and running the captions ahead of the voice.
     """
     emitter = _RecordingEmitter()
     tts = soniox.TTS(api_key="fake-key")
@@ -1048,9 +1050,9 @@ async def test_an_untimed_tail_is_bounded_so_captions_reach_it() -> None:
 
     tail = emitter.timed_words[-1]
     assert str(tail) == "brown fox"
-    # opens where the last timed word ended, closes on the audio produced
+    # opens where the last timed word ended, and claims no end
     assert tail.start_time == pytest.approx(0.09)
-    assert tail.end_time == pytest.approx(0.5)
+    assert not is_given(tail.end_time)
 
 
 async def test_an_untimed_region_mid_reply_opens_where_timing_stopped() -> None:

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -1001,3 +1001,27 @@ async def test_untimed_text_survives_a_stream_that_ends_inside_a_gap() -> None:
     soniox_tts._emit_timed_words(data, flush=True)
 
     assert "".join(str(w) for w in emitter.timed_words) == "The quick brown fox"
+
+
+async def test_untimed_text_first_keeps_the_separator_in_place() -> None:
+    """When the gap opens a stream, the untimed text carries its separator.
+
+    The separator belongs to whatever the stream publishes first. Leaving it for
+    the first timed word instead moves the whitespace: the reply loses it here
+    and grows a second one further along.
+    """
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    data = soniox_tts._StreamData(
+        emitter=emitter,  # type: ignore[arg-type]
+        waiter=asyncio.get_event_loop().create_future(),
+        opts=tts._opts,
+    )
+    # a rotated stream is handed its leading separator by the tokenizer
+    data.sent_text = " Then, after all"
+
+    soniox_tts._accumulate_timestamps(data, {"characters": list("Then,")})  # malformed
+    soniox_tts._accumulate_timestamps(data, _character_timestamps(" after all", 0.05))
+    soniox_tts._emit_timed_words(data, flush=True)
+
+    assert "".join(str(w) for w in emitter.timed_words) == " Then, after all"

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -86,7 +86,13 @@ class _FakeConnection:
     whitespace inside the stream survives.
     """
 
-    def __init__(self, *, fail_on_send: int | None = None, timestamps: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        fail_on_send: int | None = None,
+        timestamps: bool = False,
+        emit_before_failure: bool = False,
+    ) -> None:
         self.is_current = True
         self.closed = False
         self.registered_ids: list[str] = []
@@ -97,6 +103,7 @@ class _FakeConnection:
         self._sends = 0
         self._fail_on_send = fail_on_send
         self._timestamps = timestamps
+        self._emit_before_failure = emit_before_failure
 
     def register_stream(
         self,
@@ -106,6 +113,7 @@ class _FakeConnection:
         *,
         opts: Any,
         time_offset: float = 0.0,
+        audio_baseline: float = 0.0,
         timeline: soniox_tts._Timeline | None = None,
     ) -> None:
         self.registered_ids.append(stream_id)
@@ -116,6 +124,7 @@ class _FakeConnection:
                 waiter=waiter,
                 opts=opts,
                 time_offset=time_offset,
+                audio_baseline=audio_baseline,
                 timeline=timeline if timeline is not None else soniox_tts._Timeline(),
             )
         )
@@ -139,6 +148,15 @@ class _FakeConnection:
         self._sends += 1
         if self._sends == self._fail_on_send:
             self._fail_on_send = None
+            if self._emit_before_failure:
+                # One 10ms chunk fits entirely in the tail frame the emitter
+                # holds back, so pushed_duration() still reads the baseline
+                # while the timestamps for it have already been mapped.
+                slot.data.sent_text += text
+                soniox_tts._accumulate_timestamps(
+                    slot.data, _character_timestamps(text.lstrip()[:20], 0.0)
+                )
+                slot.emitter.push(_SILENCE_PCM)
             if not slot.waiter.done():
                 slot.waiter.set_exception(
                     APIStatusError("transient", status_code=429, retryable=True)
@@ -265,12 +283,17 @@ class _FakeWebSocket:
 
 
 class _RecordingEmitter:
+    """Counts pushed audio the way ``AudioEmitter.pushed_duration`` does."""
+
     def __init__(self) -> None:
         self.audio: list[bytes] = []
         self.timed_words: list[TimedString] = []
 
     def push(self, data: bytes) -> None:
         self.audio.append(data)
+
+    def pushed_duration(self, idx: int = -1) -> float:
+        return sum(len(chunk) for chunk in self.audio) / (2 * 24000)
 
     def push_timed_transcript(self, delta_text: TimedString | list[TimedString]) -> None:
         if isinstance(delta_text, list):
@@ -573,4 +596,20 @@ async def test_timed_words_rebuild_the_reply_on_one_stream() -> None:
     await _synthesize(fake, timed_words=words)
 
     assert len(fake.registered_ids) == 1
+    assert "".join(str(w) for w in words) == "".join(SENTENCES)
+
+
+async def test_a_replayed_stream_does_not_duplicate_the_transcript() -> None:
+    """A stream that already mapped timestamps is never replayed in place.
+
+    ``push_timed_transcript`` cannot be taken back, so replaying such a stream
+    onto the same emitter would leave the failed attempt's words queued in front
+    of the replay's and say everything twice. The audio watermark alone does not
+    notice: one 10ms chunk sits in the tail frame the emitter holds back, so
+    ``pushed_duration()`` still equals the baseline.
+    """
+    fake = _FakeConnection(timestamps=True, fail_on_send=1, emit_before_failure=True)
+    words: list[TimedString] = []
+    await _synthesize(fake, timed_words=words)
+
     assert "".join(str(w) for w in words) == "".join(SENTENCES)

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -840,8 +840,9 @@ async def test_a_malformed_frame_does_not_splice_across_the_gap() -> None:
     """Skipping a bad frame must not join the characters on either side of it.
 
     The buffer holds the word that frame was going to finish. Letting the next
-    frame land on it turns "bro" + "ps" into "brops" - a word nobody spoke,
-    published with plausible timings.
+    frame land on it turns "bro" + "ps" into "brops" - a word nobody spoke.
+    Publishing either side alone is no better: "ps" is not a word either, so
+    characters are dropped until a boundary.
     """
     emitter = _RecordingEmitter()
     tts = soniox.TTS(api_key="fake-key")
@@ -865,7 +866,34 @@ async def test_a_malformed_frame_does_not_splice_across_the_gap() -> None:
     soniox_tts._accumulate_timestamps(data, _character_timestamps("ps high", 0.23))
 
     published = "".join(str(w) for w in emitter.timed_words)
-    assert "brops" not in published
-    # every published word is one the agent actually said
+    # every published word is a whole word the agent said. Substring checks are
+    # too weak here: "ps" is inside "jumps" but was never a word.
+    spoken_words = set(spoken.split())
     for word in published.split():
-        assert word in spoken, f"invented {word!r}"
+        assert word in spoken_words, f"invented {word!r}"
+
+
+async def test_resync_waits_for_a_boundary_across_frames() -> None:
+    """A frame that is still inside the broken word publishes nothing."""
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    data = soniox_tts._StreamData(
+        emitter=emitter,  # type: ignore[arg-type]
+        waiter=asyncio.get_event_loop().create_future(),
+        opts=tts._opts,
+    )
+
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("The quick bro", 0.0))
+    soniox_tts._accumulate_timestamps(data, {"characters": list("wn fox ju")})  # malformed
+    assert data.resync_pending is True
+
+    # "mps" is the tail of the broken word, with no boundary in sight
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("mps", 0.22))
+    assert data.resync_pending is True
+    assert "".join(str(w) for w in emitter.timed_words) == "The quick "
+
+    # the boundary arrives with the next frame, and alignment resumes after it
+    soniox_tts._accumulate_timestamps(data, _character_timestamps(" high up", 0.25))
+    assert data.resync_pending is False
+    soniox_tts._emit_timed_words(data, flush=True)
+    assert "".join(str(w) for w in emitter.timed_words) == "The quick high up"

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -977,9 +977,8 @@ async def test_text_from_a_skipped_frame_is_published_without_timings() -> None:
     soniox_tts._emit_timed_words(data, flush=True)
 
     assert "".join(str(w) for w in emitter.timed_words) == "The quick brown fox jumps high"
-    # the gap's words carry no timings; everything else does
-    untimed = [str(w) for w in emitter.timed_words if not is_given(w.start_time)]
-    assert untimed == ["brown fox jumps "]
+    # the gap's words arrive as one chunk spanning the region, not as words
+    assert "brown fox jumps " in [str(w) for w in emitter.timed_words]
 
 
 async def test_untimed_text_survives_a_stream_that_ends_inside_a_gap() -> None:
@@ -1025,3 +1024,49 @@ async def test_untimed_text_first_keeps_the_separator_in_place() -> None:
     soniox_tts._emit_timed_words(data, flush=True)
 
     assert "".join(str(w) for w in emitter.timed_words) == " Then, after all"
+
+
+async def test_an_untimed_tail_is_bounded_so_captions_reach_it() -> None:
+    """The last untimed region is closed off, since nothing timed follows it.
+
+    The synchronizer builds its rate curve from timed points and reveals text
+    only as far as that curve goes. A tail left unbounded would sit past the
+    end of it, and the caption would stop short of words the agent spoke.
+    """
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    data = soniox_tts._StreamData(
+        emitter=emitter,  # type: ignore[arg-type]
+        waiter=asyncio.get_event_loop().create_future(),
+        opts=tts._opts,
+    )
+
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("The quick bro", 0.0))
+    emitter.push(_SILENCE_PCM * 50)  # 500ms of audio has reached the emitter
+    soniox_tts._accumulate_timestamps(data, {"characters": list("wn fox")})  # malformed
+    soniox_tts._emit_timed_words(data, flush=True)
+
+    tail = emitter.timed_words[-1]
+    assert str(tail) == "brown fox"
+    # opens where the last timed word ended, closes on the audio produced
+    assert tail.start_time == pytest.approx(0.09)
+    assert tail.end_time == pytest.approx(0.5)
+
+
+async def test_an_untimed_region_mid_reply_opens_where_timing_stopped() -> None:
+    """A region followed by timed words needs no end: the next word closes it."""
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    data = soniox_tts._StreamData(
+        emitter=emitter,  # type: ignore[arg-type]
+        waiter=asyncio.get_event_loop().create_future(),
+        opts=tts._opts,
+    )
+
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("The quick bro", 0.0))
+    soniox_tts._accumulate_timestamps(data, {"characters": list("wn fox jum")})  # malformed
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("ps high up", 0.23))
+
+    untimed = next(w for w in emitter.timed_words if str(w) == "brown fox jumps ")
+    assert untimed.start_time == pytest.approx(0.09)
+    assert not is_given(untimed.end_time)

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -771,11 +771,13 @@ async def test_interrupting_a_reply_keeps_the_last_spoken_word() -> None:
     assert "".join(str(w) for w in words).strip() == SENTENCES[0].strip()
 
 
-async def test_advancing_the_timeline_spends_the_stream() -> None:
-    """Characters that finish no word still make a stream unreplayable.
+async def test_only_published_words_advance_the_timeline() -> None:
+    """Buffered characters move nothing until they are spoken for.
 
-    They move the segment timeline, and a replacement would start from the
-    advanced value - past audio the failed attempt never produced.
+    The timeline is what a rotated stream starts from, so advancing it on
+    characters that finish no word would hand a replacement an offset past
+    audio that was never produced - and would make a stream that emitted
+    nothing look unreplayable.
     """
     emitter = _RecordingEmitter()
     tts = soniox.TTS(api_key="fake-key")
@@ -785,9 +787,50 @@ async def test_advancing_the_timeline_spends_the_stream() -> None:
         opts=tts._opts,
     )
 
-    # "Hel" completes no word, so nothing is published
+    # "Hel" finishes no word: nothing published, nothing spent
     soniox_tts._accumulate_timestamps(data, _character_timestamps("Hel", 0.0))
-
     assert emitter.timed_words == []
-    assert data.timeline.end > 0.0
+    assert data.timeline.end == 0.0
+    assert data.produced_output is False
+
+    # "lo wo" completes "Hello ", which is published and does move the timeline
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("lo wo", 3 * _SECONDS_PER_CHAR))
+    assert [str(w) for w in emitter.timed_words] == ["Hello "]
+    assert data.timeline.end == pytest.approx(0.05)
     assert data.produced_output is True
+
+
+async def test_a_timestamp_only_partial_word_stays_replayable() -> None:
+    """Buffering characters is reversible, so it must not cost a replay.
+
+    A frame can carry timestamps that finish no word. Nothing reaches the
+    emitter, so a transient failure after it is still safe to replay - and
+    aborting the reply instead would cut the agent off for nothing.
+    """
+    fake = _FakeConnection(timestamps=True)
+    tts = soniox.TTS(api_key="fake-key")
+
+    async def _fake_current_connection(*, timeout: float) -> tuple[Any, float, bool]:
+        return fake, 0.0, True
+
+    tts._current_connection = _fake_current_connection  # type: ignore[method-assign]
+
+    stream = tts.stream()
+    emitter = _RecordingEmitter()
+    try:
+        active = await stream._open_stream(emitter, "req-1")  # type: ignore[arg-type]
+        soniox_tts._accumulate_timestamps(active.data, _character_timestamps("Hel", 0.0))
+
+        assert emitter.timed_words == []
+        assert active.data.produced_output is False
+
+        active.waiter.set_exception(APIStatusError("transient", status_code=429, retryable=True))
+        replacement = await stream._settle_stream(active, emitter, "req-1")  # type: ignore[arg-type]
+
+        assert replacement is not None
+        assert replacement.stream_id != active.stream_id
+        # the replacement inherits no advance from the attempt that emitted nothing
+        assert fake.time_offsets[-1] == 0.0
+    finally:
+        await stream.aclose()
+        await tts.aclose()

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -896,7 +896,7 @@ async def test_resync_waits_for_a_boundary_across_frames() -> None:
     soniox_tts._accumulate_timestamps(data, _character_timestamps(" high up", 0.25))
     assert data.resync_pending is False
     soniox_tts._emit_timed_words(data, flush=True)
-    assert "".join(str(w) for w in emitter.timed_words) == "The quick high up"
+    assert "".join(str(w) for w in emitter.timed_words) == "The quick brown fox jumps high up"
 
 
 async def test_a_gap_costs_only_the_frame_in_a_spaceless_script() -> None:
@@ -920,8 +920,8 @@ async def test_a_gap_costs_only_the_frame_in_a_spaceless_script() -> None:
 
     published = "".join(str(w) for w in emitter.timed_words)
     assert data.resync_pending is False
-    # only the skipped frame's character is missing; the rest survives
-    assert published == "\u4eca\u5929\u5929\u5f88\u597d"
+    # nothing is lost: the skipped frame's characters come back untimed
+    assert published == "\u4eca\u5929\u5929\u6c14\u5f88\u597d"
 
 
 def test_word_boundary_follows_the_tokenizer() -> None:
@@ -953,4 +953,51 @@ async def test_a_gap_ending_on_a_boundary_costs_no_extra_word() -> None:
     soniox_tts._accumulate_timestamps(data, _character_timestamps(" high up", 0.25))
     soniox_tts._emit_timed_words(data, flush=True)
 
-    assert "".join(str(w) for w in emitter.timed_words) == "The quick high up"
+    assert "".join(str(w) for w in emitter.timed_words) == "The quick brown fox jumps high up"
+
+
+async def test_text_from_a_skipped_frame_is_published_without_timings() -> None:
+    """A frame's timings can be unusable while its characters were still spoken.
+
+    Dropping them would leave the turn's history missing words the agent said.
+    They are published untimed instead, which the synchronizer estimates
+    across - the old behaviour, confined to the stretch that lost its timings.
+    """
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    data = soniox_tts._StreamData(
+        emitter=emitter,  # type: ignore[arg-type]
+        waiter=asyncio.get_event_loop().create_future(),
+        opts=tts._opts,
+    )
+
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("The quick bro", 0.0))
+    soniox_tts._accumulate_timestamps(data, {"characters": list("wn fox jum")})  # malformed
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("ps high", 0.23))
+    soniox_tts._emit_timed_words(data, flush=True)
+
+    assert "".join(str(w) for w in emitter.timed_words) == "The quick brown fox jumps high"
+    # the gap's words carry no timings; everything else does
+    untimed = [str(w) for w in emitter.timed_words if not is_given(w.start_time)]
+    assert untimed == ["brown fox jumps "]
+
+
+async def test_untimed_text_survives_a_stream_that_ends_inside_a_gap() -> None:
+    """A stream can end before a boundary closes the untimed region.
+
+    The held text is the tail of the reply, so losing it here would cut the
+    transcript short exactly where an interruption is most likely.
+    """
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    data = soniox_tts._StreamData(
+        emitter=emitter,  # type: ignore[arg-type]
+        waiter=asyncio.get_event_loop().create_future(),
+        opts=tts._opts,
+    )
+
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("The quick bro", 0.0))
+    soniox_tts._accumulate_timestamps(data, {"characters": list("wn fox")})  # malformed
+    soniox_tts._emit_timed_words(data, flush=True)
+
+    assert "".join(str(w) for w in emitter.timed_words) == "The quick brown fox"

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import json
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -115,20 +116,20 @@ class _FakeConnection:
         time_offset: float = 0.0,
         audio_baseline: float = 0.0,
         timeline: soniox_tts._Timeline | None = None,
-    ) -> None:
+    ) -> soniox_tts._StreamData:
         self.registered_ids.append(stream_id)
         self.time_offsets.append(time_offset)
-        self._streams[stream_id] = _StreamSlot(
-            soniox_tts._StreamData(
-                emitter=emitter,
-                waiter=waiter,
-                opts=opts,
-                time_offset=time_offset,
-                audio_baseline=audio_baseline,
-                timeline=timeline if timeline is not None else soniox_tts._Timeline(),
-            )
+        data = soniox_tts._StreamData(
+            emitter=emitter,
+            waiter=waiter,
+            opts=opts,
+            time_offset=time_offset,
+            audio_baseline=audio_baseline,
+            timeline=timeline if timeline is not None else soniox_tts._Timeline(),
         )
+        self._streams[stream_id] = _StreamSlot(data)
         self.max_open_streams = max(self.max_open_streams, len(self._streams))
+        return data
 
     def unregister_stream(self, stream_id: str) -> None:
         self._streams.pop(stream_id, None)
@@ -206,12 +207,17 @@ async def _synthesize(
 
     push_t = asyncio.create_task(_push())
     frames = 0
-    async for ev in stream:
-        frames += 1
-        if timed_words is not None:
-            timed_words += ev.frame.userdata.get(USERDATA_TIMED_TRANSCRIPT, [])
-    await push_t
-    await stream.aclose()
+    try:
+        async for ev in stream:
+            frames += 1
+            if timed_words is not None:
+                timed_words += ev.frame.userdata.get(USERDATA_TIMED_TRANSCRIPT, [])
+    finally:
+        # the stream may raise, so tear down either way
+        push_t.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await push_t
+        await stream.aclose()
     return frames
 
 
@@ -613,3 +619,20 @@ async def test_a_replayed_stream_does_not_duplicate_the_transcript() -> None:
     await _synthesize(fake, timed_words=words)
 
     assert "".join(str(w) for w in words) == "".join(SENTENCES)
+
+
+async def test_words_for_unreplayable_audio_are_released() -> None:
+    """Words held for audio the emitter accepted are not dropped with the stream.
+
+    Once the emitter counts a stream's audio the stream can no longer be
+    replayed, so the words held back for it describe speech the user hears.
+    Discarding them with the stream would drop that text from the aligned
+    transcript, and from the history of a turn interrupted right there.
+    """
+    fake = _FakeConnection(timestamps=True, fail_on_send=2)
+    words: list[TimedString] = []
+    with pytest.raises(APIStatusError):
+        await _synthesize(fake, timed_words=words)
+
+    # the first sentence was spoken before the failure, so it must be reported
+    assert "".join(str(w) for w in words).strip() == SENTENCES[0].strip()

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -1,9 +1,14 @@
-"""Unit tests for Soniox TTS sentence buffering and stream rotation.
+"""Unit tests for Soniox TTS sentence buffering, stream rotation and alignment.
 
 The plugin buffers LLM chunks into complete sentences, feeds them into one
 shared Soniox stream, and rotates to a fresh ``stream_id`` when input goes
 idle for ``stream_idle_timeout`` or after a transient failure (batch replay).
 These tests drive the real ``SynthesizeStream`` against a fake ``_Connection``.
+
+The alignment tests cover ``return_timestamps``: Soniox times characters from
+each stream's own first sample, so a reply spread over several rotated streams
+only stays on one timeline if every timestamp is offset by the audio already
+emitted.
 
 Idle-timeout tests use ``virtual_time`` so timers advance deterministically.
 """
@@ -11,14 +16,22 @@ Idle-timeout tests use ``virtual_time`` so timers advance deterministically.
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 
+import aiohttp
 import pytest
 
 from livekit.agents import APIStatusError
 from livekit.agents.tts import AudioEmitter
+from livekit.agents.types import USERDATA_TIMED_TRANSCRIPT
+from livekit.agents.utils import is_given
+from livekit.agents.voice.io import TimedString
 from livekit.plugins import soniox
+from livekit.plugins.soniox import tts as soniox_tts
 
 pytestmark = [
     pytest.mark.plugin("soniox"),
@@ -28,6 +41,9 @@ pytestmark = [
 
 # 10 ms of mono s16le silence at 24 kHz
 _SILENCE_PCM = b"\x00\x00" * 240
+# One character of speech per silence chunk, so the fake server's audio and its
+# character timestamps describe the same amount of time.
+_SECONDS_PER_CHAR = 0.01
 
 SENTENCES = [
     "Hello there, this is the first sentence. ",
@@ -36,24 +52,49 @@ SENTENCES = [
 ]
 
 
+def _character_timestamps(text: str, start: float) -> dict[str, list[Any]]:
+    """Soniox-shaped timings for *text*, starting *start* seconds into the stream."""
+    starts = [start + i * _SECONDS_PER_CHAR for i in range(len(text))]
+    return {
+        "characters": list(text),
+        "character_start_times_seconds": starts,
+        "character_end_times_seconds": [t + _SECONDS_PER_CHAR for t in starts],
+    }
+
+
 @dataclass
 class _StreamSlot:
-    emitter: AudioEmitter
-    waiter: asyncio.Future[None]
+    data: soniox_tts._StreamData
+    cursor: float = 0.0  # seconds of speech this stream has already timed
+
+    @property
+    def emitter(self) -> AudioEmitter:
+        return self.data.emitter
+
+    @property
+    def waiter(self) -> asyncio.Future[None]:
+        return self.data.waiter
 
 
 class _FakeConnection:
-    """Stand-in for ``_Connection``: text produces audio, ``text_end`` terminates."""
+    """Stand-in for ``_Connection``: text produces audio, ``text_end`` terminates.
 
-    def __init__(self, *, fail_on_send: int | None = None) -> None:
+    Audio and character timestamps are kept consistent at ``_SECONDS_PER_CHAR``
+    per character, and, like the real server, timestamps restart at zero on
+    every new ``stream_id``.
+    """
+
+    def __init__(self, *, fail_on_send: int | None = None, timestamps: bool = False) -> None:
         self.is_current = True
         self.closed = False
         self.registered_ids: list[str] = []
         self.send_calls: list[tuple[str, str, bool]] = []
+        self.time_offsets: list[float] = []
         self.max_open_streams = 0
         self._streams: dict[str, _StreamSlot] = {}
         self._sends = 0
         self._fail_on_send = fail_on_send
+        self._timestamps = timestamps
 
     def register_stream(
         self,
@@ -62,9 +103,15 @@ class _FakeConnection:
         waiter: asyncio.Future[None],
         *,
         opts: Any,
+        time_offset: float = 0.0,
     ) -> None:
         self.registered_ids.append(stream_id)
-        self._streams[stream_id] = _StreamSlot(emitter, waiter)
+        self.time_offsets.append(time_offset)
+        self._streams[stream_id] = _StreamSlot(
+            soniox_tts._StreamData(
+                emitter=emitter, waiter=waiter, opts=opts, time_offset=time_offset
+            )
+        )
         self.max_open_streams = max(self.max_open_streams, len(self._streams))
 
     def unregister_stream(self, stream_id: str) -> None:
@@ -77,6 +124,8 @@ class _FakeConnection:
             return
         if text_end and not text:
             # server: final audio + audio_end + terminated
+            if self._timestamps:
+                soniox_tts._emit_timed_words(slot.data, flush=True)
             if not slot.waiter.done():
                 slot.waiter.set_result(None)
             return
@@ -88,7 +137,13 @@ class _FakeConnection:
                     APIStatusError("transient", status_code=429, retryable=True)
                 )
             return
-        slot.emitter.push(_SILENCE_PCM)
+        if not self._timestamps:
+            slot.emitter.push(_SILENCE_PCM)
+            return
+
+        soniox_tts._accumulate_timestamps(slot.data, _character_timestamps(text, slot.cursor))
+        slot.cursor += len(text) * _SECONDS_PER_CHAR
+        slot.emitter.push(_SILENCE_PCM * len(text))
 
     def cancel_stream(self, stream_id: str) -> None:
         slot = self._streams.get(stream_id)
@@ -100,6 +155,7 @@ async def _synthesize(
     fake: _FakeConnection,
     *,
     chunk_delays: list[float] | None = None,
+    timed_words: list[TimedString] | None = None,
     **tts_kwargs: Any,
 ) -> int:
     tts = soniox.TTS(api_key="fake-key", **tts_kwargs)
@@ -120,8 +176,10 @@ async def _synthesize(
 
     push_t = asyncio.create_task(_push())
     frames = 0
-    async for _ in stream:
+    async for ev in stream:
         frames += 1
+        if timed_words is not None:
+            timed_words += ev.frame.userdata.get(USERDATA_TIMED_TRANSCRIPT, [])
     await push_t
     await stream.aclose()
     return frames
@@ -171,3 +229,217 @@ async def test_invalid_stream_idle_timeout_rejected() -> None:
         soniox.TTS(api_key="fake-key", stream_idle_timeout=0)
     with pytest.raises(ValueError):
         soniox.TTS(api_key="fake-key", stream_idle_timeout=-1.0)
+
+
+class _FakeWebSocket:
+    """Minimal ``aiohttp`` websocket: records what was sent, replays what was set."""
+
+    def __init__(self, messages: list[object] | None = None) -> None:
+        self.sent: list[dict[str, Any]] = []
+        self.closed = False
+        self.close_code = 1000
+        self._messages = list(messages or [])
+
+    async def send_str(self, data: str) -> None:
+        self.sent.append(json.loads(data))
+
+    async def receive(self) -> object:
+        if self._messages:
+            return self._messages.pop(0)
+        return SimpleNamespace(type=aiohttp.WSMsgType.CLOSE, data="", extra="")
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _RecordingEmitter:
+    def __init__(self) -> None:
+        self.audio: list[bytes] = []
+        self.timed_words: list[TimedString] = []
+
+    def push(self, data: bytes) -> None:
+        self.audio.append(data)
+
+    def push_timed_transcript(self, delta_text: TimedString | list[TimedString]) -> None:
+        if isinstance(delta_text, list):
+            self.timed_words += delta_text
+        else:
+            self.timed_words.append(delta_text)
+
+
+def _span(word: TimedString) -> tuple[float, float]:
+    """The word's (start, end) in seconds, asserting the timings are present."""
+    assert is_given(word.start_time) and is_given(word.end_time)
+    return word.start_time, word.end_time
+
+
+def _text_message(payload: dict[str, Any]) -> object:
+    return SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data=json.dumps(payload))
+
+
+async def _sent_start_config(**tts_kwargs: Any) -> dict[str, Any]:
+    """Run the real send loop over a single start config and return what it sent."""
+    tts = soniox.TTS(api_key="fake-key", **tts_kwargs)
+    conn = soniox_tts._Connection(tts._opts, session=None)  # type: ignore[arg-type]
+    ws = _FakeWebSocket()
+    conn._ws = ws  # type: ignore[assignment]
+    conn._input_queue.send_nowait(soniox_tts._StartConfig(stream_id="s1", opts=tts._opts))
+    conn._input_queue.close()
+
+    await conn._send_loop()
+    await conn.aclose()
+
+    assert len(ws.sent) == 1
+    return ws.sent[0]
+
+
+async def test_capabilities_track_return_timestamps() -> None:
+    assert soniox.TTS(api_key="fake-key").capabilities.aligned_transcript is True
+    assert (
+        soniox.TTS(api_key="fake-key", return_timestamps=False).capabilities.aligned_transcript
+        is False
+    )
+
+
+async def test_start_config_requests_timestamps() -> None:
+    config = await _sent_start_config()
+    assert config["return_timestamps"] is True
+
+
+async def test_start_config_omits_timestamps_when_disabled() -> None:
+    config = await _sent_start_config(return_timestamps=False)
+    assert "return_timestamps" not in config
+
+
+async def test_recv_loop_maps_character_timestamps() -> None:
+    """Characters arriving over two frames become words on the emitter's timeline."""
+    stream_id = "stream-1"
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    conn = soniox_tts._Connection(tts._opts, session=None)  # type: ignore[arg-type]
+    waiter: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+    conn._streams[stream_id] = soniox_tts._StreamData(
+        emitter=emitter,  # type: ignore[arg-type]
+        waiter=waiter,
+        opts=tts._opts,
+        time_offset=1.5,  # this stream started 1.5s into the segment
+    )
+    conn._ws = _FakeWebSocket(  # type: ignore[assignment]
+        [
+            _text_message(
+                {
+                    "stream_id": stream_id,
+                    "audio": base64.b64encode(_SILENCE_PCM).decode("ascii"),
+                    "timestamps": _character_timestamps("Hi the", 0.0),
+                }
+            ),
+            _text_message(
+                {
+                    "stream_id": stream_id,
+                    "audio": base64.b64encode(_SILENCE_PCM).decode("ascii"),
+                    "timestamps": _character_timestamps("re", 6 * _SECONDS_PER_CHAR),
+                    "audio_end": True,
+                }
+            ),
+            _text_message({"stream_id": stream_id, "terminated": True}),
+        ]
+    )
+
+    await conn._recv_loop()
+    await conn.aclose()
+
+    assert [str(w) for w in emitter.timed_words] == ["Hi", "there"]
+    hi, there = emitter.timed_words
+    # every timestamp shifted onto the segment timeline by time_offset
+    assert hi.start_time == pytest.approx(1.50)
+    assert hi.end_time == pytest.approx(1.52)
+    assert there.start_time == pytest.approx(1.53)
+    assert there.end_time == pytest.approx(1.58)
+    assert len(emitter.audio) == 2
+    assert waiter.done() and waiter.result() is None
+
+
+async def test_aligned_transcript_reaches_frames_on_one_timeline() -> None:
+    fake = _FakeConnection(timestamps=True)
+    words: list[TimedString] = []
+    frames = await _synthesize(fake, timed_words=words)
+
+    assert frames > 0
+    assert len(fake.registered_ids) == 1
+    spoken = " ".join(str(w) for w in words)
+    assert "Hello" in spoken and "third" in spoken
+    spans = [_span(w) for w in words]
+    starts = [start for start, _ in spans]
+    assert starts == sorted(starts)
+    assert all(end >= start for start, end in spans)
+
+
+async def test_aligned_transcript_offset_across_stream_rotation() -> None:
+    """A reply split over two streams stays on one non-decreasing timeline.
+
+    Soniox restarts character times at zero for every ``stream_id``, so without
+    the open-time offset the second stream's words would jump back to ~0.
+    """
+    fake = _FakeConnection(timestamps=True)
+    words: list[TimedString] = []
+    await _synthesize(
+        fake,
+        timed_words=words,
+        chunk_delays=[3.0, 0.01, 0.01],
+        stream_idle_timeout=1.0,
+    )
+
+    assert len(fake.registered_ids) == 2
+    # the second stream opened onto audio already emitted, not at zero
+    assert fake.time_offsets[0] == 0.0
+    assert fake.time_offsets[1] > 0.0
+
+    starts = [start for start, _ in (_span(w) for w in words)]
+    assert starts == sorted(starts)
+
+    # "And" opens the second sentence, i.e. the second stream; sentence one is
+    # ~40 characters of speech, so its words cannot start back near zero.
+    first_sentence_duration = len(SENTENCES[0]) * _SECONDS_PER_CHAR
+    second_stream_start, _ = _span(next(w for w in words if str(w) == "And"))
+    assert second_stream_start > first_sentence_duration * 0.8
+
+
+async def test_partial_timestamps_are_ignored() -> None:
+    """A frame whose timing arrays disagree is dropped rather than mis-aligned."""
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    stream = soniox_tts._StreamData(
+        emitter=emitter,  # type: ignore[arg-type]
+        waiter=asyncio.get_event_loop().create_future(),
+        opts=tts._opts,
+    )
+
+    soniox_tts._accumulate_timestamps(stream, {"characters": ["a", "b"]})
+    soniox_tts._accumulate_timestamps(
+        stream,
+        {
+            "characters": ["a", "b"],
+            "character_start_times_seconds": [0.0, 0.1],
+            "character_end_times_seconds": [0.1],
+        },
+    )
+
+    assert emitter.timed_words == []
+    assert stream.char_text == ""
+
+
+def test_to_timed_words_holds_back_the_trailing_word() -> None:
+    text = "one two"
+    starts = [i * 0.1 for i in range(len(text))]
+    ends = [s + 0.1 for s in starts]
+
+    timed, remaining = soniox_tts._to_timed_words(text, starts, ends)
+    assert [str(w) for w in timed] == ["one"]
+    # the separator stays with the remainder so its characters keep their timings
+    assert remaining == " two"
+
+    timed, remaining = soniox_tts._to_timed_words(text, starts, ends, flush=True)
+    assert [str(w) for w in timed] == ["one", "two"]
+    assert remaining == ""
+    assert timed[1].start_time == pytest.approx(0.4)
+    assert timed[1].end_time == pytest.approx(0.7)

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -897,3 +897,60 @@ async def test_resync_waits_for_a_boundary_across_frames() -> None:
     assert data.resync_pending is False
     soniox_tts._emit_timed_words(data, flush=True)
     assert "".join(str(w) for w in emitter.timed_words) == "The quick high up"
+
+
+async def test_a_gap_costs_only_the_frame_in_a_spaceless_script() -> None:
+    """CJK and Thai recover immediately: every character is already a word.
+
+    Waiting for whitespace never resolves in these scripts, so the rest of the
+    reply's transcript and timeline would be discarded entirely.
+    """
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    data = soniox_tts._StreamData(
+        emitter=emitter,  # type: ignore[arg-type]
+        waiter=asyncio.get_event_loop().create_future(),
+        opts=tts._opts,
+    )
+
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("\u4eca\u5929\u5929", 0.0))
+    soniox_tts._accumulate_timestamps(data, {"characters": ["\u6c14"]})  # malformed
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("\u5f88\u597d", 0.04))
+    soniox_tts._emit_timed_words(data, flush=True)
+
+    published = "".join(str(w) for w in emitter.timed_words)
+    assert data.resync_pending is False
+    # only the skipped frame's character is missing; the rest survives
+    assert published == "\u4eca\u5929\u5929\u5f88\u597d"
+
+
+def test_word_boundary_follows_the_tokenizer() -> None:
+    assert soniox_tts._is_word_boundary(" ") is True
+    assert soniox_tts._is_word_boundary("\u4eca") is True  # CJK: a word on its own
+    assert soniox_tts._is_word_boundary("\u0e2a") is True  # Thai
+    assert soniox_tts._is_word_boundary("p") is False
+    assert soniox_tts._is_word_boundary(",") is False  # punctuation stays in the word
+
+
+async def test_a_gap_ending_on_a_boundary_costs_no_extra_word() -> None:
+    """When the frame after a gap opens on a boundary, no whole word is dropped.
+
+    Only the separator is consumed. Where the gap ends mid-word instead, the
+    tail has to go: nothing in the stream says whether those characters finish
+    the broken word or start a new one.
+    """
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    data = soniox_tts._StreamData(
+        emitter=emitter,  # type: ignore[arg-type]
+        waiter=asyncio.get_event_loop().create_future(),
+        opts=tts._opts,
+    )
+
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("The quick bro", 0.0))
+    soniox_tts._accumulate_timestamps(data, {"characters": list("wn fox jumps")})  # malformed
+    # the next frame opens on a separator, so the gap ended at a word boundary
+    soniox_tts._accumulate_timestamps(data, _character_timestamps(" high up", 0.25))
+    soniox_tts._emit_timed_words(data, flush=True)
+
+    assert "".join(str(w) for w in emitter.timed_words) == "The quick high up"

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -834,3 +834,38 @@ async def test_a_timestamp_only_partial_word_stays_replayable() -> None:
     finally:
         await stream.aclose()
         await tts.aclose()
+
+
+async def test_a_malformed_frame_does_not_splice_across_the_gap() -> None:
+    """Skipping a bad frame must not join the characters on either side of it.
+
+    The buffer holds the word that frame was going to finish. Letting the next
+    frame land on it turns "bro" + "ps" into "brops" - a word nobody spoke,
+    published with plausible timings.
+    """
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    data = soniox_tts._StreamData(
+        emitter=emitter,  # type: ignore[arg-type]
+        waiter=asyncio.get_event_loop().create_future(),
+        opts=tts._opts,
+    )
+
+    spoken = "The quick brown fox jumps high"
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("The quick bro", 0.0))
+    # "wn fox jum" arrives with timings that do not line up, so it is skipped
+    soniox_tts._accumulate_timestamps(
+        data,
+        {
+            "characters": list("wn fox jum"),
+            "character_start_times_seconds": [0.13, 0.14],
+            "character_end_times_seconds": [0.14, 0.15],
+        },
+    )
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("ps high", 0.23))
+
+    published = "".join(str(w) for w in emitter.timed_words)
+    assert "brops" not in published
+    # every published word is one the agent actually said
+    for word in published.split():
+        assert word in spoken, f"invented {word!r}"

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -769,3 +769,25 @@ async def test_interrupting_a_reply_keeps_the_last_spoken_word() -> None:
         await tts.aclose()
 
     assert "".join(str(w) for w in words).strip() == SENTENCES[0].strip()
+
+
+async def test_advancing_the_timeline_spends_the_stream() -> None:
+    """Characters that finish no word still make a stream unreplayable.
+
+    They move the segment timeline, and a replacement would start from the
+    advanced value - past audio the failed attempt never produced.
+    """
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    data = soniox_tts._StreamData(
+        emitter=emitter,  # type: ignore[arg-type]
+        waiter=asyncio.get_event_loop().create_future(),
+        opts=tts._opts,
+    )
+
+    # "Hel" completes no word, so nothing is published
+    soniox_tts._accumulate_timestamps(data, _character_timestamps("Hel", 0.0))
+
+    assert emitter.timed_words == []
+    assert data.timeline.end > 0.0
+    assert data.produced_output is True

--- a/tests/test_plugin_soniox_tts.py
+++ b/tests/test_plugin_soniox_tts.py
@@ -81,7 +81,9 @@ class _FakeConnection:
 
     Audio and character timestamps are kept consistent at ``_SECONDS_PER_CHAR``
     per character, and, like the real server, timestamps restart at zero on
-    every new ``stream_id``.
+    every new ``stream_id`` and are reported against preprocessed text: the
+    leading whitespace of a stream's first text is normalised away, while
+    whitespace inside the stream survives.
     """
 
     def __init__(self, *, fail_on_send: int | None = None, timestamps: bool = False) -> None:
@@ -104,12 +106,17 @@ class _FakeConnection:
         *,
         opts: Any,
         time_offset: float = 0.0,
+        timeline: soniox_tts._Timeline | None = None,
     ) -> None:
         self.registered_ids.append(stream_id)
         self.time_offsets.append(time_offset)
         self._streams[stream_id] = _StreamSlot(
             soniox_tts._StreamData(
-                emitter=emitter, waiter=waiter, opts=opts, time_offset=time_offset
+                emitter=emitter,
+                waiter=waiter,
+                opts=opts,
+                time_offset=time_offset,
+                timeline=timeline if timeline is not None else soniox_tts._Timeline(),
             )
         )
         self.max_open_streams = max(self.max_open_streams, len(self._streams))
@@ -138,12 +145,17 @@ class _FakeConnection:
                 )
             return
         if not self._timestamps:
+            slot.data.sent_text += text
             slot.emitter.push(_SILENCE_PCM)
             return
 
-        soniox_tts._accumulate_timestamps(slot.data, _character_timestamps(text, slot.cursor))
-        slot.cursor += len(text) * _SECONDS_PER_CHAR
-        slot.emitter.push(_SILENCE_PCM * len(text))
+        # the server strips the separator that opens a stream, keeps the rest
+        spoken = text.lstrip() if not slot.data.sent_text else text
+        slot.data.sent_text += text
+
+        soniox_tts._accumulate_timestamps(slot.data, _character_timestamps(spoken, slot.cursor))
+        slot.cursor += len(spoken) * _SECONDS_PER_CHAR
+        slot.emitter.push(_SILENCE_PCM * len(spoken))
 
     def cancel_stream(self, stream_id: str) -> None:
         slot = self._streams.get(stream_id)
@@ -318,11 +330,13 @@ async def test_recv_loop_maps_character_timestamps() -> None:
     tts = soniox.TTS(api_key="fake-key")
     conn = soniox_tts._Connection(tts._opts, session=None)  # type: ignore[arg-type]
     waiter: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+    timeline = soniox_tts._Timeline(end=1.5)
     conn._streams[stream_id] = soniox_tts._StreamData(
         emitter=emitter,  # type: ignore[arg-type]
         waiter=waiter,
         opts=tts._opts,
         time_offset=1.5,  # this stream started 1.5s into the segment
+        timeline=timeline,
     )
     conn._ws = _FakeWebSocket(  # type: ignore[assignment]
         [
@@ -348,7 +362,7 @@ async def test_recv_loop_maps_character_timestamps() -> None:
     await conn._recv_loop()
     await conn.aclose()
 
-    assert [str(w) for w in emitter.timed_words] == ["Hi", "there"]
+    assert [str(w) for w in emitter.timed_words] == ["Hi ", "there"]
     hi, there = emitter.timed_words
     # every timestamp shifted onto the segment timeline by time_offset
     assert hi.start_time == pytest.approx(1.50)
@@ -357,6 +371,9 @@ async def test_recv_loop_maps_character_timestamps() -> None:
     assert there.end_time == pytest.approx(1.58)
     assert len(emitter.audio) == 2
     assert waiter.done() and waiter.result() is None
+    # the timeline advanced to the last character, so the next stream after a
+    # rotation starts from here rather than from a lagging pushed_duration()
+    assert timeline.end == pytest.approx(1.58)
 
 
 async def test_aligned_transcript_reaches_frames_on_one_timeline() -> None:
@@ -400,7 +417,7 @@ async def test_aligned_transcript_offset_across_stream_rotation() -> None:
     # "And" opens the second sentence, i.e. the second stream; sentence one is
     # ~40 characters of speech, so its words cannot start back near zero.
     first_sentence_duration = len(SENTENCES[0]) * _SECONDS_PER_CHAR
-    second_stream_start, _ = _span(next(w for w in words if str(w) == "And"))
+    second_stream_start, _ = _span(next(w for w in words if str(w).strip() == "And"))
     assert second_stream_start > first_sentence_duration * 0.8
 
 
@@ -434,12 +451,126 @@ def test_to_timed_words_holds_back_the_trailing_word() -> None:
     ends = [s + 0.1 for s in starts]
 
     timed, remaining = soniox_tts._to_timed_words(text, starts, ends)
-    assert [str(w) for w in timed] == ["one"]
-    # the separator stays with the remainder so its characters keep their timings
-    assert remaining == " two"
+    # the separator rides with the word before it, so the chunks concatenate
+    assert [str(w) for w in timed] == ["one "]
+    assert remaining == "two"
 
     timed, remaining = soniox_tts._to_timed_words(text, starts, ends, flush=True)
-    assert [str(w) for w in timed] == ["one", "two"]
+    assert [str(w) for w in timed] == ["one ", "two"]
     assert remaining == ""
+    # timings describe the word, not the separator: "one" ends at 0.3, not 0.4
+    assert timed[0].start_time == pytest.approx(0.0)
+    assert timed[0].end_time == pytest.approx(0.3)
     assert timed[1].start_time == pytest.approx(0.4)
     assert timed[1].end_time == pytest.approx(0.7)
+
+
+async def test_timed_words_reconstruct_the_spoken_text() -> None:
+    """The SDK concatenates these chunks into chat history, so they must tile the text.
+
+    ``perform_text_forwarding`` builds the reply with ``out.text += delta``; a
+    chunk set that dropped the separators would store "Hellothere" as the text
+    the agent spoke.
+    """
+    spoken = "Hello there, this is what the agent said."
+    stream_id = "stream-1"
+    emitter = _RecordingEmitter()
+    tts = soniox.TTS(api_key="fake-key")
+    conn = soniox_tts._Connection(tts._opts, session=None)  # type: ignore[arg-type]
+    conn._streams[stream_id] = soniox_tts._StreamData(
+        emitter=emitter,  # type: ignore[arg-type]
+        waiter=asyncio.get_event_loop().create_future(),
+        opts=tts._opts,
+    )
+    # split mid-word, the way audio frames land
+    conn._ws = _FakeWebSocket(  # type: ignore[assignment]
+        [
+            _text_message(
+                {"stream_id": stream_id, "timestamps": _character_timestamps(spoken[:17], 0.0)}
+            ),
+            _text_message(
+                {
+                    "stream_id": stream_id,
+                    "timestamps": _character_timestamps(spoken[17:], 17 * _SECONDS_PER_CHAR),
+                    "audio_end": True,
+                }
+            ),
+            _text_message({"stream_id": stream_id, "terminated": True}),
+        ]
+    )
+
+    await conn._recv_loop()
+    await conn.aclose()
+
+    assert "".join(str(w) for w in emitter.timed_words) == spoken
+
+
+async def test_rotation_offset_outruns_a_lagging_pushed_duration() -> None:
+    """A rotated stream starts from the timeline, not from ``pushed_duration()``.
+
+    ``pushed_duration()`` counts neither audio still queued in the emitter nor
+    the tail frame it holds back, so at rotation time it can sit behind words
+    that were already emitted. Taking it alone would start the new stream early
+    and overlap them.
+    """
+    fake = _FakeConnection(timestamps=True)
+    tts = soniox.TTS(api_key="fake-key")
+
+    async def _fake_current_connection(*, timeout: float) -> tuple[Any, float, bool]:
+        return fake, 0.0, True
+
+    tts._current_connection = _fake_current_connection  # type: ignore[method-assign]
+
+    stream = tts.stream()
+    try:
+        # words emitted so far reach 2.134s, but the emitter only admits to 2.090s
+        stream._timeline.end = 2.134
+        emitter = SimpleNamespace(pushed_duration=lambda: 2.090)
+        active = await stream._open_stream(emitter, "req-1")  # type: ignore[arg-type]
+
+        assert fake.time_offsets[-1] == pytest.approx(2.134)
+        # the retry watermark still tracks the emitter, not the timeline: it
+        # answers "has any audio been emitted since this stream opened?"
+        assert active.baseline == pytest.approx(2.090)
+    finally:
+        await stream.aclose()
+        await tts.aclose()
+
+
+def test_to_timed_words_keeps_a_leading_separator() -> None:
+    """Text before the first word still reaches the transcript."""
+    text = " hi"
+    starts = [i * 0.1 for i in range(len(text))]
+    ends = [s + 0.1 for s in starts]
+
+    timed, remaining = soniox_tts._to_timed_words(text, starts, ends, flush=True)
+    assert "".join(str(w) for w in timed) + remaining == text
+
+
+async def test_timed_words_rebuild_the_reply_across_a_rotation() -> None:
+    """The reply survives a stream rotation intact, separator included.
+
+    The sentence tokenizer hands each stream its leading separator and Soniox
+    normalises it away, so without restoring it the chunks concatenate to
+    "one sentence.And here comes" in chat history.
+    """
+    fake = _FakeConnection(timestamps=True)
+    words: list[TimedString] = []
+    await _synthesize(
+        fake,
+        timed_words=words,
+        chunk_delays=[3.0, 0.01, 0.01],
+        stream_idle_timeout=1.0,
+    )
+
+    assert len(fake.registered_ids) == 2
+    assert "".join(str(w) for w in words) == "".join(SENTENCES)
+
+
+async def test_timed_words_rebuild_the_reply_on_one_stream() -> None:
+    fake = _FakeConnection(timestamps=True)
+    words: list[TimedString] = []
+    await _synthesize(fake, timed_words=words)
+
+    assert len(fake.registered_ids) == 1
+    assert "".join(str(w) for w in words) == "".join(SENTENCES)


### PR DESCRIPTION
## Summary

Closes #6727.

The Soniox TTS websocket returns character-level audio timings when the start config asks for
`return_timestamps`, but the plugin neither requested them nor read them. It declared
`TTSCapabilities(streaming=True)` with no `aligned_transcript`, so sessions running
`use_tts_aligned_transcript=True` fell back to the SDK's constant speaking-rate estimate — and an
interrupted utterance recorded imprecise spoken text, even though the provider exposes the same
character-level data `livekit-plugins-elevenlabs` already maps.

This requests `return_timestamps`, folds the per-frame character arrays into whole words, and pushes
them through the emitter's aligned-transcript path.

Word durations in one 6.3s reply measured live ranged from 45ms (`'the'`) to 562ms
(`'interrupts.'`), with a 549ms pause between sentences — spread a constant rate cannot represent.

## Changes

- **`return_timestamps: bool = True`** on `TTS`, wired to both the start config and
  `TTSCapabilities.aligned_transcript`, so the plugin can never claim a capability it did not
  request. `return_timestamps=False` opts out.
- **`_recv_loop` maps each frame's `timestamps` before pushing that frame's audio**, since the
  emitter attaches pending timed words to the next frame it emits.
- **`_to_timed_words`** splits the character buffer with the SDK's `split_words`
  (`split_character=True`, so CJK and Thai split correctly) and holds the trailing word back until
  more characters arrive — a frame can end mid-word.
- **The emitted chunks tile the text.** Each runs to the start of the next word, so separators ride
  with the word before them. `perform_text_forwarding` builds the reply with `out.text += delta`, so
  bare word slices would store `"Hellothere,this"` as what the agent said. Timings still describe
  the word alone, not the separator.
- **Malformed frames** (missing or mismatched arrays) are dropped rather than mis-aligned.

### Where this plugin differs from ElevenLabs

ElevenLabs uses one websocket context per utterance. This plugin does not: a single
`SynthesizeStream` spans several Soniox `stream_id`s, rotating on LLM idle gaps and on stream age so
the server's per-stream timeout cannot kill synthesis mid-sentence. Three consequences:

1. **Timings restart per stream.** Soniox times characters from each stream's own first sample, so a
   straight port would send `TranscriptSynchronizer` (`dt = start_time - pushed_duration`) backwards
   partway through a reply. Each stream is offset by the audio already emitted when it opened.

2. **The offset cannot come from `pushed_duration()` alone.** That counts neither audio still queued
   in the emitter nor the tail frame it holds back, so it lags. A `_Timeline` shared across the
   segment tracks the furthest timestamp seen, and a rotated stream starts from whichever is
   further along. Measured live, this moved a rotation from 2.090s to 2.134s — exactly the end of
   the previous stream's last word.

3. **The separator between streams is lost.** The sentence tokenizer hands each stream its leading
   whitespace (`" Then, after a long pause..."`) and Soniox normalises that away before timing the
   text, so two streams concatenated to `"one sentence.Then"`. It is taken back from the text the
   stream was actually given, leaving scripts that do not space their sentences alone.

### Replay safety

A stream that fails transiently is replayed on a fresh `stream_id` so the reply is not cut short.
That is only safe while the stream has produced nothing, and `pushed_duration()` answers that
question late: audio handed to the emitter is invisible until it becomes frames, so a spent stream
could look replayable and have its audio — and its already-published words — spoken twice.

`_StreamData.produced_output` records the fact directly, set the moment audio or timed words are
handed over, and gates the replay. Words are published as soon as they are complete, so nothing is
withheld and nothing can be lost. A stream that will not be replayed flushes the word it was
holding back, since no more characters are coming for it — on failure, and in `_run`'s cleanup,
which is the path an interruption takes.

## Testing

`tests/test_plugin_soniox_tts.py` — 23 tests, 19 new:

- the real `_send_loop` sends `return_timestamps`, and omits it when disabled
- the real `_recv_loop` reassembles `"Hi the"` + `"re"` into `["Hi ", "there"]`, shifted onto the
  segment timeline, and marks audio-only frames as produced output
- **the chunks rebuild the reply exactly** — on one stream, across a rotation, and through
  `_recv_loop`
- timed words reach `frame.userdata[USERDATA_TIMED_TRANSCRIPT]` end-to-end through the real
  `SynthesizeStream`
- a reply split across two streams stays on one non-decreasing timeline
- a rotated stream starts from the timeline rather than from a lagging `pushed_duration()`
- a stream that published words, or merely pushed audio, is never replayed
- **an interruption through `SynthesizeStream.aclose()` keeps the last spoken word**
- mismatched timing arrays are ignored; `_to_timed_words` hold-back, flush and leading-separator
  behaviour

Every fix was mutation-tested: reverting it fails a test, and only the tests that should fail.

`ruff format`, `ruff check` and `mypy` are clean on the touched files.

### Verified against the live API

Checked end-to-end against a real Soniox key, including the rotation path:

```
stream 1 opened at offset 0.000s
stream 2 opened at offset 2.134s
    1.659 ->   2.134  'sentence.'     <- last word of stream 1
    2.416 ->   2.561  'Then, '        <- stream 2 continues the timeline
    ...
    6.607 ->   6.998  'third.'
rebuilt: 'First the agent says one sentence. Then, after a long pause, it says another one. And finally a third.'
```

The server restarts its own clock for stream 2, and `'Then, '` still lands after the previous
stream's last word rather than back near 0.28s — with the chunks rebuilding the spoken text exactly.
