### PR TITLE
fix(voice): report e2e_latency for the first reply after a handoff

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -1564,6 +1564,7 @@ class AgentActivity(RecognitionHooks):
             "speech_created",
             SpeechCreatedEvent(speech_handle=handle, user_initiated=True, source="say"),
         )
+        user_metrics = self._on_enter_user_metrics()
 
         if (
             self._rt_session is not None
@@ -1594,6 +1595,7 @@ class AgentActivity(RecognitionHooks):
                     audio=audio or None,
                     add_to_chat_ctx=add_to_chat_ctx,
                     model_settings=ModelSettings(),
+                    _previous_user_metrics=user_metrics,
                 ),
                 speech_handle=handle,
                 name="AgentActivity.tts_say",
@@ -1659,6 +1661,7 @@ class AgentActivity(RecognitionHooks):
             "speech_created",
             SpeechCreatedEvent(speech_handle=handle, user_initiated=True, source="generate_reply"),
         )
+        user_metrics = self._on_enter_user_metrics()
 
         if isinstance(self.llm, llm.RealtimeModel):
             self._create_speech_task(
@@ -1689,6 +1692,7 @@ class AgentActivity(RecognitionHooks):
                         if utils.is_given(tool_choice) or self._tool_choice is None
                         else self._tool_choice
                     ),
+                    _previous_user_metrics=user_metrics,
                 ),
                 speech_handle=handle,
                 name="AgentActivity.pipeline_reply",
@@ -2885,6 +2889,7 @@ class AgentActivity(RecognitionHooks):
         audio: AsyncIterable[rtc.AudioFrame] | None,
         add_to_chat_ctx: bool,
         model_settings: ModelSettings,
+        _previous_user_metrics: llm.MetricsReport | None = None,
     ) -> None:
         with tracer.start_as_current_span(
             "agent_turn", context=self._session._root_span_context
@@ -2909,6 +2914,7 @@ class AgentActivity(RecognitionHooks):
                     audio=audio,
                     add_to_chat_ctx=add_to_chat_ctx,
                     model_settings=model_settings,
+                    _previous_user_metrics=_previous_user_metrics,
                 )
             finally:
                 otel_metrics.record_invoke_agent_duration(
@@ -2922,6 +2928,7 @@ class AgentActivity(RecognitionHooks):
         audio: AsyncIterable[rtc.AudioFrame] | None,
         add_to_chat_ctx: bool,
         model_settings: ModelSettings,
+        _previous_user_metrics: llm.MetricsReport | None = None,
     ) -> None:
         current_span = trace.get_current_span(context=speech_handle._agent_turn_context)
         current_span.set_attribute(trace_types.ATTR_SPEECH_ID, speech_handle.id)
@@ -3112,6 +3119,16 @@ class AgentActivity(RecognitionHooks):
                         started_speaking_at - started_forwarding_at
                     )
 
+                if _previous_user_metrics and "stopped_speaking_at" in _previous_user_metrics:
+                    e2e_latency = (
+                        started_speaking_at - _previous_user_metrics["stopped_speaking_at"]
+                    )
+                    assistant_metrics["e2e_latency"] = e2e_latency
+                    current_span.set_attribute(trace_types.ATTR_E2E_LATENCY, e2e_latency)
+
+                if self._session._unanswered_user_metrics is _previous_user_metrics:
+                    self._session._unanswered_user_metrics = None
+
             msg = self._agent._chat_ctx.add_message(
                 role="assistant",
                 content=forwarded_text,
@@ -3148,6 +3165,17 @@ class AgentActivity(RecognitionHooks):
             if isinstance(tool, llm.RawFunctionTool | llm.FunctionTool)
             and tool.info.flags & ToolFlag.IGNORE_ON_ENTER
         ]
+
+    def _on_enter_user_metrics(self) -> llm.MetricsReport | None:
+        """The user turn still unanswered, when this speech comes from on_enter."""
+        on_enter_data = _OnEnterContextVar.get(None)
+        if (
+            on_enter_data is None
+            or on_enter_data.agent != self._agent
+            or on_enter_data.session != self._session
+        ):
+            return None
+        return self._session._unanswered_user_metrics
 
     @utils.log_exceptions(logger=logger)
     async def _pipeline_reply_task(
@@ -3395,6 +3423,7 @@ class AgentActivity(RecognitionHooks):
             self._agent._chat_ctx.insert(new_message)
             self._session._conversation_item_added(new_message)
             user_metrics = new_message.metrics
+            self._session._unanswered_user_metrics = user_metrics
 
         if speech_handle.interrupted:
             current_span.set_attribute(trace_types.ATTR_SPEECH_INTERRUPTED, True)
@@ -3596,6 +3625,9 @@ class AgentActivity(RecognitionHooks):
                 assistant_metrics["e2e_latency"] = e2e_latency
                 current_span.set_attribute(trace_types.ATTR_E2E_LATENCY, e2e_latency)
 
+            if self._session._unanswered_user_metrics is user_metrics:
+                self._session._unanswered_user_metrics = None
+
         current_span.set_attribute(trace_types.ATTR_SPEECH_INTERRUPTED, speech_handle.interrupted)
 
         forwarded_text = "".join(out.forwarded_text for out in segment_outputs)
@@ -3770,9 +3802,10 @@ class AgentActivity(RecognitionHooks):
                             if max_steps_reached or draining or model_settings.tool_choice == "none"
                             else "auto",
                         ),
-                        # in case the current reply only generated tools (no speech), re-use the current user_metrics for the next
-                        # tool response generation
-                        _previous_user_metrics=user_metrics if not forwarded_text else None,
+                        # the tool reply answers whatever user turn is still unanswered: this
+                        # one if the reply only generated tools, or the last turn of a
+                        # sub-conversation an inline AgentTask ran inside the tool
+                        _previous_user_metrics=self._session._unanswered_user_metrics,
                     ),
                     speech_handle=speech_handle,
                     name="AgentActivity.pipeline_reply",

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3104,31 +3104,33 @@ class AgentActivity(RecognitionHooks):
                 forwarded_text = ""
         current_span.set_attribute(trace_types.ATTR_RESPONSE_TEXT, forwarded_text)
 
-        if forwarded_text and add_to_chat_ctx:
-            assistant_metrics: llm.MetricsReport = {}
+        assistant_metrics: llm.MetricsReport = {}
 
-            if tts_gen_data and tts_gen_data.ttfb is not None:
-                assistant_metrics["tts_node_ttfb"] = tts_gen_data.ttfb
+        if tts_gen_data and tts_gen_data.ttfb is not None:
+            assistant_metrics["tts_node_ttfb"] = tts_gen_data.ttfb
 
-            if stopped_speaking_at and started_speaking_at:
-                assistant_metrics["started_speaking_at"] = started_speaking_at
-                assistant_metrics["stopped_speaking_at"] = stopped_speaking_at
+        if stopped_speaking_at and started_speaking_at:
+            assistant_metrics["started_speaking_at"] = started_speaking_at
+            assistant_metrics["stopped_speaking_at"] = stopped_speaking_at
 
-                if started_forwarding_at is not None:
-                    assistant_metrics["playback_latency"] = (
-                        started_speaking_at - started_forwarding_at
-                    )
+            if started_forwarding_at is not None:
+                assistant_metrics["playback_latency"] = started_speaking_at - started_forwarding_at
 
-                if _previous_user_metrics and "stopped_speaking_at" in _previous_user_metrics:
+            # the audio answers the borrowed user turn, stored or not, unless another speech
+            # reported it first
+            if (
+                _previous_user_metrics is not None
+                and self._session._unanswered_user_metrics is _previous_user_metrics
+            ):
+                if "stopped_speaking_at" in _previous_user_metrics:
                     e2e_latency = (
                         started_speaking_at - _previous_user_metrics["stopped_speaking_at"]
                     )
                     assistant_metrics["e2e_latency"] = e2e_latency
                     current_span.set_attribute(trace_types.ATTR_E2E_LATENCY, e2e_latency)
+                self._session._unanswered_user_metrics = None
 
-                if self._session._unanswered_user_metrics is _previous_user_metrics:
-                    self._session._unanswered_user_metrics = None
-
+        if forwarded_text and add_to_chat_ctx:
             msg = self._agent._chat_ctx.add_message(
                 role="assistant",
                 content=forwarded_text,
@@ -3418,11 +3420,15 @@ class AgentActivity(RecognitionHooks):
 
         # add new message to chat context if the speech is scheduled
 
+        # a reply to its own user message owns that turn; a tool reply or an on_enter reply
+        # borrows the unanswered one and keeps it only if no other speech reports it first
         user_metrics: llm.MetricsReport | None = _previous_user_metrics
+        owns_turn = False
         if new_message is not None and speech_handle.scheduled:
             self._agent._chat_ctx.insert(new_message)
             self._session._conversation_item_added(new_message)
             user_metrics = new_message.metrics
+            owns_turn = True
             self._session._unanswered_user_metrics = user_metrics
 
         if speech_handle.interrupted:
@@ -3619,6 +3625,9 @@ class AgentActivity(RecognitionHooks):
 
             if started_forwarding_at is not None:
                 assistant_metrics["playback_latency"] = started_speaking_at - started_forwarding_at
+
+            if not owns_turn and self._session._unanswered_user_metrics is not user_metrics:
+                user_metrics = None
 
             if user_metrics and "stopped_speaking_at" in user_metrics:
                 e2e_latency = started_speaking_at - user_metrics["stopped_speaking_at"]

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -905,14 +905,18 @@ class AgentActivity(RecognitionHooks):
                 @utils.log_exceptions(logger=logger)
                 async def _traceable_on_enter() -> None:
                     data = _OnEnterData(session=self._session, agent=self._agent)
+                    # the turn this agent was entered on; a turn the user commits while on_enter
+                    # runs is not its to decline
+                    entered_on = self._session._unanswered_user_metrics
                     try:
                         tk = _OnEnterContextVar.set(data)
                         await self._agent.on_enter()
                     finally:
                         _OnEnterContextVar.reset(tk)
-                        # an on_enter that returns without speaking has declined to answer the
-                        # user turn; speeches it created already took their copy
-                        self._session._unanswered_user_metrics = None
+                        # an on_enter that returns without speaking has declined the turn;
+                        # speeches it created already took their copy
+                        if self._session._unanswered_user_metrics is entered_on:
+                            self._session._unanswered_user_metrics = None
 
                 self._on_enter_task = task = self._create_speech_task(
                     _traceable_on_enter(), name="AgentTask_on_enter"

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -47,6 +47,7 @@ from ..utils.misc import is_given
 from ._utils import _set_participant_attributes
 from .agent import (
     Agent,
+    AgentTask,
     ModelSettings,
     _get_activity_task_info,
     _set_activity_task_info,
@@ -909,6 +910,9 @@ class AgentActivity(RecognitionHooks):
                         await self._agent.on_enter()
                     finally:
                         _OnEnterContextVar.reset(tk)
+                        # an on_enter that returns without speaking has declined to answer the
+                        # user turn; speeches it created already took their copy
+                        self._session._unanswered_user_metrics = None
 
                 self._on_enter_task = task = self._create_speech_task(
                     _traceable_on_enter(), name="AgentTask_on_enter"
@@ -1564,7 +1568,7 @@ class AgentActivity(RecognitionHooks):
             "speech_created",
             SpeechCreatedEvent(speech_handle=handle, user_initiated=True, source="say"),
         )
-        user_metrics = self._on_enter_user_metrics()
+        user_metrics = self._take_on_enter_user_metrics()
 
         if (
             self._rt_session is not None
@@ -1661,7 +1665,7 @@ class AgentActivity(RecognitionHooks):
             "speech_created",
             SpeechCreatedEvent(speech_handle=handle, user_initiated=True, source="generate_reply"),
         )
-        user_metrics = self._on_enter_user_metrics()
+        user_metrics = self._take_on_enter_user_metrics()
 
         if isinstance(self.llm, llm.RealtimeModel):
             self._create_speech_task(
@@ -3116,19 +3120,11 @@ class AgentActivity(RecognitionHooks):
             if started_forwarding_at is not None:
                 assistant_metrics["playback_latency"] = started_speaking_at - started_forwarding_at
 
-            # the audio answers the borrowed user turn, stored or not, unless another speech
-            # reported it first
-            if (
-                _previous_user_metrics is not None
-                and self._session._unanswered_user_metrics is _previous_user_metrics
-            ):
-                if "stopped_speaking_at" in _previous_user_metrics:
-                    e2e_latency = (
-                        started_speaking_at - _previous_user_metrics["stopped_speaking_at"]
-                    )
-                    assistant_metrics["e2e_latency"] = e2e_latency
-                    current_span.set_attribute(trace_types.ATTR_E2E_LATENCY, e2e_latency)
-                self._session._unanswered_user_metrics = None
+            # the audio answers the user turn, stored message or not
+            if _previous_user_metrics and "stopped_speaking_at" in _previous_user_metrics:
+                e2e_latency = started_speaking_at - _previous_user_metrics["stopped_speaking_at"]
+                assistant_metrics["e2e_latency"] = e2e_latency
+                current_span.set_attribute(trace_types.ATTR_E2E_LATENCY, e2e_latency)
 
         if forwarded_text and add_to_chat_ctx:
             msg = self._agent._chat_ctx.add_message(
@@ -3168,8 +3164,8 @@ class AgentActivity(RecognitionHooks):
             and tool.info.flags & ToolFlag.IGNORE_ON_ENTER
         ]
 
-    def _on_enter_user_metrics(self) -> llm.MetricsReport | None:
-        """The user turn still unanswered, when this speech comes from on_enter."""
+    def _take_on_enter_user_metrics(self) -> llm.MetricsReport | None:
+        """Claim the unanswered user turn for a speech created inside on_enter."""
         on_enter_data = _OnEnterContextVar.get(None)
         if (
             on_enter_data is None
@@ -3177,7 +3173,9 @@ class AgentActivity(RecognitionHooks):
             or on_enter_data.session != self._session
         ):
             return None
-        return self._session._unanswered_user_metrics
+        metrics = self._session._unanswered_user_metrics
+        self._session._unanswered_user_metrics = None
+        return metrics
 
     @utils.log_exceptions(logger=logger)
     async def _pipeline_reply_task(
@@ -3420,15 +3418,11 @@ class AgentActivity(RecognitionHooks):
 
         # add new message to chat context if the speech is scheduled
 
-        # a reply to its own user message owns that turn; a tool reply or an on_enter reply
-        # borrows the unanswered one and keeps it only if no other speech reports it first
         user_metrics: llm.MetricsReport | None = _previous_user_metrics
-        owns_turn = False
         if new_message is not None and speech_handle.scheduled:
             self._agent._chat_ctx.insert(new_message)
             self._session._conversation_item_added(new_message)
             user_metrics = new_message.metrics
-            owns_turn = True
             self._session._unanswered_user_metrics = user_metrics
 
         if speech_handle.interrupted:
@@ -3626,9 +3620,6 @@ class AgentActivity(RecognitionHooks):
             if started_forwarding_at is not None:
                 assistant_metrics["playback_latency"] = started_speaking_at - started_forwarding_at
 
-            if not owns_turn and self._session._unanswered_user_metrics is not user_metrics:
-                user_metrics = None
-
             if user_metrics and "stopped_speaking_at" in user_metrics:
                 e2e_latency = started_speaking_at - user_metrics["stopped_speaking_at"]
                 assistant_metrics["e2e_latency"] = e2e_latency
@@ -3723,6 +3714,9 @@ class AgentActivity(RecognitionHooks):
 
         # important: no agent output should be used after this point
 
+        # the reply chain goes on through a tool reply, a handoff, or an inline task handing
+        # back to the tool that awaited it; otherwise it ends here and nothing answers the turn
+        chain_continues = False
         if len(tool_output.output) > 0:
             max_steps_reached = speech_handle.num_steps >= self._session.options.max_tool_steps + 1
 
@@ -3765,6 +3759,12 @@ class AgentActivity(RecognitionHooks):
             if fnc_executed_ev._handoff_required and new_agent_task and not ignore_task_switch:
                 self._session.update_agent(new_agent_task)
                 draining = True
+
+            chain_continues = (
+                fnc_executed_ev.has_tool_reply
+                or self._session._agent is not self._agent
+                or (isinstance(self._agent, AgentTask) and self._agent.done())
+            )
 
             tool_messages = new_calls + new_fnc_outputs
             # commit now so results survive even if the reply speech never runs (#3702)
@@ -3823,6 +3823,9 @@ class AgentActivity(RecognitionHooks):
                 self._schedule_speech(
                     speech_handle, SpeechHandle.SPEECH_PRIORITY_NORMAL, force=True
                 )
+
+        if not chain_continues:
+            self._session._unanswered_user_metrics = None
 
     @utils.log_exceptions(logger=logger)
     async def _realtime_reply_task(

--- a/livekit-agents/livekit/agents/voice/agent_session.py
+++ b/livekit-agents/livekit/agents/voice/agent_session.py
@@ -698,6 +698,8 @@ class AgentSession(rtc.EventEmitter[EventTypes], Generic[Userdata_T]):
         self._foreground_guards: set[asyncio.Future[None]] = set()
         # TODO(theomonnom): need a better way to expose early assistant metrics
         self._early_assistant_metrics: MetricsReport | None = None
+        # the latest user turn no agent speech has reported e2e_latency for yet
+        self._unanswered_user_metrics: MetricsReport | None = None
 
         # trace
         self._user_speaking_span: trace.Span | None = None

--- a/tests/fake_vad.py
+++ b/tests/fake_vad.py
@@ -27,6 +27,9 @@ class FakeVAD(VAD):
         self._fake_user_speeches = fake_user_speeches
         self._min_speech_duration = min_speech_duration
         self._min_silence_duration = min_silence_duration
+        # one clock for every stream: a handoff opens a new stream mid-run, timed against
+        # the same origin the fake STT uses
+        self._start_time: float | None = None
 
     def stream(self) -> VADStream:
         return FakeVADStream(self)
@@ -42,13 +45,16 @@ class FakeVADStream(VADStream):
         if not self._vad._fake_user_speeches:
             return
 
-        async for input_frame in self._input_ch:
-            if isinstance(input_frame, rtc.AudioFrame):
-                break
-        else:
-            return
-
-        start_time = time.perf_counter()
+        if self._vad._start_time is None:
+            # the clock starts with the first frame; the fake input pushes one burst, so a
+            # later stream must not wait for another
+            async for input_frame in self._input_ch:
+                if isinstance(input_frame, rtc.AudioFrame):
+                    break
+            else:
+                return
+            self._vad._start_time = time.perf_counter()
+        start_time = self._vad._start_time
 
         def current_time() -> float:
             return time.perf_counter() - start_time
@@ -56,6 +62,9 @@ class FakeVADStream(VADStream):
         for fake_speech in self._vad._fake_user_speeches:
             next_start_of_speech_time = fake_speech.start_time + self._vad._min_speech_duration
             next_end_of_speech_time = fake_speech.end_time + self._vad._min_silence_duration
+
+            if current_time() >= next_end_of_speech_time:
+                continue  # already over before this stream opened
 
             if current_time() < next_start_of_speech_time:
                 await asyncio.sleep(next_start_of_speech_time - current_time())

--- a/tests/test_e2e_latency_handoff.py
+++ b/tests/test_e2e_latency_handoff.py
@@ -525,3 +525,39 @@ async def test_reply_after_awaited_task_in_on_enter_answers_the_last_turn() -> N
     _assert_answers(question, go)
     assert thanks.text_content == "thanks Bob"
     _assert_answers(thanks, bob)
+
+
+async def test_turn_committed_during_on_enter_survives_its_end() -> None:
+    """The user speaks while on_enter still runs; that turn's tool-only handoff keeps its latency."""
+
+    class Slow(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="slow")
+
+        async def on_enter(self) -> None:
+            await asyncio.sleep(3.0)
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> Agent:
+            return Greeter()
+
+    class Router(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="router")
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> Agent:
+            return Slow()
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "go")
+    actions.add_llm("", tool_calls=[HANDOFF_CALL])
+    actions.add_user_speech(3.5, 4.0, "support please")
+    actions.add_llm("", tool_calls=[HANDOFF_CALL])
+    actions.add_llm("hello from the greeter", input="greet")
+    actions.add_tts(1.0)
+
+    messages = await _messages(actions, Router(), drain_delay=4.0)
+    _go, support = _by_role(messages, "user")
+    (greeting,) = _by_role(messages, "assistant")
+    _assert_answers(greeting, support)

--- a/tests/test_e2e_latency_handoff.py
+++ b/tests/test_e2e_latency_handoff.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from livekit.agents import Agent, AgentTask, RunContext, function_tool
+from livekit.agents.llm import ChatMessage, FunctionToolCall
+
+from .fake_session import FakeActions, create_session, run_session
+
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
+
+HANDOFF_CALL = FunctionToolCall(name="handoff", arguments="{}", call_id="call_1")
+
+
+class Greeter(Agent):
+    def __init__(self) -> None:
+        super().__init__(instructions="greeter")
+
+    async def on_enter(self) -> None:
+        self.session.generate_reply(instructions="greet")
+
+
+async def _messages(
+    actions: FakeActions, agent: Agent, *, drain_delay: float = 2.0
+) -> list[ChatMessage]:
+    session = create_session(actions)
+    events: list = []
+    session.on("conversation_item_added", events.append)
+    await run_session(session, agent, drain_delay=drain_delay)
+    return [ev.item for ev in events if ev.item.type == "message"]
+
+
+def _by_role(messages: list[ChatMessage], role: str) -> list[ChatMessage]:
+    return [m for m in messages if m.role == role]
+
+
+def _assert_answers(assistant: ChatMessage, user: ChatMessage) -> None:
+    assert assistant.metrics["e2e_latency"] == pytest.approx(
+        assistant.metrics["started_speaking_at"] - user.metrics["stopped_speaking_at"]
+    )
+
+
+async def test_handoff_reply_reports_e2e_latency() -> None:
+    """A tool returning the next agent: its on_enter reply answers the user turn."""
+
+    class Router(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="router")
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> Agent:
+            return Greeter()
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "go")
+    actions.add_llm("", tool_calls=[HANDOFF_CALL])
+    actions.add_llm("hello from the greeter", input="greet")
+    actions.add_tts(1.0)
+
+    messages = await _messages(actions, Router())
+    (user,) = _by_role(messages, "user")
+    (greeting,) = _by_role(messages, "assistant")
+    assert greeting.text_content == "hello from the greeter"
+    _assert_answers(greeting, user)
+
+
+async def test_update_agent_from_tool_reports_e2e_latency() -> None:
+    """A tool calling update_agent itself is the same handoff."""
+
+    class Router(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="router")
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> None:
+            self.session.update_agent(Greeter())
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "go")
+    actions.add_llm("", tool_calls=[HANDOFF_CALL])
+    actions.add_llm("hello from the greeter", input="greet")
+    actions.add_tts(1.0)
+
+    messages = await _messages(actions, Router())
+    (user,) = _by_role(messages, "user")
+    (greeting,) = _by_role(messages, "assistant")
+    _assert_answers(greeting, user)
+
+
+async def test_speech_before_handoff_answers_the_turn() -> None:
+    """The LLM speaks and hands off in one step: the speech answers, the greeting does not."""
+
+    class Router(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="router")
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> Agent:
+            return Greeter()
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "go")
+    actions.add_llm("let me transfer you", tool_calls=[HANDOFF_CALL])
+    actions.add_tts(1.0)
+    actions.add_llm("hello from the greeter", input="greet")
+    actions.add_tts(1.0)
+
+    messages = await _messages(actions, Router())
+    (user,) = _by_role(messages, "user")
+    transfer, greeting = _by_role(messages, "assistant")
+    assert transfer.text_content == "let me transfer you"
+    _assert_answers(transfer, user)
+    assert "e2e_latency" not in greeting.metrics
+
+
+async def test_tool_reply_before_handoff_answers_the_turn() -> None:
+    """A tool returning (agent, text): the tool reply answers, the greeting does not."""
+
+    class Router(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="router")
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> tuple[Agent, str]:
+            return Greeter(), "transferring"
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "go")
+    actions.add_llm("", tool_calls=[HANDOFF_CALL])
+    actions.add_llm("transferring you now", input="transferring")
+    actions.add_tts(1.0)
+    actions.add_llm("hello from the greeter", input="greet")
+    actions.add_tts(1.0)
+
+    messages = await _messages(actions, Router())
+    (user,) = _by_role(messages, "user")
+    tool_reply, greeting = _by_role(messages, "assistant")
+    assert tool_reply.text_content == "transferring you now"
+    _assert_answers(tool_reply, user)
+    assert "e2e_latency" not in greeting.metrics
+
+
+async def test_say_in_on_enter_answers_the_turn() -> None:
+    """A say() greeting is the first thing the user hears; the reply after it is not."""
+
+    class SayGreeter(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="say greeter")
+
+        async def on_enter(self) -> None:
+            await self.session.say("welcome")
+            self.session.generate_reply(instructions="greet")
+
+    class Router(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="router")
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> Agent:
+            return SayGreeter()
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "go")
+    actions.add_llm("", tool_calls=[HANDOFF_CALL])
+    actions.add_tts(1.0, input="welcome")
+    actions.add_llm("how can I help", input="greet")
+    actions.add_tts(1.0)
+
+    messages = await _messages(actions, Router())
+    (user,) = _by_role(messages, "user")
+    welcome, reply = _by_role(messages, "assistant")
+    assert welcome.text_content == "welcome"
+    _assert_answers(welcome, user)
+    assert "e2e_latency" not in reply.metrics
+
+
+async def test_nested_handoff_in_on_enter_reports_e2e_latency() -> None:
+    """on_enter awaits an AgentTask: the task's own on_enter reply answers the user turn."""
+
+    class AskName(AgentTask[None]):
+        def __init__(self) -> None:
+            super().__init__(instructions="ask name")
+
+        async def on_enter(self) -> None:
+            self.session.generate_reply(instructions="ask_name")
+
+        @function_tool
+        async def record_name(self, ctx: RunContext, name: str) -> str:
+            """Called when the user provides their name."""
+            self.complete(None)
+            return "recorded"
+
+    class Survey(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="survey")
+
+        async def on_enter(self) -> None:
+            await AskName()
+
+    class Router(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="router")
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> Agent:
+            return Survey()
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "go")
+    actions.add_llm("", tool_calls=[HANDOFF_CALL])
+    actions.add_llm("what is your name?", input="ask_name")
+    actions.add_tts(1.0)
+    actions.add_user_speech(6.0, 7.0, "Bob")
+    actions.add_llm(
+        "",
+        tool_calls=[
+            FunctionToolCall(name="record_name", arguments='{"name": "Bob"}', call_id="c2")
+        ],
+    )
+
+    messages = await _messages(actions, Router())
+    go, _bob = _by_role(messages, "user")
+    (question,) = _by_role(messages, "assistant")
+    assert question.text_content == "what is your name?"
+    _assert_answers(question, go)
+
+
+async def test_task_spawned_in_on_enter_reports_e2e_latency() -> None:
+    """A speech from a task on_enter spawned without awaiting still runs in on_enter's context."""
+
+    class LateGreeter(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="late greeter")
+            self._task: asyncio.Task[None] | None = None
+
+        async def on_enter(self) -> None:
+            async def _greet_later() -> None:
+                await asyncio.sleep(0.5)
+                self.session.generate_reply(instructions="greet")
+
+            self._task = asyncio.create_task(_greet_later())
+
+    class Router(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="router")
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> Agent:
+            return LateGreeter()
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "go")
+    actions.add_llm("", tool_calls=[HANDOFF_CALL])
+    actions.add_llm("hello from the greeter", input="greet")
+    actions.add_tts(1.0)
+
+    messages = await _messages(actions, Router())
+    (user,) = _by_role(messages, "user")
+    (greeting,) = _by_role(messages, "assistant")
+    _assert_answers(greeting, user)
+
+
+async def test_new_user_turn_supersedes_the_handoff_turn() -> None:
+    """A user turn arriving before on_enter speaks is the one answered next; a late speech answers nothing."""
+
+    class LateGreeter(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="late greeter")
+            self._task: asyncio.Task[None] | None = None
+
+        async def on_enter(self) -> None:
+            async def _greet_later() -> None:
+                await asyncio.sleep(4.0)
+                self.session.generate_reply(instructions="greet")
+
+            self._task = asyncio.create_task(_greet_later())
+
+    class Router(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="router")
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> Agent:
+            return LateGreeter()
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "go")
+    actions.add_llm("", tool_calls=[HANDOFF_CALL])
+    actions.add_user_speech(4.0, 4.5, "hello again")
+    actions.add_llm("hi again")
+    actions.add_tts(1.0)
+    actions.add_llm("hello from the greeter", input="greet")
+    actions.add_tts(1.0)
+
+    messages = await _messages(actions, Router(), drain_delay=4.0)
+    _go, again = _by_role(messages, "user")
+    reply, greeting = _by_role(messages, "assistant")
+    assert reply.text_content == "hi again"
+    _assert_answers(reply, again)
+    assert greeting.text_content == "hello from the greeter"
+    assert "e2e_latency" not in greeting.metrics
+
+
+async def test_inline_task_in_tool_answers_each_turn() -> None:
+    """user -> tool -> await task -> task asks -> user answers -> task done -> tool reply."""
+
+    class AskEmail(AgentTask[str]):
+        def __init__(self) -> None:
+            super().__init__(instructions="ask email")
+
+        async def on_enter(self) -> None:
+            self.session.generate_reply(instructions="ask_email")
+
+        @function_tool
+        async def record_email(self, ctx: RunContext, email: str) -> None:
+            """Called when the user provides their email."""
+            self.complete(email)
+
+    class Booker(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="booker")
+
+        @function_tool
+        async def book(self, ctx: RunContext) -> str:
+            """Book a room."""
+            email = await AskEmail()
+            return f"booked for {email}"
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "book a room")
+    actions.add_llm("", tool_calls=[FunctionToolCall(name="book", arguments="{}", call_id="c1")])
+    actions.add_llm("what is your email?", input="ask_email")
+    actions.add_tts(1.0)
+    actions.add_user_speech(6.0, 7.0, "a@b.com")
+    actions.add_llm(
+        "",
+        tool_calls=[
+            FunctionToolCall(name="record_email", arguments='{"email": "a@b.com"}', call_id="c2")
+        ],
+    )
+    actions.add_llm("your room is booked", input="booked for a@b.com")
+    actions.add_tts(1.0)
+
+    messages = await _messages(actions, Booker(), drain_delay=4.0)
+    book, email = _by_role(messages, "user")
+    question, confirmation = _by_role(messages, "assistant")
+    assert question.text_content == "what is your email?"
+    _assert_answers(question, book)
+    assert confirmation.text_content == "your room is booked"
+    _assert_answers(confirmation, email)

--- a/tests/test_e2e_latency_handoff.py
+++ b/tests/test_e2e_latency_handoff.py
@@ -4,7 +4,7 @@ import asyncio
 
 import pytest
 
-from livekit.agents import Agent, AgentTask, RunContext, function_tool
+from livekit.agents import Agent, AgentSession, AgentTask, RunContext, function_tool
 from livekit.agents.llm import ChatMessage, FunctionToolCall
 
 from .fake_session import FakeActions, create_session, run_session
@@ -293,8 +293,8 @@ async def test_nested_handoff_in_on_enter_reports_e2e_latency() -> None:
     _assert_answers(question, go)
 
 
-async def test_task_spawned_in_on_enter_reports_e2e_latency() -> None:
-    """A speech from a task on_enter spawned without awaiting still runs in on_enter's context."""
+async def test_task_spawned_in_on_enter_speaks_after_the_turn() -> None:
+    """on_enter returned without speaking; a speech from a task it spawned is a new utterance."""
 
     class LateGreeter(Agent):
         def __init__(self) -> None:
@@ -323,9 +323,8 @@ async def test_task_spawned_in_on_enter_reports_e2e_latency() -> None:
     actions.add_tts(1.0)
 
     messages = await _messages(actions, Router())
-    (user,) = _by_role(messages, "user")
     (greeting,) = _by_role(messages, "assistant")
-    _assert_answers(greeting, user)
+    assert "e2e_latency" not in greeting.metrics
 
 
 async def test_new_user_turn_supersedes_the_handoff_turn() -> None:
@@ -416,3 +415,113 @@ async def test_inline_task_in_tool_answers_each_turn() -> None:
     _assert_answers(question, book)
     assert confirmation.text_content == "your room is booked"
     _assert_answers(confirmation, email)
+
+
+def _handoff_later(session: AgentSession, delay: float) -> None:
+    """A handoff nothing in the conversation caused, like a timer or an external event."""
+    asyncio.get_event_loop().call_later(delay, session.update_agent, Greeter())
+
+
+async def test_silent_tool_ends_the_turn() -> None:
+    """A tool with no reply and no handoff ends the chain; a later unrelated handoff answers nothing."""
+
+    class Router(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="router")
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> None:
+            _handoff_later(self.session, 2.0)
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "go")
+    actions.add_llm("", tool_calls=[HANDOFF_CALL])
+    actions.add_llm("hello from the greeter", input="greet")
+    actions.add_tts(1.0)
+
+    messages = await _messages(actions, Router(), drain_delay=4.0)
+    (greeting,) = _by_role(messages, "assistant")
+    assert "e2e_latency" not in greeting.metrics
+
+
+async def test_silent_on_enter_ends_the_turn() -> None:
+    """An on_enter that returns without speaking declines the turn; a later handoff answers nothing."""
+
+    class Silent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="silent")
+
+        async def on_enter(self) -> None:
+            _handoff_later(self.session, 2.0)
+
+    class Router(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="router")
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> Agent:
+            return Silent()
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "go")
+    actions.add_llm("", tool_calls=[HANDOFF_CALL])
+    actions.add_llm("hello from the greeter", input="greet")
+    actions.add_tts(1.0)
+
+    messages = await _messages(actions, Router(), drain_delay=4.0)
+    (greeting,) = _by_role(messages, "assistant")
+    assert "e2e_latency" not in greeting.metrics
+
+
+async def test_reply_after_awaited_task_in_on_enter_answers_the_last_turn() -> None:
+    """on_enter awaits a task, then replies: the reply answers the turn the task left open."""
+
+    class AskName(AgentTask[str]):
+        def __init__(self) -> None:
+            super().__init__(instructions="ask name")
+
+        async def on_enter(self) -> None:
+            self.session.generate_reply(instructions="ask_name")
+
+        @function_tool
+        async def record_name(self, ctx: RunContext, name: str) -> None:
+            """Called when the user provides their name."""
+            self.complete(name)
+
+    class Survey(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="survey")
+
+        async def on_enter(self) -> None:
+            name = await AskName()
+            self.session.generate_reply(instructions=f"thank {name}")
+
+    class Router(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="router")
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> Agent:
+            return Survey()
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "go")
+    actions.add_llm("", tool_calls=[HANDOFF_CALL])
+    actions.add_llm("what is your name?", input="ask_name")
+    actions.add_tts(1.0)
+    actions.add_user_speech(6.0, 7.0, "Bob")
+    actions.add_llm(
+        "",
+        tool_calls=[
+            FunctionToolCall(name="record_name", arguments='{"name": "Bob"}', call_id="c2")
+        ],
+    )
+    actions.add_llm("thanks Bob", input="thank Bob")
+    actions.add_tts(1.0)
+
+    messages = await _messages(actions, Router(), drain_delay=4.0)
+    go, bob = _by_role(messages, "user")
+    question, thanks = _by_role(messages, "assistant")
+    _assert_answers(question, go)
+    assert thanks.text_content == "thanks Bob"
+    _assert_answers(thanks, bob)

--- a/tests/test_e2e_latency_handoff.py
+++ b/tests/test_e2e_latency_handoff.py
@@ -176,6 +176,72 @@ async def test_say_in_on_enter_answers_the_turn() -> None:
     assert "e2e_latency" not in reply.metrics
 
 
+async def test_concurrent_on_enter_speeches_answer_once() -> None:
+    """say() and generate_reply() queued together from on_enter: only the first reports."""
+
+    class DoubleGreeter(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="double greeter")
+
+        async def on_enter(self) -> None:
+            self.session.say("welcome")
+            self.session.generate_reply(instructions="greet")
+
+    class Router(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="router")
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> Agent:
+            return DoubleGreeter()
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "go")
+    actions.add_llm("", tool_calls=[HANDOFF_CALL])
+    actions.add_tts(1.0, input="welcome")
+    actions.add_llm("how can I help", input="greet")
+    actions.add_tts(1.0)
+
+    messages = await _messages(actions, Router())
+    (user,) = _by_role(messages, "user")
+    welcome, reply = _by_role(messages, "assistant")
+    assert welcome.text_content == "welcome"
+    _assert_answers(welcome, user)
+    assert "e2e_latency" not in reply.metrics
+
+
+async def test_unstored_say_in_on_enter_still_answers_the_turn() -> None:
+    """say(add_to_chat_ctx=False) plays the answer; the reply after it reports nothing."""
+
+    class QuietGreeter(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="quiet greeter")
+
+        async def on_enter(self) -> None:
+            await self.session.say("welcome", add_to_chat_ctx=False)
+            self.session.generate_reply(instructions="greet")
+
+    class Router(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions="router")
+
+        @function_tool
+        async def handoff(self, ctx: RunContext) -> Agent:
+            return QuietGreeter()
+
+    actions = FakeActions()
+    actions.add_user_speech(0.5, 2.5, "go")
+    actions.add_llm("", tool_calls=[HANDOFF_CALL])
+    actions.add_tts(1.0, input="welcome")
+    actions.add_llm("how can I help", input="greet")
+    actions.add_tts(1.0)
+
+    messages = await _messages(actions, Router())
+    (reply,) = _by_role(messages, "assistant")
+    assert reply.text_content == "how can I help"
+    assert "e2e_latency" not in reply.metrics
+
+
 async def test_nested_handoff_in_on_enter_reports_e2e_latency() -> None:
     """on_enter awaits an AgentTask: the task's own on_enter reply answers the user turn."""
 


### PR DESCRIPTION
**Problem:** `e2e_latency` is computed from the user turn's metrics held in a local of the reply task, so the first reply after an agent handoff never gets it, and a tool reply after an inline `AgentTask` reports the whole sub-conversation as one latency. The slowest turns of a call are the ones missing from the message, the `lk.e2e_latency` span attribute, and the OTel histogram.

**Fix:** The session keeps the latest user turn no speech has answered, set where the reply task commits the user message. The tool reply reads it, a `say()` or `generate_reply()` created inside `on_enter` claims it, and it ends when a speech reports it, when the reply chain ends without a tool reply or a handoff, or when an `on_enter` returns without speaking.

Closes #7157. Supersedes #7161.

<details>
<summary>Context for reviewing and coding agents</summary>

> **How to see it**
>
> `tests/test_e2e_latency_handoff.py` has 15 cases; most fail on `main`. Each asserts `e2e_latency == started_speaking_at - user.stopped_speaking_at` on the assistant message that answers a turn, and its absence on the message that does not. The inline-task case is the flow user -> tool -> `await AgentTask` -> the task asks -> the user answers -> the task completes -> tool reply: the question carries the first turn's latency and the tool reply carries the answer turn's.
>
> **Which speeches take the pending turn**
>
> The tool reply in `_pipeline_reply_task_impl` reads it in place of the threaded `user_metrics if not forwarded_text else None`. The two are equal on the paths `main` covers, since a step that spoke has already cleared it. `say()` and `_generate_reply()` claim it at creation, only under the existing `_OnEnterContextVar` gate, so a nested `AgentTask` awaited from `on_enter` claims it in its own `on_enter`, and a reply created after that await claims whatever turn the task left open. A `generate_reply()` outside `on_enter`, such as an inactivity nudge or a tool's background task, never reads it. The realtime path reports nothing, as on `main`.
>
> **When the turn ends unanswered**
>
> Three places: the report block of the speech that owns it, by identity, so an interrupted reply leaves it for the next speech; the end of `_pipeline_reply_task_impl` when no tool reply follows, the session's agent is unchanged, and the agent is not an `AgentTask` that just completed; and the `finally` of `on_enter`, for the turn that was pending when `on_enter` started, so a turn the user commits while `on_enter` runs stays pending for its own reply chain. The `AgentTask.done()` check exists because `complete()` only resolves a future and the switch back to the awaiting tool happens later, so the inner activity's chain end must not drop the turn the outer tool reply will answer.
>
> **Why a session field and not the task-local ContextVar of #7161**
>
> The value has to cross activities. An `on_enter` task has no speech handle, and an inline task's `on_enter` runs while the outer tool is still awaiting, so neither a handle attribute nor the outer task's context reaches it. #7161 also carried the value unconditionally, so an LLM that spoke before the handoff call produced two `e2e_latency` values for one user turn, and consumed it in any `_generate_reply`, so a `say()` greeting left it for a later unrelated reply.
>
> **Why a speech spawned from `on_enter` that speaks later reports nothing**
>
> Once `on_enter` returns without speaking, the agent has declined the turn. A speech from a task it spawned is a new utterance, and the `on_enter` end clear is what keeps a handoff nothing in the conversation caused from reporting a latency from minutes earlier.
>
> **Test harness change**
>
> `FakeVAD` restarted its clock per stream, and only the first stream ever saw an audio frame, so a spoken turn after a handoff had no timing anchors in any test. It now shares one clock across streams and waits for a frame only once. The 19 unit modules that use it pass unchanged.

</details>
