### PR TITLE
fix(google): deliver tool calls before combined turn completion

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -1156,7 +1156,10 @@ class RealtimeSession(llm.RealtimeSession):
                             )
 
                     if response.server_content:
-                        self._handle_server_content(response.server_content)
+                        self._handle_server_content(
+                            response.server_content,
+                            defer_completion=response.tool_call is not None,
+                        )
                     if response.tool_call:
                         self._handle_tool_calls(response.tool_call)
                     if response.tool_call_cancellation:
@@ -1290,7 +1293,12 @@ class RealtimeSession(llm.RealtimeSession):
 
         self.emit("generation_created", generation_event)
 
-    def _handle_server_content(self, server_content: types.LiveServerContent) -> None:
+    def _handle_server_content(
+        self,
+        server_content: types.LiveServerContent,
+        *,
+        defer_completion: bool = False,
+    ) -> None:
         current_gen = self._current_generation
         if not current_gen:
             if self._rejected_tool_calls:
@@ -1379,7 +1387,9 @@ class RealtimeSession(llm.RealtimeSession):
             # interrupt agent if there is no pending user initiated generation
             self._handle_input_speech_started()
 
-        if server_content.turn_complete:
+        # Gemini may combine turn_complete with a tool call in one message. Keep the
+        # function channel open until the tool call handler has delivered the call.
+        if server_content.turn_complete and not defer_completion:
             self._mark_current_generation_done()
 
     def _mark_current_generation_done(self) -> None:

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -221,6 +221,28 @@ async def test_tool_call_is_delivered_without_written_call_text(
         assert await _drain_generation(generations[0]) == ("", 0, ["getWeather"])
 
 
+async def test_tool_call_with_turn_complete_is_delivered_before_generation_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A combined terminal content/tool-call response must not close the call channel early."""
+    async with _make_session(monkeypatch) as session:
+        generations: list[llm.GenerationCreatedEvent] = []
+        session.on("generation_created", generations.append)
+        session._start_new_generation()
+
+        # _recv_task defers completion for server content when the same response also
+        # contains a tool call. Reproduce that dispatch order here so the tool call can
+        # still be delivered through the open channel.
+        session._handle_server_content(
+            types.LiveServerContent(turn_complete=True),
+            defer_completion=True,
+        )
+        session._handle_tool_calls(_tool_call(call_id="fc-combined"))
+
+        assert len(generations) == 1
+        assert await _drain_generation(generations[0]) == ("", 0, ["lookup"])
+
+
 async def test_transcript_keeps_model_text_in_text_modality(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes #7151

## What changed

Google Realtime can send a single response containing both terminal server content and a tool call. The receive loop now defers generation finalization for that server content, keeping the function channel open until the tool call is delivered. Existing responses without a tool call retain their current completion behavior.

## Validation

- `python -m pytest tests/test_plugin_google_realtime.py -q` (19 passed)
- `ruff check livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py tests/test_plugin_google_realtime.py`
- `ruff format --check livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py tests/test_plugin_google_realtime.py`
