### PR TITLE
google: make the generation_created wait configurable

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -62,6 +62,10 @@ class _ChatCtxToolResponse(types.LiveClientToolResponse):
 # stop rejecting tool calls after this many in a row to avoid a loop (tool_choice="none")
 MAX_TOOL_CALL_REJECTIONS = 3
 
+# how long a requested generation waits for its `generation_created` event before the caller's
+# future fails; see `RealtimeSession.generation_created_timeout`
+DEFAULT_GENERATION_CREATED_TIMEOUT = 5.0
+
 # Known VertexAI models for the Live API
 # See: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/live-api
 KNOWN_VERTEXAI_MODELS: frozenset[str] = frozenset(
@@ -528,6 +532,7 @@ class RealtimeSession(llm.RealtimeSession):
         self._session_should_close = asyncio.Event()
         self._response_created_futures: dict[str, asyncio.Future[llm.GenerationCreatedEvent]] = {}
         self._pending_generation_fut: asyncio.Future[llm.GenerationCreatedEvent] | None = None
+        self._generation_created_timeout: float = DEFAULT_GENERATION_CREATED_TIMEOUT
         # number of tool calls rejected in the current tool_choice="none" turn; non-zero also
         # means we're draining that turn's trailing events (which have no generation to attach
         # to). reset when the next generation starts.
@@ -782,6 +787,32 @@ class RealtimeSession(llm.RealtimeSession):
     def session_resumption_handle(self) -> str | None:
         return self._session_resumption_handle
 
+    @property
+    def generation_created_timeout(self) -> float:
+        """How long a requested generation waits, in seconds, for its `generation_created`.
+
+        The wait is armed by `generate_reply`. When it elapses the future given to the caller
+        fails with a `RealtimeError` and the turn is given up on, even if the server answers a
+        moment later.
+
+        The default, `DEFAULT_GENERATION_CREATED_TIMEOUT`, is cut for a conversational turn,
+        where a longer wait would leave the user in silence. A caller that runs a turn known to
+        be slower than that -- a hidden, tool-only turn at the end of a call, for instance,
+        whose function call is delivered in one message and can take longer to arrive -- raises
+        this for that turn and restores the previous value once it is over, rather than making
+        every other turn wait that long.
+
+        It is read when a wait is armed, so it applies to the generations requested after it is
+        set, never to one already in flight.
+        """
+        return self._generation_created_timeout
+
+    @generation_created_timeout.setter
+    def generation_created_timeout(self, value: float) -> None:
+        if value <= 0:
+            raise ValueError(f"generation_created_timeout must be greater than 0, got {value}")
+        self._generation_created_timeout = value
+
     def push_audio(self, frame: rtc.AudioFrame) -> None:
         for f in self._resample_audio(frame):
             for nf in self._bstream.write(f.data.tobytes()):
@@ -863,7 +894,9 @@ class RealtimeSession(llm.RealtimeSession):
                 if self._pending_generation_fut is fut:
                     self._pending_generation_fut = None
 
-        timeout_handle = asyncio.get_event_loop().call_later(5.0, _on_timeout)
+        timeout_handle = asyncio.get_event_loop().call_later(
+            self._generation_created_timeout, _on_timeout
+        )
 
         def _on_fut_done(f: asyncio.Future[llm.GenerationCreatedEvent]) -> None:
             timeout_handle.cancel()

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -12,7 +12,11 @@ from google.genai import types
 
 from livekit.agents import llm, utils
 from livekit.plugins.google.realtime.api_proto import ClientEvents
-from livekit.plugins.google.realtime.realtime_api import RealtimeModel, RealtimeSession
+from livekit.plugins.google.realtime.realtime_api import (
+    DEFAULT_GENERATION_CREATED_TIMEOUT,
+    RealtimeModel,
+    RealtimeSession,
+)
 from livekit.plugins.google.utils import create_function_response
 
 pytestmark = pytest.mark.unit
@@ -836,3 +840,53 @@ async def test_failed_send_with_a_queued_update_replays_each_item_once(
         assert session._unsent_item_ids == set()
     finally:
         await session.aclose()
+
+
+def _record_armed_delays(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Record every delay armed on the running loop, without changing what it does."""
+    loop = asyncio.get_event_loop()
+    real_call_later = loop.call_later
+    delays: list[float] = []
+
+    def _spy(delay: float, callback: Any, *args: Any, **kwargs: Any) -> asyncio.TimerHandle:
+        delays.append(delay)
+        return real_call_later(delay, callback, *args, **kwargs)
+
+    monkeypatch.setattr(loop, "call_later", _spy)
+    return delays
+
+
+async def test_generation_created_wait_defaults_to_five_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with _make_session(monkeypatch) as session:
+        assert session.generation_created_timeout == DEFAULT_GENERATION_CREATED_TIMEOUT
+
+        delays = _record_armed_delays(monkeypatch)
+        session.generate_reply(instructions="Say hello")
+
+        assert delays == [5.0]
+
+
+async def test_generation_created_wait_is_read_when_the_wait_is_armed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async with _make_session(monkeypatch) as session:
+        session.generation_created_timeout = 15.0
+
+        delays = _record_armed_delays(monkeypatch)
+        session.generate_reply(instructions="Say hello")
+
+        assert delays == [15.0]
+
+
+@pytest.mark.parametrize("rejected", [0, 0.0, -1.0, -0.001])
+async def test_generation_created_wait_rejects_a_value_that_is_not_positive(
+    monkeypatch: pytest.MonkeyPatch, rejected: float
+) -> None:
+    """A wait of zero or less would fail every turn before the server could answer any."""
+    async with _make_session(monkeypatch) as session:
+        with pytest.raises(ValueError, match="greater than 0"):
+            session.generation_created_timeout = rejected
+
+        assert session.generation_created_timeout == DEFAULT_GENERATION_CREATED_TIMEOUT


### PR DESCRIPTION
## What

The Google realtime plugin gives every `generate_reply` a hard-coded 5 s to produce its `generation_created` event (the model's first piece of output) before failing the caller's future. This PR turns that into a session-level property, `RealtimeSession.generation_created_timeout`, with the default unchanged (`DEFAULT_GENERATION_CREATED_TIMEOUT = 5.0`) and a setter that rejects non-positive values. The wait is read when it is armed, so it applies to generations requested after it is set, never to one already in flight.

## Why

5 s is the right budget for a conversational turn: the first audio chunk follows a few words. It is too short for a tool-only turn, because a function call is not streamed — it is delivered in one message once its whole argument JSON is generated. We run a hidden, tool-only turn on the live session at the end of each call (it saves the lead and the call outcome); in production its tool call regularly landed between 0.6 and 4.9 s *after* the 5 s wait had already declared the turn failed, and the turn was abandoned while the answer was on its way. Today a caller has no way to wait for it without patching the plugin. With this change the application widens the wait around that one turn and restores it afterwards, and every other turn behaves exactly as before.

## Tests

`tests/test_plugin_google_realtime.py`: default delay is 5.0; after setting 15.0 the armed delay is 15.0; the setter rejects 0 and negative values. `pytest tests/test_plugin_google_realtime.py --unit` passes, `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)