### PR TITLE
fix(deepgram): include word confidence for stt v1 alternatives

### DIFF
--- a/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
+++ b/livekit-plugins/livekit-plugins-deepgram/livekit/plugins/deepgram/stt.py
@@ -935,6 +935,7 @@ def live_transcription_to_speech_data(
                     text=_word_text(word, use_punctuated_word=use_punctuated_word),
                     start_time=word.get("start", 0) + start_time_offset,
                     end_time=word.get("end", 0) + start_time_offset,
+                    confidence=word.get("confidence", NOT_GIVEN),
                     start_time_offset=start_time_offset,
                 )
                 for word in alt["words"]
@@ -978,6 +979,7 @@ def prerecorded_transcription_to_speech_event(
                         text=_word_text(word, use_punctuated_word=use_punctuated_word),
                         start_time=word.get("start", 0),
                         end_time=word.get("end", 0),
+                        confidence=word.get("confidence", NOT_GIVEN),
                     )
                     for word in alt["words"]
                 ],


### PR DESCRIPTION
Closes #7180 .

## What

Forward Deepgram's per-word `confidence` into `TimedString` at the two
places the plugin builds them.

## Why

This is #5034's fix applied to the other module. `stt_v2.py` forwards
Deepgram's per-word confidence into `TimedString`; `stt.py` builds the same
`TimedString` at two sites without it, so words from the v1 `STT` always
report `NOT_GIVEN`. As #5034 put it for v2, the confidence "wasn't set on
the word level, even though it is used to set the overall combined
confidence" — v1 likewise reads `alt["confidence"]` for the utterance and
drops the per-word values.

The field is declared:

```python
class TimedString(str):
    confidence: NotGivenOr[float]   # NOT_GIVEN when unavailable
```

and Deepgram returns `confidence` on every entry of `words[]`.
`livekit-plugins-assemblyai` and `livekit-plugins-google` populate it too,
so v1 is now the outlier.

The raw JSON is discarded inside the plugin, so downstream code cannot
recover the value: `Agent.stt_node` receives already-parsed `TimedString`s,
and `UserInputTranscribedEvent` carries only `transcript: str`.

Per-word confidence lets an agent tell *which part* of a spoken value it is
unsure about, rather than only *that* the utterance might be wrong — which
is what matters for structured values like email addresses and reference
numbers.

## Default value

`word.get("confidence", NOT_GIVEN)` rather than `0`, matching the field's
declared `NotGivenOr[float]` contract: a consumer ranking words by
confidence needs "unknown" to stay distinguishable from "zero confidence",
since those call for opposite handling.

## Changes

Two lines, no new imports (`NOT_GIVEN` is already imported at the top of
the file):

- `live_transcription_to_speech_data`
- `prerecorded_transcription_to_speech_event`

## Verification

`ruff check` and `ruff format` clean under the repo's own config. Both
functions are pure
`dict -> SpeechData`, so this is checkable without a network call:

```python
from livekit.agents.utils import is_given
from livekit.plugins.deepgram.stt import prerecorded_transcription_to_speech_event

event = prerecorded_transcription_to_speech_event(
    "en-US",
    {
        "metadata": {"request_id": "r"},
        "results": {
            "channels": [
                {
                    "alternatives": [
                        {
                            "transcript": "hello world",
                            "confidence": 0.98,
                            "words": [
                                {"word": "hello", "start": 0.0, "end": 0.4,
                                 "confidence": 0.99},
                                {"word": "world", "start": 0.4, "end": 0.9,
                                 "confidence": 0.42},
                            ],
                        }
                    ]
                }
            ]
        },
    },
)

words = event.alternatives[0].words
assert [w.confidence for w in words] == [0.99, 0.42]   # before: [NOT_GIVEN, NOT_GIVEN]
assert all(is_given(w.confidence) for w in words)
```

I did not add a test file — `tests/` has no unit tests for this plugin's
parsing helpers, so I did not want to establish a pattern uninvited. Happy
to add one wherever you'd like it.

## Behaviour change

Additive, and the same shape as #5034. Words gain a value where they
previously had `NOT_GIVEN`; nothing that already worked changes. Consumers
gating on `is_given()` keep working either way.