### PR TITLE
fix(phonic): apply update_options to every active realtime session

### DIFF
--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -8,7 +8,7 @@ import time
 import typing
 import weakref
 from collections.abc import AsyncIterable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Literal, TypedDict
 
 from livekit import rtc
@@ -496,7 +496,10 @@ class RealtimeModel(llm.RealtimeModel):
 class RealtimeSession(llm.RealtimeSession):
     def __init__(self, realtime_model: RealtimeModel) -> None:
         super().__init__(realtime_model)
-        self._opts = realtime_model._opts
+        # per-session copy of opts so update_options can diff against this session's own
+        # state: sessions of one model would otherwise share it, and the first update would
+        # leave every other session detecting no change and keeping its server config
+        self._opts = replace(realtime_model._opts)
         self._tools = llm.ToolContext.empty()
         self._chat_ctx = llm.ChatContext.empty()
 

--- a/tests/test_plugin_phonic_realtime.py
+++ b/tests/test_plugin_phonic_realtime.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import pytest
+
+from livekit.agents import utils
+from livekit.plugins.phonic.realtime.realtime_model import RealtimeModel, RealtimeSession
+
+pytestmark = pytest.mark.unit
+
+
+@asynccontextmanager
+async def _make_session(model: RealtimeModel) -> AsyncIterator[RealtimeSession]:
+    """A session whose background connect loop is stopped before it hits the network.
+
+    ``_config_sent`` is set because ``update_options`` deliberately schedules no reset
+    until the initial config has gone out, and these tests are about what happens after
+    that point.
+    """
+    session = model.session()
+    session._send_ch.close()
+    await utils.aio.cancel_and_wait(session._main_atask)
+    session._config_sent = True
+    try:
+        yield session
+    finally:
+        await session.aclose()
+
+
+async def test_update_options_resets_every_active_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHONIC_API_KEY", "fake-key")
+    model = RealtimeModel(voice="original")
+
+    async with _make_session(model) as first, _make_session(model) as second:
+        model.update_options(voice="updated")
+
+        assert first._options_reset_task is not None
+        assert second._options_reset_task is not None
+        assert first._opts.voice == "updated"
+        assert second._opts.voice == "updated"
+
+
+async def test_update_options_ignores_values_that_did_not_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHONIC_API_KEY", "fake-key")
+    model = RealtimeModel(voice="original")
+
+    async with _make_session(model) as session:
+        model.update_options(voice="original")
+
+        assert session._options_reset_task is None
+
+
+async def test_instructions_set_on_one_session_do_not_reach_another(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHONIC_API_KEY", "fake-key")
+    model = RealtimeModel(voice="original")
+
+    async with _make_session(model) as first, _make_session(model) as second:
+        # instructions are only accepted before the initial config goes out
+        first._config_sent = False
+        second._config_sent = False
+        untouched = second._opts.instructions
+
+        await first.update_instructions("for the first session only")
+
+        assert first._opts.instructions == "for the first session only"
+        assert second._opts.instructions == untouched


### PR DESCRIPTION
## Problem

Every `RealtimeSession` created from one `RealtimeModel` shares the model's `_RealtimeOptions`
instance. `update_options` decides whether to send a Phonic reset by comparing the requested values
against that shared object, so the first session to be updated writes the new values, and every
other session then finds nothing changed and returns without sending its reset.

With three active sessions, one of them sends the reset and the other two keep running their
previous server configuration. Which one wins is not predictable, since the sessions are held in a
`WeakSet`. All three report the new values locally, because they are reading the object the winner
wrote, so nothing on this side looks wrong.

The same aliasing lets one session's `update_instructions` overwrite another live session's
instructions before the initial config is sent.

## Changes

Each session now takes its own copy of the model's options when it is created, so `update_options`
compares against the state of the session it is updating. The openai and nvidia realtime models
already do this, for this reason.

Change detection is kept as it was: passing a value a session already holds still sends no reset,
which matters because a redundant reset interrupts the current generation.

`RealtimeModel`'s own options stay the constructor template and are not written by
`update_options`, which matches its documented behaviour of changing the active sessions. A session
created after an update previously inherited that update, but only when another session happened to
be alive at the time.

Adds `tests/test_plugin_phonic_realtime.py`, the first tests for this plugin.
