### PR TITLE
fix(tests): run the false-interruption resume tests on virtual time

### DIFF
--- a/tests/test_false_interruption_resume.py
+++ b/tests/test_false_interruption_resume.py
@@ -32,7 +32,7 @@ from .fake_io import FakeAudioOutput
 from .fake_realtime import FakeRealtimeModel, fake_capabilities
 from .fake_vad import FakeVAD
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.virtual_time, pytest.mark.no_concurrent]
 
 # scaled-down shipped defaults, keeping max_delay - vad_min_silence > timeout
 VAD_MIN_SILENCE = 0.05


### PR DESCRIPTION
## Problem

`tests/test_false_interruption_resume.py` runs on the real clock and on a shared event loop, and it
can fail on CI over code it does not touch. It failed that way on #7159 on 7 September, where it
was reported as unrelated to that PR and the contributor closed and reopened to re-run CI.

The test asserts that `_false_interruption_pending` is true after sleeping past the
false-interruption timeout. That flag is transient: `_on_timeout` sets it only while the
end-of-turn decision is still open, and `_on_turn_settled` clears it again once the decision
settles. Sampled across the span on an idle machine it is true only between 0.30s and 0.45s, and
the test samples at 0.35s.

What closes that window early is not the test's own sleep running late. The bounce task in
`_run_eou_detection` anchors its wait to `last_speaking_time + endpointing_delay`. If the loop is
starved before that task's first step, the anchor has already passed, the wait collapses to zero
and the turn settles immediately. Settling commits the turn, and `_cancel_speech_pause` cancels the
false-interruption timer before it can set the flag at all, so the test wakes and reads false.

## Changes

Marks the module `virtual_time` and `no_concurrent`, the pair already used by the thirty-three
modules that run this way, including `test_audio_recognition_aclose.py` and
`test_disallow_interruptions_pause.py`. That loop advances its clock only when it goes idle, so
runner contention cannot move a deadline and the ordering the test depends on is fixed.

Nothing else changes. No source file, no assertion, no tolerance and no constant is touched, and
the `unit` category marker is kept so selection is unchanged. The module goes from about 3.7s of
real sleeping to 0.08s.
