### PR TITLE
plugins/phonic: make allow_tool_chaining configurable per tool

### DIFF
--- a/livekit-plugins/livekit-plugins-phonic/README.md
+++ b/livekit-plugins/livekit-plugins-phonic/README.md
@@ -151,10 +151,11 @@ RealtimeModel(
 | `require_speech_before_tool_call` | `bool` | `False` | Require the agent to speak before the tool can be called |
 | `forbid_speech_after_tool_call` | `bool` | `False` | Suppress the auto-generated spoken reply after the tool. Use for tools that always hand off to another agent (a non-handoff tool set here would leave the agent silent) |
 | `forbid_tool_call_after_speech` | `bool` | `False` | Drop the tool call if the agent already spoke this turn |
+| `allow_tool_chaining` | `bool` | `False` | Allow another tool call immediately after this tool's output |
 | `respond_after_sec` | `float` | — | **`choose_not_to_respond` only.** Seconds to wait after the tool fires; if the user stays silent, the agent speaks a follow-up. Omit to keep the default (stay silent). |
 | `speech_before_tool_call` | `str` | — | **`keypad_input` / `natural_conversation_ending` only.** `required` \| `optional` \| `suppressed`. |
 
-The plugin always sends tool calls with `wait_for_speech_before_tool_call` on and `allow_tool_chaining` off; these are not configurable per tool.
+The plugin always sends tool calls with `wait_for_speech_before_tool_call` on; this is not configurable per tool.
 
 > **Deprecated:** the top-level `forbid_speech_after_tool_call: list[str]` option still works but is deprecated — it now folds each listed tool into `configs_for_tools` as `forbid_speech_after_tool_call=True` (an explicit `configs_for_tools` entry wins) and logs a warning. Prefer `configs_for_tools`.
 

--- a/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
+++ b/livekit-plugins/livekit-plugins-phonic/livekit/plugins/phonic/realtime/realtime_model.py
@@ -72,6 +72,7 @@ class PhonicToolConfig(TypedDict, total=False):
     require_speech_before_tool_call: bool
     forbid_speech_after_tool_call: bool
     forbid_tool_call_after_speech: bool
+    allow_tool_chaining: bool
     # Built-in tools only (set on the matching ``phonic_tools`` entry):
     respond_after_sec: float  # choose_not_to_respond: seconds to wait before a follow-up (or omit)
     speech_before_tool_call: (
@@ -659,13 +660,13 @@ class RealtimeSession(llm.RealtimeSession):
                     "type": "custom_websocket",
                     "tool_schema": tool_schema,
                     "tool_call_output_timeout_ms": TOOL_CALL_OUTPUT_TIMEOUT_MS,
-                    # fixed, not configurable: the plugin does not support tool chaining or tool
-                    # calls during agent speech within the Realtime generations framework
+                    # fixed, not configurable: the plugin does not support tool calls during
+                    # agent speech
                     "wait_for_speech_before_tool_call": True,
-                    "allow_tool_chaining": False,
                     "require_speech_before_tool_call": cfg.get(
                         "require_speech_before_tool_call", False
                     ),
+                    "allow_tool_chaining": cfg.get("allow_tool_chaining", False),
                     "forbid_speech_after_tool_call": cfg.get(
                         "forbid_speech_after_tool_call", False
                     ),
@@ -1447,8 +1448,8 @@ class RealtimeSession(llm.RealtimeSession):
             )
         )
 
-        # At most 1 tool call is supported per turn due to `allow_tool_chaining: False`,
-        # allowing us to close the generation.
+        # Close the generation after the tool call. With allow_tool_chaining enabled, any
+        # chained follow-up call arrives as a new generation.
         self._close_current_generation(interrupted=False)
 
     def _handle_tool_call_interrupted(self, message: ToolCallInterruptedPayload) -> None:


### PR DESCRIPTION
Adds `allow_tool_chaining` to the Phonic plugin's per-tool `configs_for_tools`, alongside the existing `require_speech_before_tool_call` / `forbid_speech_after_tool_call` / `forbid_tool_call_after_speech` options.

Defaults to `False`, so existing behavior is unchanged. Set it per tool to allow another tool call immediately after that tool's output.