### PR TITLE
fix(voice): bound EndCallTool wait for tool-reply playout

### DIFF
--- a/livekit-agents/livekit/agents/beta/tools/end_call.py
+++ b/livekit-agents/livekit/agents/beta/tools/end_call.py
@@ -105,6 +105,7 @@ class EndCallTool(Toolset):
     async def _delayed_session_shutdown(self, ctx: RunContext) -> None:
         """Shutdown the session after the tool reply is played out"""
         speech_created_fut = asyncio.Future[SpeechHandle]()
+        speech_handle: SpeechHandle | None = None
 
         @ctx.session.once("speech_created")
         def _on_speech_created(ev: SpeechCreatedEvent) -> None:
@@ -116,9 +117,15 @@ class EndCallTool(Toolset):
             await asyncio.wait_for(speech_handle, timeout=TOOL_REPLY_TIMEOUT)
         except asyncio.TimeoutError:
             logger.warning("tool reply timed out, shutting down session")
+            # Default shutdown drains and can wait on the same unfinished reply.
+            # Force-interrupt and skip drain so room/SIP cleanup still runs (#5096).
+            if speech_handle is not None and not speech_handle.done():
+                speech_handle.interrupt(force=True)
+            ctx.session.shutdown(drain=False)
+        else:
+            ctx.session.shutdown()
         finally:
             ctx.session.off("speech_created", _on_speech_created)
-            ctx.session.shutdown()
 
     def _on_session_close(self, ev: CloseEvent) -> None:
         """Close the job process when AgentSession is closed"""

--- a/livekit-agents/livekit/agents/beta/tools/end_call.py
+++ b/livekit-agents/livekit/agents/beta/tools/end_call.py
@@ -23,6 +23,12 @@ Once called, no further interaction is possible with the user.
 Don't generate any other text or response when the tool is called.
 """
 
+# Bound both the wait for the tool-reply speech_created event and the wait for that
+# speech to finish. Guarding only the first await left a hang path: speech_created
+# fires, but await speech_handle never returns, finally never runs, and shutdown is
+# skipped (room/SIP stay up when delete_room=True). See #5096.
+TOOL_REPLY_TIMEOUT = 5.0
+
 
 class EndCallTool(Toolset):
     def __init__(
@@ -106,8 +112,8 @@ class EndCallTool(Toolset):
                 speech_created_fut.set_result(ev.speech_handle)
 
         try:
-            speech_handle = await asyncio.wait_for(speech_created_fut, timeout=5.0)
-            await speech_handle
+            speech_handle = await asyncio.wait_for(speech_created_fut, timeout=TOOL_REPLY_TIMEOUT)
+            await asyncio.wait_for(speech_handle, timeout=TOOL_REPLY_TIMEOUT)
         except asyncio.TimeoutError:
             logger.warning("tool reply timed out, shutting down session")
         finally:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -340,7 +340,7 @@ class _FakeEndCallSession:
     """Minimal session surface for EndCallTool._delayed_session_shutdown."""
 
     def __init__(self) -> None:
-        self.shutdown_count = 0
+        self.shutdown_calls: list[bool] = []
         self._handlers: dict[str, list[Any]] = {}
 
     def once(self, event: str, callback: Any = None) -> Any:
@@ -364,8 +364,8 @@ class _FakeEndCallSession:
         for callback in list(self._handlers.get(event, [])):
             callback(ev)
 
-    def shutdown(self) -> None:
-        self.shutdown_count += 1
+    def shutdown(self, *, drain: bool = True) -> None:
+        self.shutdown_calls.append(drain)
 
 
 @pytest.mark.asyncio
@@ -399,8 +399,8 @@ async def test_delayed_session_shutdown_times_out_when_speech_handle_hangs() -> 
     # Without a timeout on `await speech_handle`, this never returns — even under
     # virtual time, because no timer is scheduled for a bare Future.
     await asyncio.wait_for(task, timeout=end_call_mod.TOOL_REPLY_TIMEOUT + 1.0)
-    assert session.shutdown_count == 1
-    assert not hanging.done()
+    assert session.shutdown_calls == [False]
+    assert hanging.interrupted
 
 
 @pytest.mark.asyncio
@@ -419,7 +419,7 @@ async def test_delayed_session_shutdown_times_out_when_speech_created_never_fire
         tool._delayed_session_shutdown(ctx),
         timeout=end_call_mod.TOOL_REPLY_TIMEOUT + 1.0,
     )
-    assert session.shutdown_count == 1
+    assert session.shutdown_calls == [False]
 
 
 @pytest.mark.asyncio
@@ -448,11 +448,11 @@ async def test_delayed_session_shutdown_waits_for_completed_speech_handle() -> N
         ),
     )
     await asyncio.sleep(0)
-    assert session.shutdown_count == 0
+    assert session.shutdown_calls == []
 
     handle._mark_done()
     await asyncio.wait_for(task, timeout=1.0)
-    assert session.shutdown_count == 1
+    assert session.shutdown_calls == [True]
 
 
 class TestToolExecution:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -336,6 +336,125 @@ def test_end_call_tool_ignore_on_enter_flag():
     assert tool.info.flags & ToolFlag.IGNORE_ON_ENTER
 
 
+class _FakeEndCallSession:
+    """Minimal session surface for EndCallTool._delayed_session_shutdown."""
+
+    def __init__(self) -> None:
+        self.shutdown_count = 0
+        self._handlers: dict[str, list[Any]] = {}
+
+    def once(self, event: str, callback: Any = None) -> Any:
+        if callback is None:
+
+            def decorator(cb: Any) -> Any:
+                self._handlers.setdefault(event, []).append(cb)
+                return cb
+
+            return decorator
+
+        self._handlers.setdefault(event, []).append(callback)
+        return callback
+
+    def off(self, event: str, callback: Any) -> None:
+        handlers = self._handlers.get(event)
+        if handlers and callback in handlers:
+            handlers.remove(callback)
+
+    def emit(self, event: str, ev: Any) -> None:
+        for callback in list(self._handlers.get(event, [])):
+            callback(ev)
+
+    def shutdown(self) -> None:
+        self.shutdown_count += 1
+
+
+@pytest.mark.asyncio
+async def test_delayed_session_shutdown_times_out_when_speech_handle_hangs() -> None:
+    """speech_created fired but playout never finishes must still shut down (#5096)."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from livekit.agents.beta import EndCallTool
+    from livekit.agents.beta.tools import end_call as end_call_mod
+    from livekit.agents.voice.events import SpeechCreatedEvent
+    from livekit.agents.voice.speech_handle import SpeechHandle
+
+    tool = EndCallTool(delete_room=False)
+    session = _FakeEndCallSession()
+    ctx = SimpleNamespace(session=session)
+
+    task = asyncio.create_task(tool._delayed_session_shutdown(ctx))
+    await asyncio.sleep(0)
+
+    hanging = SpeechHandle.create()
+    session.emit(
+        "speech_created",
+        SpeechCreatedEvent(
+            user_initiated=False,
+            source="generate_reply",
+            speech_handle=hanging,
+        ),
+    )
+
+    # Without a timeout on `await speech_handle`, this never returns — even under
+    # virtual time, because no timer is scheduled for a bare Future.
+    await asyncio.wait_for(task, timeout=end_call_mod.TOOL_REPLY_TIMEOUT + 1.0)
+    assert session.shutdown_count == 1
+    assert not hanging.done()
+
+
+@pytest.mark.asyncio
+async def test_delayed_session_shutdown_times_out_when_speech_created_never_fires() -> None:
+    import asyncio
+    from types import SimpleNamespace
+
+    from livekit.agents.beta import EndCallTool
+    from livekit.agents.beta.tools import end_call as end_call_mod
+
+    tool = EndCallTool(delete_room=False)
+    session = _FakeEndCallSession()
+    ctx = SimpleNamespace(session=session)
+
+    await asyncio.wait_for(
+        tool._delayed_session_shutdown(ctx),
+        timeout=end_call_mod.TOOL_REPLY_TIMEOUT + 1.0,
+    )
+    assert session.shutdown_count == 1
+
+
+@pytest.mark.asyncio
+async def test_delayed_session_shutdown_waits_for_completed_speech_handle() -> None:
+    import asyncio
+    from types import SimpleNamespace
+
+    from livekit.agents.beta import EndCallTool
+    from livekit.agents.voice.events import SpeechCreatedEvent
+    from livekit.agents.voice.speech_handle import SpeechHandle
+
+    tool = EndCallTool(delete_room=False)
+    session = _FakeEndCallSession()
+    ctx = SimpleNamespace(session=session)
+
+    task = asyncio.create_task(tool._delayed_session_shutdown(ctx))
+    await asyncio.sleep(0)
+
+    handle = SpeechHandle.create()
+    session.emit(
+        "speech_created",
+        SpeechCreatedEvent(
+            user_initiated=False,
+            source="generate_reply",
+            speech_handle=handle,
+        ),
+    )
+    await asyncio.sleep(0)
+    assert session.shutdown_count == 0
+
+    handle._mark_done()
+    await asyncio.wait_for(task, timeout=1.0)
+    assert session.shutdown_count == 1
+
+
 class TestToolExecution:
     def test_function_arguments_to_pydantic_model(self):
         schema1 = function_arguments_to_pydantic_model(mock_tool_1)


### PR DESCRIPTION
## Summary

- `_delayed_session_shutdown` already wraps the wait for `speech_created` in `asyncio.wait_for(..., timeout=5.0)`, but then does a bare `await speech_handle`
- if that handle never completes, `finally` never runs and `ctx.session.shutdown()` is skipped — room/`delete_room` cleanup never happens (SIP can stay up)
- wrap the speech-handle await in the same `TOOL_REPLY_TIMEOUT`, keep the existing warning + shutdown path

Closes #5096 (timeout asymmetry only; not Gemini instruction-following).

## Testing

- `pytest tests/test_tools.py::test_delayed_session_shutdown_times_out_when_speech_handle_hangs` — fails on main (hangs), passes with the fix
- also covers: `speech_created` never fires; handle completes normally
- `ruff check` / `ruff format` clean on touched files