### PR TITLE
fix(google): preserve FunctionTool schemas for text API

### DIFF
--- a/livekit-agents/livekit/agents/llm/_provider_format/google.py
+++ b/livekit-agents/livekit/agents/llm/_provider_format/google.py
@@ -154,16 +154,20 @@ def to_fnc_ctx(
             tools.append(schema)
 
         elif isinstance(tool, llm.FunctionTool):
-            from livekit.plugins.google.utils import _GeminiJsonSchema
-
             fnc = llm.utils.build_legacy_openai_schema(tool, internally_tagged=True)
-            json_schema = _GeminiJsonSchema(fnc["parameters"]).simplify()
-
             schema = {
                 "name": fnc["name"],
                 "description": fnc["description"],
-                "parameters": json_schema or None,
             }
+            if use_parameters_json_schema:
+                schema["parameters_json_schema"] = fnc["parameters"]
+            else:
+                # Gemini Live doesn't support parameters_json_schema, use the simplified JSON Schema instead
+                # see: https://github.com/googleapis/python-genai/issues/1147
+                from livekit.plugins.google.utils import _GeminiJsonSchema
+
+                schema["parameters"] = _GeminiJsonSchema(fnc["parameters"]).simplify() or None
+
             if tool_behavior is not None:
                 schema["behavior"] = tool_behavior
             tools.append(schema)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -207,6 +207,22 @@ class TestToolContext:
         }
         assert "type" not in chat_tools[0]["function"]
 
+    def test_google_function_tool_uses_full_schema_for_text_api(self):
+        @function_tool
+        async def save_contact(fields: dict[str, str]) -> None:
+            """Save contact fields."""
+
+        ctx = ToolContext([save_contact])
+
+        text_tools = ctx.parse_function_tools("google")
+        text_fields = text_tools[0]["parameters_json_schema"]["properties"]["fields"]
+        assert text_fields["additionalProperties"] == {"type": "string"}
+
+        live_tools = ctx.parse_function_tools("google", use_parameters_json_schema=False)
+        live_fields = live_tools[0]["parameters"]["properties"]["fields"]
+        assert "parameters_json_schema" not in live_tools[0]
+        assert "additionalProperties" not in live_fields
+
     def test_update_tools_changes_equality(self):
         ctx1 = ToolContext([mock_tool_1])
         ctx2 = ToolContext([mock_tool_1])


### PR DESCRIPTION
## Summary

Fixes #7170.

Google text requests now emit a `FunctionTool`'s complete JSON Schema through `parameters_json_schema`, preserving `additionalProperties` for free-form object parameters. Google Live requests continue to use the existing simplified `parameters` representation because that API does not support `parameters_json_schema`.

## Verification

- `uv run --frozen pytest tests/test_tools.py tests/test_schema_gemini.py -q` — 119 passed
- `uv run --frozen ruff check livekit-agents/livekit/agents/llm/_provider_format/google.py tests/test_tools.py`
- `uv run --frozen ruff format --check livekit-agents/livekit/agents/llm/_provider_format/google.py tests/test_tools.py`
- `git diff --check`
- `create_tools_config` validation confirms the generated `FunctionDeclaration` retains the nested `additionalProperties` schema