### PR TITLE
docs: fix overridden spelling in agent comment

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -311,8 +311,8 @@ class Agent:
             self._expressive = expressive
 
     # -- Pipeline nodes --
-    # They can all be overriden by subclasses, by default they use the STT/LLM/TTS specified in the
-    # constructor of the VoiceAgent
+    # They can all be overridden by subclasses. By default, they use the STT/LLM/TTS
+    # specified in the constructor of the VoiceAgent
 
     async def on_enter(self) -> None:
         """Called when the task is entered"""


### PR DESCRIPTION
The pipeline node comment uses "overriden", which is a misspelling of "overridden". This updates the comment and wraps the line to keep it within the project formatting limit.

Validation:
- ruff check livekit-agents/livekit/agents/voice/agent.py
- ruff format --check livekit-agents/livekit/agents/voice/agent.py
- git diff --check