### PR TITLE
fix(openai): support gpt-5.6 reasoning_effort with function tools

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/llm.py
@@ -40,6 +40,7 @@ from openai.types import ReasoningEffort
 from openai.types.chat import ChatCompletionToolChoiceOptionParam, completion_create_params
 
 from .models import (
+    _REASONING_EFFORT_NONE_MODELS,
     CerebrasChatModels,
     ChatModels,
     CometAPIChatModels,
@@ -58,6 +59,11 @@ from .models import (
 from .utils import AsyncAzureADTokenProvider
 
 lk_oai_debug = int(os.getenv("LK_OPENAI_DEBUG", 0))
+
+# models that reject any reasoning_effort value but "none" once function tools are attached
+_REASONING_EFFORT_TOOL_REQUIRES_NONE_MODELS: frozenset[str] = frozenset(
+    {"gpt-5.6", "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"}
+)
 
 Verbosity = Literal["low", "medium", "high"]
 PromptCacheRetention = Literal["in_memory", "24h"]
@@ -124,7 +130,7 @@ class LLM(llm.LLM):
         super().__init__()
 
         if not is_given(reasoning_effort) and _supports_reasoning_effort(model):
-            if model in ["gpt-5.1", "gpt-5.2", "gpt-5.4", "gpt-5.4-mini"]:
+            if model in _REASONING_EFFORT_NONE_MODELS:
                 reasoning_effort = "none"
             else:
                 reasoning_effort = "minimal"
@@ -1024,6 +1030,9 @@ class LLM(llm.LLM):
 
         if is_given(response_format):
             extra["response_format"] = llm_utils.to_openai_response_format(response_format)  # type: ignore
+
+        if tools and self._opts.model in _REASONING_EFFORT_TOOL_REQUIRES_NONE_MODELS:
+            extra["reasoning_effort"] = "none"
 
         return LLMStream(
             self,

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/models.py
@@ -20,6 +20,10 @@ TTSVoices = Literal[
 ]
 DalleModels = Literal["dall-e-2", "dall-e-3"]
 ChatModels = Literal[
+    "gpt-5.6",
+    "gpt-5.6-luna",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
     "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
@@ -291,6 +295,10 @@ SambaNovaChatModels = Literal[
 
 def _supports_reasoning_effort(model: ChatModels | str) -> bool:
     return model in [
+        "gpt-5.6",
+        "gpt-5.6-luna",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
         "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -300,6 +308,22 @@ def _supports_reasoning_effort(model: ChatModels | str) -> bool:
         "gpt-5-mini",
         "gpt-5-nano",
     ]
+
+
+# Lowest tier these accept is "none"; everything else in _supports_reasoning_effort falls back
+# to "minimal", which the gpt-5.6 family rejects outright.
+_REASONING_EFFORT_NONE_MODELS: frozenset[str] = frozenset(
+    {
+        "gpt-5.6",
+        "gpt-5.6-luna",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.2",
+        "gpt-5.1",
+    }
+)
 
 
 @dataclass

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/responses/llm.py
@@ -44,7 +44,7 @@ from openai.types.responses.response_stream_event import ResponseStreamEvent
 from openai.types.shared_params import ResponsesModel
 
 from ..log import logger
-from ..models import _supports_reasoning_effort
+from ..models import _REASONING_EFFORT_NONE_MODELS, _supports_reasoning_effort
 from ..tools import OpenAITool
 
 ServiceTier = Literal["auto", "default", "flex", "scale", "priority"]
@@ -242,7 +242,7 @@ class LLM(llm.LLM):
         super().__init__()
 
         if not is_given(reasoning) and _supports_reasoning_effort(model):
-            if model in ["gpt-5.1", "gpt-5.2", "gpt-5.4", "gpt-5.4-mini"]:
+            if model in _REASONING_EFFORT_NONE_MODELS:
                 reasoning = Reasoning(effort="none")
             else:
                 reasoning = Reasoning(effort="minimal")


### PR DESCRIPTION
## Problem

`gpt-5.6`, `gpt-5.6-luna`, `gpt-5.6-sol`, and `gpt-5.6-terra` aren't in `ChatModels` or
`_supports_reasoning_effort()`, so the plugin doesn't recognize them as reasoning models at all.

This causes two independent 400s from OpenAI. First, an unspecified `reasoning_effort` falls
through to the `"minimal"` default, which this family rejects outright, tools or not:

Unsupported value: 'reasoning_effort' does not support 'minimal' with this model.
Supported values are: 'none', 'low', 'medium', 'high', 'xhigh'.

Second, once function tools are attached, gpt-5.6 requires `reasoning_effort` to be explicitly
`"none"` — omitting the parameter also 400s, unlike gpt-5.2/gpt-5.4, which just need it absent:

Function tools with reasoning_effort are not supported for gpt-5.6-luna in
/v1/chat/completions. To use function tools, use /v1/responses or set
reasoning_effort to 'none'.

## Changes

- `models.py`: register the 4 gpt-5.6 variants in `ChatModels` and `_supports_reasoning_effort`;
  add `_REASONING_EFFORT_NONE_MODELS`, the set of models whose correct default is `"none"`.
- `llm.py`: use `_REASONING_EFFORT_NONE_MODELS` for default selection (previously a hardcoded
  list missing gpt-5.6); add `_REASONING_EFFORT_TOOL_REQUIRES_NONE_MODELS` and force
  `reasoning_effort="none"` at request time when tools are attached, scoped to gpt-5.6 only.
- `responses/llm.py`: same default-selection fix — the Responses API already accepts tools with
  any `reasoning_effort` value, verified live, so no coercion is needed there.

## Testing

Live against the OpenAI API across all 8 affected models (gpt-5.1, gpt-5.2, gpt-5.4,
gpt-5.4-mini, and all 4 gpt-5.6 variants), with function tools attached, both with no
`reasoning_effort` set and with an explicit override — 16/16 passing. Confirmed
`_REASONING_EFFORT_TOOL_REQUIRES_NONE_MODELS` contains only the 4 gpt-5.6 models by inspecting
it directly at runtime; gpt-5.1/5.2/5.4/5.4-mini are unaffected.


<img width="951" height="63" alt="Screenshot 2026-09-08 at 3 05 55 PM" src="https://github.com/user-attachments/assets/411991aa-98ef-4e6f-8afb-987799d3e811" />
