### PR TITLE
fix(google): allow generate_reply without a mutable chat context

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -815,15 +815,6 @@ class RealtimeSession(llm.RealtimeSession):
     ) -> asyncio.Future[llm.GenerationCreatedEvent]:
         if is_given(tools):
             logger.warning("per-response tools is not supported by Google Realtime API, ignoring")
-        if not self._realtime_model.capabilities.mutable_chat_context:
-            logger.warning(
-                f"generate_reply is not compatible with '{self._opts.model}' and will be ignored."
-            )
-            fut = asyncio.Future[llm.GenerationCreatedEvent]()
-            fut.set_exception(
-                llm.RealtimeError(f"generate_reply is not compatible with '{self._opts.model}'")
-            )
-            return fut
         if self._pending_generation_fut and not self._pending_generation_fut.done():
             logger.warning(
                 "generate_reply called while another generation is pending, cancelling previous."
@@ -845,13 +836,21 @@ class RealtimeSession(llm.RealtimeSession):
             )
             self._in_user_activity = False
 
-        # Gemini requires the last message to end with user's turn
-        # so we need to add a placeholder user turn in order to trigger a new generation
-        turns = []
-        if is_given(instructions):
-            turns.append(types.Content(parts=[types.Part(text=instructions)], role="model"))
-        turns.append(types.Content(parts=[types.Part(text=".")], role="user"))
-        self._send_client_event(types.LiveClientContent(turns=turns, turn_complete=True))
+        if self._realtime_model.capabilities.mutable_chat_context:
+            # Gemini requires the last message to end with user's turn
+            # so we need to add a placeholder user turn in order to trigger a new generation
+            turns = []
+            if is_given(instructions):
+                turns.append(types.Content(parts=[types.Part(text=instructions)], role="model"))
+            turns.append(types.Content(parts=[types.Part(text=".")], role="user"))
+            self._send_client_event(types.LiveClientContent(turns=turns, turn_complete=True))
+        else:
+            # the session keeps its own history (see history_config in _build_connect_config)
+            # and rejects client turns, so the placeholder above is not accepted. realtime
+            # text input starts a generation without appending to the context.
+            self._send_client_event(
+                types.LiveClientRealtimeInput(text=instructions if is_given(instructions) else ".")
+            )
 
         def _on_timeout() -> None:
             if not fut.done():

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -836,3 +836,70 @@ async def test_failed_send_with_a_queued_update_replays_each_item_once(
         assert session._unsent_item_ids == set()
     finally:
         await session.aclose()
+
+
+async def test_generate_reply_appends_a_turn_when_the_context_is_mutable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gemini needs the context to end on a user turn, so a placeholder one triggers the reply."""
+    async with _make_connected_session(monkeypatch) as session:
+        assert session._realtime_model.capabilities.mutable_chat_context
+        fut = session.generate_reply(instructions="say hi")
+
+        contents = [m for m in await _drain_sent(session) if isinstance(m, types.LiveClientContent)]
+        assert len(contents) == 1
+        assert contents[0].turn_complete is True
+        assert [(p.text, c.role) for c in contents[0].turns or [] for p in c.parts or []] == [
+            ("say hi", "model"),
+            (".", "user"),
+        ]
+        fut.cancel()
+
+
+async def test_generate_reply_uses_realtime_text_when_the_context_is_immutable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session that owns its history rejects client turns; realtime text starts the turn.
+
+    Refusing generate_reply outright left these models with no way to open an
+    agent-initiated turn -- greetings, handoffs and post-tool prompts all go through it.
+    """
+    async with _make_configured_session(
+        monkeypatch, model="gemini-3.1-flash-live-preview"
+    ) as session:
+        assert not session._realtime_model.capabilities.mutable_chat_context
+        session._msg_ch = utils.aio.Chan[ClientEvents]()
+        session._active_session = object()  # type: ignore[assignment]
+        try:
+            fut = session.generate_reply(instructions="say hi")
+            assert not fut.done(), "the reply is no longer refused up front"
+
+            sent = await _drain_sent(session)
+            assert not [m for m in sent if isinstance(m, types.LiveClientContent)]
+            inputs = [m for m in sent if isinstance(m, types.LiveClientRealtimeInput)]
+            assert [m.text for m in inputs] == ["say hi"]
+            fut.cancel()
+        finally:
+            session._active_session = None
+
+
+async def test_generate_reply_without_instructions_nudges_an_immutable_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`instructions` is often absent, so fall back to the same "." nudge the other path uses."""
+    async with _make_configured_session(
+        monkeypatch, model="gemini-3.1-flash-live-preview"
+    ) as session:
+        session._msg_ch = utils.aio.Chan[ClientEvents]()
+        session._active_session = object()  # type: ignore[assignment]
+        try:
+            fut = session.generate_reply()
+            inputs = [
+                m
+                for m in await _drain_sent(session)
+                if isinstance(m, types.LiveClientRealtimeInput)
+            ]
+            assert [m.text for m in inputs] == ["."]
+            fut.cancel()
+        finally:
+            session._active_session = None


### PR DESCRIPTION
`generate_reply()` raised `RealtimeError` whenever `mutable_chat_context` was False. That capability is computed as `"3.1" not in model`, so every Gemini 3.1 Live model hit it — leaving those models with no way to open an agent-initiated turn at all. Greetings, replies after a handoff, and prompts issued after a tool result all go through `generate_reply()`, and each raised instead.

The capability describes whether the client may append to the conversation mid-session, not whether the model can generate. The plugin already acts on exactly that when it connects:

```python
history_config=types.HistoryConfig(initial_history_in_client_content=True)
if not self._realtime_model.capabilities.mutable_chat_context
else None,
```

A session configured that way keeps its own history and rejects the placeholder user turn `generate_reply()` sends as a trigger. That is a reason to send a *different* trigger, not to refuse — the same session accepts realtime text input, which starts a generation without touching the context.

**Fix:** drop the refusal and branch on the capability to pick the trigger. `instructions` is frequently `NOT_GIVEN` (`agent_activity` passes `instructions or NOT_GIVEN`), so the realtime-input path falls back to the same `"."` nudge the other path already uses. `_send_task` already routes `LiveClientRealtimeInput.text` to `send_realtime_input`, so the send path is unchanged.

Nothing in `agent_activity` gates `generate_reply()` on `mutable_chat_context` — its uses there are handoff reuse, chat context reset, and the interrupted-tool commit — so this is contained to the plugin, and no capability is added or changed.

**Tests:** three, covering the mutable path (placeholder turn, unchanged), the immutable path (realtime text, no client content, no longer refused up front), and the missing-`instructions` fallback. The two immutable-path tests fail on `main` with `RealtimeError: generate_reply is not compatible with 'gemini-3.1-flash-live-preview'`.

Fixes #7192