### PR TITLE
Expose TTS fallback controls and activation events (LKINF-495)

### DIFF
--- a/livekit-agents/livekit/agents/inference/__init__.py
+++ b/livekit-agents/livekit/agents/inference/__init__.py
@@ -9,7 +9,7 @@ from .interruption import (
 )
 from .llm import LLM, LLMModels, LLMStream
 from .stt import STT, STTModels
-from .tts import TTS, TTSModels
+from .tts import TTS, FallbackActivatedEvent, TTSModels
 from .vad import VAD, VADModels
 
 if TYPE_CHECKING:
@@ -39,6 +39,7 @@ __all__ = [
     "LLMStream",
     "STTModels",
     "TTSModels",
+    "FallbackActivatedEvent",
     "LLMModels",
     "VADModels",
     "AdaptiveInterruptionDetector",

--- a/livekit-agents/livekit/agents/inference/tts.py
+++ b/livekit-agents/livekit/agents/inference/tts.py
@@ -6,9 +6,10 @@ import json
 import os
 import weakref
 from dataclasses import dataclass, replace
-from typing import Any, Literal, TypedDict, overload
+from typing import Any, Literal, TypedDict, cast, overload
 
 import aiohttp
+from pydantic import BaseModel, ValidationError
 from typing_extensions import NotRequired
 
 from .. import tts, utils
@@ -117,6 +118,36 @@ class FallbackModel(TypedDict):
 
 FallbackModelType = FallbackModel | str
 
+FallbackType = Literal["unknown", "fallback", "system_default"]
+FallbackCause = Literal["unknown", "timeout", "canceled", "provider_error", "quota_exceeded"]
+_FALLBACK_TYPES = frozenset(("unknown", "fallback", "system_default"))
+_FALLBACK_CAUSES = frozenset(("unknown", "timeout", "canceled", "provider_error", "quota_exceeded"))
+
+
+class FallbackActivatedEvent(BaseModel):
+    """A fallback model produced content-bearing synthesis output."""
+
+    session_id: str
+    fallback_type: FallbackType
+    provider: str
+    model: str
+    voice: str
+    cause: FallbackCause
+
+
+def _normalize_fallback_type(fallback_type: object) -> FallbackType:
+    if isinstance(fallback_type, str) and fallback_type in _FALLBACK_TYPES:
+        return cast(FallbackType, fallback_type)
+    return "unknown"
+
+
+def _normalize_fallback_cause(
+    cause: object,
+) -> FallbackCause:
+    if isinstance(cause, str) and cause in _FALLBACK_CAUSES:
+        return cast(FallbackCause, cause)
+    return "unknown"
+
 
 def _has_aligned_transcript(model: str, extra_kwargs: dict[str, Any]) -> bool:
     provider = model.split("/")[0]
@@ -219,7 +250,49 @@ class _TTSOptions:
     api_secret: str
     extra_kwargs: dict[str, Any]
     fallback: NotGivenOr[list[FallbackModel]]
+    disable_system_default_fallback: bool
     conn_options: NotGivenOr[APIConnectOptions]
+
+
+def _build_session_create_payload(opts: _TTSOptions) -> dict[str, Any]:
+    params: dict[str, Any] = {
+        "type": "session.create",
+        "sample_rate": str(opts.sample_rate),
+        "encoding": opts.encoding,
+        "extra": opts.extra_kwargs,
+    }
+
+    if opts.voice:
+        params["voice"] = opts.voice
+    if opts.model:
+        params["model"] = opts.model
+    if opts.language:
+        params["language"] = opts.language
+
+    if opts.fallback or opts.disable_system_default_fallback:
+        models = (
+            [
+                {
+                    "model": fallback.get("model"),
+                    "voice": fallback.get("voice"),
+                    "extra": fallback.get("extra_kwargs", {}),
+                }
+                for fallback in opts.fallback
+            ]
+            if is_given(opts.fallback)
+            else []
+        )
+        params["fallback"] = {"models": models}
+        if opts.disable_system_default_fallback:
+            params["fallback"]["disable_system_default_fallback"] = True
+
+    if opts.conn_options:
+        params["connection"] = {
+            "timeout": opts.conn_options.timeout,
+            "retries": opts.conn_options.max_retry,
+        }
+
+    return params
 
 
 @dataclass(eq=False)
@@ -228,7 +301,7 @@ class _TTSConnection:
     session_id: str | None
 
 
-class TTS(tts.TTS):
+class TTS(tts.TTS[Literal["fallback_activated"]]):
     @overload
     def __init__(
         self,
@@ -244,6 +317,7 @@ class TTS(tts.TTS):
         http_session: aiohttp.ClientSession | None = None,
         extra_kwargs: NotGivenOr[CartesiaOptions] = NOT_GIVEN,
         fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
+        disable_system_default_fallback: bool = False,
         conn_options: NotGivenOr[APIConnectOptions] = NOT_GIVEN,
     ) -> None:
         pass
@@ -263,6 +337,7 @@ class TTS(tts.TTS):
         http_session: aiohttp.ClientSession | None = None,
         extra_kwargs: NotGivenOr[DeepgramOptions] = NOT_GIVEN,
         fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
+        disable_system_default_fallback: bool = False,
         conn_options: NotGivenOr[APIConnectOptions] = NOT_GIVEN,
     ) -> None:
         pass
@@ -282,6 +357,7 @@ class TTS(tts.TTS):
         http_session: aiohttp.ClientSession | None = None,
         extra_kwargs: NotGivenOr[RimeOptions] = NOT_GIVEN,
         fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
+        disable_system_default_fallback: bool = False,
         conn_options: NotGivenOr[APIConnectOptions] = NOT_GIVEN,
     ) -> None:
         pass
@@ -301,6 +377,7 @@ class TTS(tts.TTS):
         http_session: aiohttp.ClientSession | None = None,
         extra_kwargs: NotGivenOr[InworldOptions] = NOT_GIVEN,
         fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
+        disable_system_default_fallback: bool = False,
         conn_options: NotGivenOr[APIConnectOptions] = NOT_GIVEN,
     ) -> None:
         pass
@@ -320,6 +397,7 @@ class TTS(tts.TTS):
         http_session: aiohttp.ClientSession | None = None,
         extra_kwargs: NotGivenOr[XaiOptions] = NOT_GIVEN,
         fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
+        disable_system_default_fallback: bool = False,
         conn_options: NotGivenOr[APIConnectOptions] = NOT_GIVEN,
     ) -> None:
         pass
@@ -339,6 +417,7 @@ class TTS(tts.TTS):
         http_session: aiohttp.ClientSession | None = None,
         extra_kwargs: NotGivenOr[FishAudioOptions] = NOT_GIVEN,
         fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
+        disable_system_default_fallback: bool = False,
         conn_options: NotGivenOr[APIConnectOptions] = NOT_GIVEN,
     ) -> None:
         pass
@@ -358,6 +437,7 @@ class TTS(tts.TTS):
         http_session: aiohttp.ClientSession | None = None,
         extra_kwargs: NotGivenOr[dict[str, Any]] = NOT_GIVEN,
         fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
+        disable_system_default_fallback: bool = False,
         conn_options: NotGivenOr[APIConnectOptions] = NOT_GIVEN,
     ) -> None:
         pass
@@ -384,6 +464,7 @@ class TTS(tts.TTS):
             | FishAudioOptions
         ] = NOT_GIVEN,
         fallback: NotGivenOr[list[FallbackModelType] | FallbackModelType] = NOT_GIVEN,
+        disable_system_default_fallback: bool = False,
         conn_options: NotGivenOr[APIConnectOptions] = NOT_GIVEN,
     ) -> None:
         """Livekit Cloud Inference TTS
@@ -401,6 +482,8 @@ class TTS(tts.TTS):
             extra_kwargs (dict, optional): Extra kwargs to pass to the TTS model.
             fallback (FallbackModelType, optional): Fallback models - either a list of model names,
                 a list of FallbackModel instances.
+            disable_system_default_fallback (bool, optional): Disable system-configured fallback
+                models.
             conn_options (APIConnectOptions, optional): Connection options for request attempts.
         """
         sample_rate = sample_rate if is_given(sample_rate) else DEFAULT_SAMPLE_RATE
@@ -459,6 +542,7 @@ class TTS(tts.TTS):
             api_secret=lk_api_secret,
             extra_kwargs=resolved_extra_kwargs,
             fallback=fallback_models,
+            disable_system_default_fallback=disable_system_default_fallback,
             conn_options=conn_options if is_given(conn_options) else DEFAULT_API_CONNECT_OPTIONS,
         )
         self._session = http_session
@@ -532,35 +616,7 @@ class TTS(tts.TTS):
         except aiohttp.ClientConnectorError as e:
             raise APIConnectionError("failed to connect to LiveKit Inference TTS") from e
 
-        params: dict[str, Any] = {
-            "type": "session.create",
-            "sample_rate": str(self._opts.sample_rate),
-            "encoding": self._opts.encoding,
-            "extra": self._opts.extra_kwargs,
-        }
-
-        if self._opts.voice:
-            params["voice"] = self._opts.voice
-        if self._opts.model:
-            params["model"] = self._opts.model
-        if self._opts.language:
-            params["language"] = self._opts.language
-        if self._opts.fallback:
-            models = [
-                {
-                    "model": m.get("model"),
-                    "voice": m.get("voice"),
-                    "extra": m.get("extra_kwargs", {}),
-                }
-                for m in self._opts.fallback
-            ]
-            params["fallback"] = {"models": models}
-
-        if self._opts.conn_options:
-            params["connection"] = {
-                "timeout": self._opts.conn_options.timeout,
-                "retries": self._opts.conn_options.max_retry,
-            }
+        params = _build_session_create_payload(self._opts)
 
         try:
             payload = json.dumps(params)
@@ -725,12 +781,33 @@ class SynthesizeStream(tts.SynthesizeStream):
                     current_session_id = session_id
                     output_emitter.start_segment(segment_id=session_id)
 
-                if data.get("type") == "session.created":
+                msg_type = data.get("type")
+                if msg_type == "session.created":
                     pass
-                elif data.get("type") == "output_audio":
+                elif msg_type == "fallback_activated":
+                    try:
+                        event = FallbackActivatedEvent(
+                            session_id=data.get("session_id"),
+                            fallback_type=_normalize_fallback_type(data.get("fallback_type")),
+                            provider=data.get("provider"),
+                            model=data.get("model"),
+                            voice=data.get("voice"),
+                            cause=_normalize_fallback_cause(data.get("cause")),
+                        )
+                    except ValidationError as e:
+                        logger.warning(
+                            "ignoring invalid fallback activation notice",
+                            extra={"session_id": data.get("session_id"), "error": str(e)},
+                        )
+                        continue
+                    self._tts.emit(
+                        "fallback_activated",
+                        event,
+                    )
+                elif msg_type == "output_audio":
                     b64data = base64.b64decode(data["audio"])
                     output_emitter.push(b64data)
-                elif data.get("type") == "output_alignment":
+                elif msg_type == "output_alignment":
                     aligned: list[TimedString] = []
                     if words := data.get("words"):
                         aligned = [
@@ -754,14 +831,14 @@ class SynthesizeStream(tts.SynthesizeStream):
                             if self._expressive
                             else aligned
                         )
-                elif data.get("type") == "done":
+                elif msg_type == "done":
                     if self._held_tokens:  # release an unclosed span, cue unresolved
                         output_emitter.push_timed_transcript(
                             drop_bracket_cues([], self._held_tokens, final=True)
                         )
                     output_emitter.end_input()
                     break
-                elif data.get("type") == "error":
+                elif msg_type == "error":
                     raise APIError(f"LiveKit Inference TTS returned error: {msg.data}")
 
         try:

--- a/tests/test_inference_tts_alignment.py
+++ b/tests/test_inference_tts_alignment.py
@@ -11,6 +11,7 @@ import pytest
 
 import livekit.agents.inference.tts as inference_tts
 from livekit.agents import APIConnectOptions
+from livekit.agents.inference import FallbackActivatedEvent
 from livekit.agents.inference._utils import HEADER_SESSION_ID
 from livekit.agents.inference.tts import TTS
 from livekit.agents.types import USERDATA_TIMED_TRANSCRIPT
@@ -133,3 +134,129 @@ async def test_connection_retains_header_session_id(monkeypatch: pytest.MonkeyPa
     assert http_session.headers[HEADER_SESSION_ID] == "inference_connection"
     assert connection.session_id == "inference_connection"
     assert connection.ws is websocket
+
+
+@pytest.mark.parametrize(
+    ("fallback_type", "cause", "expected_fallback_type", "expected_cause"),
+    [
+        ("fallback", "quota_exceeded", "fallback", "quota_exceeded"),
+        ("future_type", "future_cause", "unknown", "unknown"),
+    ],
+)
+async def test_emits_fallback_activated_event(
+    fallback_type: str,
+    cause: str,
+    expected_fallback_type: str,
+    expected_cause: str,
+) -> None:
+    websocket = _FakeWebSocket(
+        [
+            {"type": "session.created", "session_id": "session-1"},
+            {
+                "type": "fallback_activated",
+                "session_id": "session-1",
+                "fallback_type": fallback_type,
+                "provider": "deepgram",
+                "model": "deepgram/aura-2",
+                "voice": "asteria",
+                "cause": cause,
+            },
+            {
+                "type": "output_audio",
+                "audio": base64.b64encode(b"\0\0" * 2400).decode(),
+            },
+            {"type": "done"},
+        ]
+    )
+    tts = TTS(
+        model="cartesia/sonic-3",
+        api_key="test-key",
+        api_secret="test-secret",
+        base_url="https://example.livekit.cloud",
+    )
+    tts._pool = _FakePool(websocket)  # type: ignore[assignment]
+    fallback_events: list[FallbackActivatedEvent] = []
+    tts.on("fallback_activated", fallback_events.append)
+
+    async with tts.stream(conn_options=APIConnectOptions(max_retry=0, timeout=1.0)) as stream:
+        stream.push_text("hello")
+        stream.end_input()
+        audio_events = [event async for event in stream]
+
+    assert fallback_events == [
+        FallbackActivatedEvent(
+            session_id="session-1",
+            fallback_type=expected_fallback_type,
+            provider="deepgram",
+            model="deepgram/aura-2",
+            voice="asteria",
+            cause=expected_cause,
+        )
+    ]
+    assert audio_events
+
+
+async def test_malformed_fallback_notice_does_not_interrupt_audio() -> None:
+    websocket = _FakeWebSocket(
+        [
+            {"type": "session.created", "session_id": "session-1"},
+            {
+                "type": "fallback_activated",
+                "session_id": "session-1",
+                "fallback_type": "fallback",
+                "model": "deepgram/aura-2",
+                "voice": "asteria",
+                "cause": "provider_error",
+            },
+            {
+                "type": "output_audio",
+                "audio": base64.b64encode(b"\0\0" * 2400).decode(),
+            },
+            {"type": "done"},
+        ]
+    )
+    tts = TTS(
+        model="cartesia/sonic-3",
+        api_key="test-key",
+        api_secret="test-secret",
+        base_url="https://example.livekit.cloud",
+    )
+    tts._pool = _FakePool(websocket)  # type: ignore[assignment]
+    fallback_events: list[FallbackActivatedEvent] = []
+    tts.on("fallback_activated", fallback_events.append)
+
+    async with tts.stream(conn_options=APIConnectOptions(max_retry=0, timeout=1.0)) as stream:
+        stream.push_text("hello")
+        stream.end_input()
+        audio_events = [event async for event in stream]
+
+    assert fallback_events == []
+    assert audio_events
+
+
+async def test_unknown_gateway_message_remains_harmless() -> None:
+    websocket = _FakeWebSocket(
+        [
+            {"type": "session.created", "session_id": "session-1"},
+            {"type": "future_message", "session_id": "session-1", "data": "ignored"},
+            {
+                "type": "output_audio",
+                "audio": base64.b64encode(b"\0\0" * 2400).decode(),
+            },
+            {"type": "done"},
+        ]
+    )
+    tts = TTS(
+        model="cartesia/sonic-3",
+        api_key="test-key",
+        api_secret="test-secret",
+        base_url="https://example.livekit.cloud",
+    )
+    tts._pool = _FakePool(websocket)  # type: ignore[assignment]
+
+    async with tts.stream(conn_options=APIConnectOptions(max_retry=0, timeout=1.0)) as stream:
+        stream.push_text("hello")
+        stream.end_input()
+        audio_events = [event async for event in stream]
+
+    assert audio_events

--- a/tests/test_inference_tts_fallback.py
+++ b/tests/test_inference_tts_fallback.py
@@ -3,6 +3,7 @@ import pytest
 from livekit.agents.inference.tts import (
     TTS,
     FallbackModel,
+    _build_session_create_payload,
     _normalize_fallback,
     _parse_model_string,
 )
@@ -169,3 +170,66 @@ class TestNormalizeFallback:
         fallback = FallbackModel(model="cartesia/sonic", voice="")
         result = _normalize_fallback(fallback)
         assert result == [{"model": "cartesia/sonic", "voice": ""}]
+
+
+@pytest.mark.parametrize("fallback", [None, []])
+def test_session_create_omits_empty_fallback(fallback) -> None:
+    kwargs = {} if fallback is None else {"fallback": fallback}
+
+    payload = _build_session_create_payload(_make_tts(**kwargs)._opts)
+
+    assert payload == {
+        "type": "session.create",
+        "sample_rate": "24000",
+        "encoding": "pcm_s16le",
+        "extra": {},
+        "model": "cartesia/sonic",
+        "connection": {"timeout": 10.0, "retries": 3},
+    }
+
+
+@pytest.mark.parametrize("fallback", [None, []])
+def test_session_create_can_disable_system_fallback_without_models(fallback) -> None:
+    kwargs = (
+        {"disable_system_default_fallback": True}
+        if fallback is None
+        else {"fallback": fallback, "disable_system_default_fallback": True}
+    )
+
+    payload = _build_session_create_payload(_make_tts(**kwargs)._opts)
+
+    assert payload["fallback"] == {
+        "models": [],
+        "disable_system_default_fallback": True,
+    }
+
+
+@pytest.mark.parametrize("disable_system_default_fallback", [False, True])
+def test_session_create_maps_fallback_models_exactly(
+    disable_system_default_fallback: bool,
+) -> None:
+    tts = _make_tts(
+        fallback=[
+            "deepgram/aura-2:asteria",
+            FallbackModel(
+                model="rime/mistv3",
+                voice="speaker-1",
+                extra_kwargs={"speed_alpha": 0.9},
+            ),
+        ],
+        disable_system_default_fallback=disable_system_default_fallback,
+    )
+
+    payload = _build_session_create_payload(tts._opts)
+
+    assert payload["fallback"] == {
+        "models": [
+            {"model": "deepgram/aura-2", "voice": "asteria", "extra": {}},
+            {
+                "model": "rime/mistv3",
+                "voice": "speaker-1",
+                "extra": {"speed_alpha": 0.9},
+            },
+        ],
+        **({"disable_system_default_fallback": True} if disable_system_default_fallback else {}),
+    }


### PR DESCRIPTION
## Summary
- add constructor-only `disable_system_default_fallback` and serialize opt-out even without customer fallback models
- expose a typed `fallback_activated` event for regular and system-default fallback output
- include the serving provider, model, voice, sanitized cause, and fallback type
- normalize future causes and fallback types to `unknown`
- ignore structurally malformed notices without interrupting audio
- keep existing fallback-model payloads unchanged

## Testing
- `uv run pytest tests/test_inference_tts_fallback.py tests/test_inference_tts_alignment.py`
- `uv run ruff check livekit-agents/livekit/agents/inference/tts.py livekit-agents/livekit/agents/inference/__init__.py tests/test_inference_tts_fallback.py tests/test_inference_tts_alignment.py`
- `uv run ruff format --check livekit-agents/livekit/agents/inference/tts.py livekit-agents/livekit/agents/inference/__init__.py tests/test_inference_tts_fallback.py tests/test_inference_tts_alignment.py`
- `uv run --group typing mypy -p livekit.agents`

## Coordinated PRs
- Gateway: https://github.com/livekit/agent-gateway/pull/1363
- JavaScript: https://github.com/livekit/agents-js/pull/2468

[LKINF-495](https://linear.app/livekit/issue/LKINF-495/expose-tts-fallback-controls-and-notices)