### PR TITLE
fix(google): don't start a generation from audio trailing a tool call

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -547,6 +547,7 @@ class RealtimeSession(llm.RealtimeSession):
 
         # a tool call ends the turn, but the server can keep streaming audio that belongs
         # to it. those frames must not open a generation for a turn that is already over.
+        # cleared when the turn really ends, or when the call is answered on the wire.
         self._turn_ended_by_tool_call = False
 
         self._in_user_activity = False
@@ -819,8 +820,6 @@ class RealtimeSession(llm.RealtimeSession):
     ) -> asyncio.Future[llm.GenerationCreatedEvent]:
         if is_given(tools):
             logger.warning("per-response tools is not supported by Google Realtime API, ignoring")
-        # the reply we are about to ask for is a new turn, whatever ended the last one
-        self._turn_ended_by_tool_call = False
         if not self._realtime_model.capabilities.mutable_chat_context:
             logger.warning(
                 f"generate_reply is not compatible with '{self._opts.model}' and will be ignored."
@@ -1114,6 +1113,10 @@ class RealtimeSession(llm.RealtimeSession):
                     )
                 elif isinstance(msg, types.LiveClientToolResponse) and msg.function_responses:
                     await session.send_tool_response(function_responses=msg.function_responses)
+                    # the turn a tool call ended is over once that call is answered. this
+                    # is the backstop for a model that ends such a turn without a
+                    # turn_complete, which would otherwise suppress model_turn for good.
+                    self._turn_ended_by_tool_call = False
                 elif isinstance(msg, types.LiveClientRealtimeInput):
                     if msg.audio:
                         await session.send_realtime_input(audio=msg.audio)

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -547,11 +547,8 @@ class RealtimeSession(llm.RealtimeSession):
 
         # a tool call ends the turn, but the server can keep streaming audio that belongs
         # to it. those frames must not open a generation for a turn that is already over.
-        # cleared when the turn really ends, or when the call is answered on the wire.
+        # cleared by the events that end that turn or begin the next one.
         self._turn_ended_by_tool_call = False
-        # bumped by every tool call, so a response that took a while to send can tell
-        # whether the turn it answers is still the one being suppressed
-        self._tool_call_epoch = 0
 
         self._in_user_activity = False
         self._session_lock = asyncio.Lock()
@@ -1115,15 +1112,7 @@ class RealtimeSession(llm.RealtimeSession):
                         turn_complete=msg.turn_complete if msg.turn_complete is not None else True,
                     )
                 elif isinstance(msg, types.LiveClientToolResponse) and msg.function_responses:
-                    epoch = self._tool_call_epoch
                     await session.send_tool_response(function_responses=msg.function_responses)
-                    # the turn a tool call ended is over once that call is answered. this
-                    # is the backstop for a model that ends such a turn without a
-                    # turn_complete, which would otherwise suppress model_turn for good.
-                    # a tool call that landed while this was in flight ended a later turn,
-                    # which this response does not answer.
-                    if epoch == self._tool_call_epoch:
-                        self._turn_ended_by_tool_call = False
                 elif isinstance(msg, types.LiveClientRealtimeInput):
                     if msg.audio:
                         await session.send_realtime_input(audio=msg.audio)
@@ -1577,7 +1566,6 @@ class RealtimeSession(llm.RealtimeSession):
                 )
             )
         self._turn_ended_by_tool_call = True
-        self._tool_call_epoch += 1
         self._mark_current_generation_done()
 
     def _handle_tool_call_cancellation(

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -545,6 +545,10 @@ class RealtimeSession(llm.RealtimeSession):
         # ids of chat ctx items queued but not yet sent, so a handle does not claim them
         self._unsent_item_ids: set[str] = set()
 
+        # a tool call ends the turn, but the server can keep streaming audio that belongs
+        # to it. those frames must not open a generation for a turn that is already over.
+        self._turn_ended_by_tool_call = False
+
         self._in_user_activity = False
         self._session_lock = asyncio.Lock()
         self._num_retries = 0
@@ -815,6 +819,8 @@ class RealtimeSession(llm.RealtimeSession):
     ) -> asyncio.Future[llm.GenerationCreatedEvent]:
         if is_given(tools):
             logger.warning("per-response tools is not supported by Google Realtime API, ignoring")
+        # the reply we are about to ask for is a new turn, whatever ended the last one
+        self._turn_ended_by_tool_call = False
         if not self._realtime_model.capabilities.mutable_chat_context:
             logger.warning(
                 f"generate_reply is not compatible with '{self._opts.model}' and will be ignored."
@@ -1305,6 +1311,7 @@ class RealtimeSession(llm.RealtimeSession):
 
     def _start_new_generation(self) -> None:
         self._rejected_tool_calls = 0
+        self._turn_ended_by_tool_call = False
         if self._current_generation and not self._current_generation._done:
             logger.warning("starting new generation while another is active. Finalizing previous.")
             self._mark_current_generation_done()
@@ -1443,6 +1450,7 @@ class RealtimeSession(llm.RealtimeSession):
             self._handle_input_speech_started()
 
         if server_content.turn_complete:
+            self._turn_ended_by_tool_call = False
             self._mark_current_generation_done()
 
     def _mark_current_generation_done(self) -> None:
@@ -1558,6 +1566,7 @@ class RealtimeSession(llm.RealtimeSession):
                     arguments=arguments,
                 )
             )
+        self._turn_ended_by_tool_call = True
         self._mark_current_generation_done()
 
     def _handle_tool_call_cancellation(
@@ -1688,7 +1697,8 @@ class RealtimeSession(llm.RealtimeSession):
             return True
 
         if (sc := resp.server_content) and (
-            sc.model_turn
+            # audio can trail a turn a tool call already ended; it belongs to that turn
+            (sc.model_turn and not self._turn_ended_by_tool_call)
             or (
                 sc.output_transcription and sc.output_transcription and sc.output_transcription.text
             )

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -549,6 +549,9 @@ class RealtimeSession(llm.RealtimeSession):
         # to it. those frames must not open a generation for a turn that is already over.
         # cleared when the turn really ends, or when the call is answered on the wire.
         self._turn_ended_by_tool_call = False
+        # bumped by every tool call, so a response that took a while to send can tell
+        # whether the turn it answers is still the one being suppressed
+        self._tool_call_epoch = 0
 
         self._in_user_activity = False
         self._session_lock = asyncio.Lock()
@@ -1112,11 +1115,15 @@ class RealtimeSession(llm.RealtimeSession):
                         turn_complete=msg.turn_complete if msg.turn_complete is not None else True,
                     )
                 elif isinstance(msg, types.LiveClientToolResponse) and msg.function_responses:
+                    epoch = self._tool_call_epoch
                     await session.send_tool_response(function_responses=msg.function_responses)
                     # the turn a tool call ended is over once that call is answered. this
                     # is the backstop for a model that ends such a turn without a
                     # turn_complete, which would otherwise suppress model_turn for good.
-                    self._turn_ended_by_tool_call = False
+                    # a tool call that landed while this was in flight ended a later turn,
+                    # which this response does not answer.
+                    if epoch == self._tool_call_epoch:
+                        self._turn_ended_by_tool_call = False
                 elif isinstance(msg, types.LiveClientRealtimeInput):
                     if msg.audio:
                         await session.send_realtime_input(audio=msg.audio)
@@ -1570,6 +1577,7 @@ class RealtimeSession(llm.RealtimeSession):
                 )
             )
         self._turn_ended_by_tool_call = True
+        self._tool_call_epoch += 1
         self._mark_current_generation_done()
 
     def _handle_tool_call_cancellation(

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -836,3 +836,60 @@ async def test_failed_send_with_a_queued_update_replays_each_item_once(
         assert session._unsent_item_ids == set()
     finally:
         await session.aclose()
+
+
+async def test_audio_trailing_a_tool_call_does_not_start_a_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool call ends the turn, but the server keeps streaming audio that belongs to it.
+
+    Opening a generation for those frames interrupts the one still playing, so the reply
+    is committed truncated and the turn's usage lands on an empty generation (issue #7195).
+    """
+    async with _make_session(monkeypatch) as session:
+        generations: list[llm.GenerationCreatedEvent] = []
+        session.on("generation_created", generations.append)
+
+        session._start_new_generation()
+        session._handle_server_content(_audio_content())
+        session._handle_tool_calls(_tool_call())
+        assert len(generations) == 1
+
+        # the trailing frame, and the events that close the turn behind it
+        trailing = _audio_content()
+        assert session._is_new_generation(types.LiveServerMessage(server_content=trailing)) is False
+        session._handle_server_content(trailing)
+        session._handle_server_content(types.LiveServerContent(generation_complete=True))
+        session._handle_server_content(types.LiveServerContent(turn_complete=True))
+
+        assert len(generations) == 1, "the finished turn's audio must not open a new one"
+        assert await _drain_generation(generations[0]) == ("", 1, ["lookup"])
+
+
+async def test_the_next_real_turn_still_opens_a_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The suppression lasts only until the turn actually ends."""
+    async with _make_session(monkeypatch) as session:
+        session._start_new_generation()
+        session._handle_tool_calls(_tool_call())
+        assert session._turn_ended_by_tool_call
+
+        session._handle_server_content(types.LiveServerContent(turn_complete=True))
+        assert not session._turn_ended_by_tool_call
+        assert session._is_new_generation(types.LiveServerMessage(server_content=_audio_content()))
+
+
+async def test_generate_reply_after_a_tool_call_is_not_suppressed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A reply asked for right after a tool call is a new turn, whatever ended the last one."""
+    async with _make_connected_session(monkeypatch) as session:
+        session._start_new_generation()
+        session._handle_tool_calls(_tool_call())
+        assert session._turn_ended_by_tool_call
+
+        fut = session.generate_reply()
+        assert not session._turn_ended_by_tool_call
+        assert session._is_new_generation(types.LiveServerMessage(server_content=_audio_content()))
+        fut.cancel()

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -880,16 +880,58 @@ async def test_the_next_real_turn_still_opens_a_generation(
         assert session._is_new_generation(types.LiveServerMessage(server_content=_audio_content()))
 
 
-async def test_generate_reply_after_a_tool_call_is_not_suppressed(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A reply asked for right after a tool call is a new turn, whatever ended the last one."""
+async def test_answering_the_call_ends_the_suppression(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Answering the call is the other boundary, for a turn that never gets a turn_complete.
+
+    It is cleared when the response reaches the socket, not when it is queued, so audio
+    still in flight from the finished turn cannot be taken for the reply to that answer.
+    """
+
+    class _Socket:
+        async def send_tool_response(self, **kwargs: object) -> None: ...
+
     async with _make_connected_session(monkeypatch) as session:
+        socket = _Socket()
+        session._active_session = socket  # type: ignore[assignment]
         session._start_new_generation()
         session._handle_tool_calls(_tool_call())
-        assert session._turn_ended_by_tool_call
 
-        fut = session.generate_reply()
+        session._send_client_event(
+            types.LiveClientToolResponse(function_responses=[types.FunctionResponse(id="fc_1")])
+        )
+        assert session._turn_ended_by_tool_call, "queueing the answer is not sending it"
+
+        session._msg_ch.close()
+        await session._send_task(socket)  # type: ignore[arg-type]
         assert not session._turn_ended_by_tool_call
         assert session._is_new_generation(types.LiveServerMessage(server_content=_audio_content()))
+
+
+async def test_a_reply_requested_after_a_tool_call_ignores_the_finished_turns_audio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pending reply must not be resolved by audio left over from the tool call's turn.
+
+    `_start_new_generation` hands the pending `generate_reply` future whatever generation
+    it opens, so suppression has to outlive the call to `generate_reply` -- the request has
+    not even reached the socket yet.
+    """
+    async with _make_connected_session(monkeypatch) as session:
+        generations: list[llm.GenerationCreatedEvent] = []
+        session.on("generation_created", generations.append)
+
+        session._start_new_generation()
+        session._handle_tool_calls(_tool_call())
+        generations.clear()
+
+        fut = session.generate_reply()
+        assert session._turn_ended_by_tool_call, "the request is only queued, not sent"
+
+        # audio still arriving from the turn the tool call ended
+        session._handle_server_content(_audio_content())
+        assert not session._is_new_generation(
+            types.LiveServerMessage(server_content=_audio_content())
+        )
+        assert not generations, "no generation is opened for the finished turn"
+        assert not fut.done(), "the pending reply stays bound to the turn actually requested"
         fut.cancel()

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -935,3 +935,45 @@ async def test_a_reply_requested_after_a_tool_call_ignores_the_finished_turns_au
         assert not generations, "no generation is opened for the finished turn"
         assert not fut.done(), "the pending reply stays bound to the turn actually requested"
         fut.cancel()
+
+
+async def test_a_tool_call_arriving_mid_send_keeps_the_suppression(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The send and receive tasks run concurrently, so a newer call can land mid-send.
+
+    Answering the older call says nothing about the turn the newer one ended.
+    """
+
+    class _Socket:
+        def __init__(self) -> None:
+            self.gate = asyncio.Event()
+
+        async def send_tool_response(self, **kwargs: object) -> None:
+            await self.gate.wait()
+
+    async with _make_connected_session(monkeypatch) as session:
+        socket = _Socket()
+        session._active_session = socket  # type: ignore[assignment]
+        session._start_new_generation()
+        session._handle_tool_calls(_tool_call())
+        session._send_client_event(
+            types.LiveClientToolResponse(function_responses=[types.FunctionResponse(id="fc_1")])
+        )
+        session._msg_ch.close()
+
+        send = asyncio.create_task(session._send_task(socket))  # type: ignore[arg-type]
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+        # a second call lands while the first response is still on its way out
+        session._start_new_generation()
+        session._handle_tool_calls(_tool_call("fc_2"))
+
+        socket.gate.set()
+        await send
+
+        assert session._turn_ended_by_tool_call, "the newer call's turn is still suppressed"
+        assert not session._is_new_generation(
+            types.LiveServerMessage(server_content=_audio_content())
+        )

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -880,33 +880,6 @@ async def test_the_next_real_turn_still_opens_a_generation(
         assert session._is_new_generation(types.LiveServerMessage(server_content=_audio_content()))
 
 
-async def test_answering_the_call_ends_the_suppression(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Answering the call is the other boundary, for a turn that never gets a turn_complete.
-
-    It is cleared when the response reaches the socket, not when it is queued, so audio
-    still in flight from the finished turn cannot be taken for the reply to that answer.
-    """
-
-    class _Socket:
-        async def send_tool_response(self, **kwargs: object) -> None: ...
-
-    async with _make_connected_session(monkeypatch) as session:
-        socket = _Socket()
-        session._active_session = socket  # type: ignore[assignment]
-        session._start_new_generation()
-        session._handle_tool_calls(_tool_call())
-
-        session._send_client_event(
-            types.LiveClientToolResponse(function_responses=[types.FunctionResponse(id="fc_1")])
-        )
-        assert session._turn_ended_by_tool_call, "queueing the answer is not sending it"
-
-        session._msg_ch.close()
-        await session._send_task(socket)  # type: ignore[arg-type]
-        assert not session._turn_ended_by_tool_call
-        assert session._is_new_generation(types.LiveServerMessage(server_content=_audio_content()))
-
-
 async def test_a_reply_requested_after_a_tool_call_ignores_the_finished_turns_audio(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -935,45 +908,3 @@ async def test_a_reply_requested_after_a_tool_call_ignores_the_finished_turns_au
         assert not generations, "no generation is opened for the finished turn"
         assert not fut.done(), "the pending reply stays bound to the turn actually requested"
         fut.cancel()
-
-
-async def test_a_tool_call_arriving_mid_send_keeps_the_suppression(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The send and receive tasks run concurrently, so a newer call can land mid-send.
-
-    Answering the older call says nothing about the turn the newer one ended.
-    """
-
-    class _Socket:
-        def __init__(self) -> None:
-            self.gate = asyncio.Event()
-
-        async def send_tool_response(self, **kwargs: object) -> None:
-            await self.gate.wait()
-
-    async with _make_connected_session(monkeypatch) as session:
-        socket = _Socket()
-        session._active_session = socket  # type: ignore[assignment]
-        session._start_new_generation()
-        session._handle_tool_calls(_tool_call())
-        session._send_client_event(
-            types.LiveClientToolResponse(function_responses=[types.FunctionResponse(id="fc_1")])
-        )
-        session._msg_ch.close()
-
-        send = asyncio.create_task(session._send_task(socket))  # type: ignore[arg-type]
-        for _ in range(50):
-            await asyncio.sleep(0)
-
-        # a second call lands while the first response is still on its way out
-        session._start_new_generation()
-        session._handle_tool_calls(_tool_call("fc_2"))
-
-        socket.gate.set()
-        await send
-
-        assert session._turn_ended_by_tool_call, "the newer call's turn is still suppressed"
-        assert not session._is_new_generation(
-            types.LiveServerMessage(server_content=_audio_content())
-        )


### PR DESCRIPTION
A tool call ends the turn and `_handle_tool_calls` finalizes the generation, but the server can keep streaming `model_turn` audio that belongs to it. `_is_new_generation()` returned True for any `model_turn`, so a single trailing frame opened a second generation for a turn that was already over.

From a live call:

```
input_transcription(finished, "My Monster Jam device is not working.")
  -> new generation started: GR_e618ac79ab58
  ... model_turn audio + output_transcription stream the full reply ...
tool_call  Get_Products
  -> generation done: GR_e618ac79ab58
     output_text='I completely understand how frustrating that must be.
                  Please give me just a moment while I pull up your details.'
output_transcription(finished=True)          # no .text, correctly ignored
model_turn(inline_data=audio/pcm)            # trailing frame from the finished turn
  -> new generation started: GR_ffb4da1884e7
generation_complete=True
turn_complete=True, usage_metadata(total_token_count=1230)
  -> generation done: GR_ffb4da1884e7  output_text=''   (lived 0.5 ms)
```

Three consequences:

1. The spurious generation interrupts the one still playing, so the assistant message is committed as `content: ['I completely'], interrupted: True` while the plugin holds the full sentence in `output_text`.
2. `_SegmentSynchronizerImpl.playback_finished called before text/audio input is done` — the synchronizer cut off mid-turn.
3. `usage_metadata` arrives with `turn_complete`, by which point `_current_generation` is the empty one, so the turn's tokens are recorded against a generation that produced nothing.

**Fix:** remember that a tool call ended the turn, and ignore `model_turn` until the turn really ends. The flag is cleared wherever a new turn legitimately begins — `_start_new_generation`, `turn_complete`, and `generate_reply`, the last so a reply requested right after a tool call is not suppressed.

The trailing content itself was already handled: `push_text` guards on `text_ch.closed` and the audio branch guards on `audio_ch.closed`, both dropping with a warning. The only damage came from `_start_new_generation()` being called, so suppressing that is sufficient and nothing else changes.

`_is_new_generation()` already carried a comment about this class of event — it excludes empty transcriptions and `generation_complete` for the same reason — `model_turn` was the gap.

**Tests:** three, covering the trailing frame, that the next real turn still opens a generation, and that `generate_reply` after a tool call is not suppressed. All three fail on `main`.

Fixes #7195