### PR TITLE
fix(google): keep tool argument defaults in the Gemini schema

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/utils.py
@@ -150,7 +150,6 @@ class _GeminiJsonSchema:
 
     def _simplify(self, schema: dict[str, Any], refs_stack: tuple[str, ...]) -> None:
         schema.pop("title", None)
-        schema.pop("default", None)
         schema.pop("additionalProperties", None)
         schema.pop("$schema", None)
 

--- a/tests/test_schema_gemini.py
+++ b/tests/test_schema_gemini.py
@@ -55,7 +55,7 @@ async def test_json_def_replaced():
                 "items": {
                     "properties": {
                         "lat": {"type": types.Type.NUMBER},
-                        "lng": {"type": types.Type.NUMBER},
+                        "lng": {"default": 1.1, "type": types.Type.NUMBER},
                     },
                     "required": ["lat"],
                     "type": types.Type.OBJECT,
@@ -94,6 +94,7 @@ async def test_json_def_replaced_any_of():
                 "required": ["lat", "lng"],
                 "type": types.Type.OBJECT,
                 "nullable": True,
+                "default": None,
             }
         },
         "type": types.Type.OBJECT,
@@ -185,3 +186,27 @@ async def test_json_def_date():
         "type": types.Type.OBJECT,
     }
     assert gemini_schema == expected_gemini_schema
+
+
+async def test_default_is_kept():
+    """Gemini's Schema has a `default` field, and a dropped default changes the call.
+
+    A tool argument the caller pre-filled is the model's only record of the value; with the
+    default stripped it has nothing to send, omits the argument, and the tool is invoked
+    without it.
+    """
+
+    class Params(BaseModel):
+        automation_id: str = "auto-42"
+        version: int = 3
+        name: str
+
+    gemini_schema = utils._GeminiJsonSchema(Params.model_json_schema()).simplify()
+    assert gemini_schema is not None
+    assert gemini_schema["properties"] == {
+        "automation_id": {"default": "auto-42", "type": types.Type.STRING},
+        "version": {"default": 3, "type": types.Type.INTEGER},
+        "name": {"type": types.Type.STRING},
+    }
+    # the surviving default must still be a value Gemini accepts on its Schema
+    types.Schema(**gemini_schema["properties"]["automation_id"])


### PR DESCRIPTION
`_GeminiJsonSchema._simplify` dropped `default` from every property of a tool's JSON Schema:

```python
schema.pop("title", None)
schema.pop("default", None)   # removed
schema.pop("additionalProperties", None)
```

`google.genai.types.Schema` has a `default` field, so unlike `title` or `$schema` this is not compatibility stripping — it removes information Gemini accepts and uses. For an argument the caller pre-filled, that default is the model's only record of the value: with it gone the model omits the argument, and a tool that needs it (an MCP server expecting `automationId` / `version`, say) rejects the call with an invalid-arguments error.

Both paths through `_GeminiJsonSchema` are affected — the `chat()` LLM path, and the realtime path, which is routed through `simplify()` for raw-schema function tools because Gemini Live does not accept `parameters_json_schema` (#5560, googleapis/python-genai#1147).

**Tests:** `test_default_is_kept` asserts the defaults survive and round-trips the result through `types.Schema`, so the kept value is proven acceptable to the genai type. Two existing expectations are updated to keep the defaults they previously asserted were stripped.

A nullable field (`Location | None = None`) now keeps `"default": None`. That is left as-is rather than filtered: it is the schema as declared, and it serializes away.

`schema.pop("default", None)` has been there since #1588 and looks carried over from the pydantic-ai implementation this class is based on, alongside the keywords Gemini genuinely rejects.

Fixes #7189