### PR TITLE
fix(hotel_receptionist): give the room-booking flow an exit when no card is taken

### DIFF
--- a/examples/hotel_receptionist/book_room.py
+++ b/examples/hotel_receptionist/book_room.py
@@ -248,7 +248,13 @@ class BookRoomTask(AgentTask[RoomBooking]):
     @function_tool()
     async def open_credit_card_dialog(self) -> str:
         """Open the credit-card dialog. It collects the card number, expiry, security code, and cardholder name from the caller in one focused step."""
-        card = await GetCardTask(chat_ctx=speech_only(self.chat_ctx))
+        try:
+            card = await GetCardTask(chat_ctx=speech_only(self.chat_ctx))
+        except ToolError as e:
+            return (
+                f"no card taken ({e}) - the booking can't be finalized without one; offer to "
+                "finish by callback once they have a card and call give_up"
+            )
         self._card_last4 = card.card_number[-4:]
         return f"card recorded (ending {self._card_last4}) | {self._status()}"
 
@@ -302,7 +308,7 @@ class BookRoomTask(AgentTask[RoomBooking]):
 
     @function_tool(flags=ToolFlag.IGNORE_ON_ENTER)
     async def give_up(self, reason: str) -> None:
-        """Caller wants to abandon the booking.
+        """Caller wants to abandon the booking, or the booking can't be finalized because no card could be taken.
 
         Args:
             reason: short explanation.


### PR DESCRIPTION
## Summary

Stacked on #6803. That PR lets `GetCardTask` end without a card via `decline_card_capture`, which completes the task with a `ToolError`. On the new-booking path `BookRoomTask.open_credit_card_dialog` awaited the task without catching it, so the error reached BookRoom's LLM as a bare "couldn't get the card details" while its last directive was still "next: call open_credit_card_dialog". The model reopened the card dialog, and the re-ask loop #6803 removes from the sub-task moved up one level.

- `open_credit_card_dialog` catches the `ToolError` and returns a directive: the booking can't be finalized without a card, offer to finish by callback, call `give_up`
- `give_up`'s docstring widens to cover "no card could be taken" so the model has a named exit

The card-update path (`start_card_update`) already handles the error through the receptionist's own instructions and is unchanged.

## Testing

- `pytest examples/hotel_receptionist/ tests/test_tools.py --allow-uncategorized` (114 passed)
- `ruff format --check` and `ruff check` clean
- Scenario 15 ("Caller pushing about a declined card") simulated on this branch: [passed](https://cloud.livekit.io/projects/p_6hxckww6414/simulations/runs/SR_Jek87RtxnTMM). It exercises the card-update path, not this one; nothing in the suite drives a declined capture inside a new booking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)