### PR TITLE
feat(voice): expose SpeechHandle.hold_interruptions context manager

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -2057,11 +2057,11 @@ class AgentActivity(RecognitionHooks):
         try:
             self.interrupt()  # input_speech_started is also interrupting on the serverside realtime session  # noqa: E501
         except RuntimeError:
-            # only out of sync when the server cancelled its own response, with client-side turn
-            # taking an uninterruptible speech is expected
+            # held / allow_interruptions=False speech is expected under server turn detection;
+            # force=True still cuts through. Avoid exception-level noise on that path.
             if self._rt_turn_detection_enabled:
-                logger.exception(
-                    "RealtimeAPI input_speech_started, but current speech is not interruptable, this should never happen!"  # noqa: E501
+                logger.debug(
+                    "RealtimeAPI input_speech_started while current speech is not interruptable"
                 )
 
     def _on_input_speech_stopped(self, ev: llm.InputSpeechStoppedEvent) -> None:

--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -157,6 +157,23 @@ class SpeechHandle:
             with contextlib.suppress(RuntimeError):
                 self.allow_interruptions = self._interruption_holds_restore
 
+    @contextlib.contextmanager
+    def hold_interruptions(self) -> Generator[SpeechHandle, None, None]:
+        """Temporarily disallow interruptions on this speech (counted, restoring).
+
+        Nested or overlapping holders compose: the first holder remembers the previous
+        ``allow_interruptions`` value and the last release restores it.
+        ``interrupt(force=True)`` still cuts through a hold.
+
+        Yields:
+            SpeechHandle: this handle.
+        """
+        self._hold_interruptions()
+        try:
+            yield self
+        finally:
+            self._release_interruptions()
+
     @property
     def chat_items(self) -> list[llm.ChatItem]:
         return self._chat_items

--- a/livekit-agents/livekit/agents/voice/speech_handle.py
+++ b/livekit-agents/livekit/agents/voice/speech_handle.py
@@ -121,6 +121,10 @@ class SpeechHandle:
         interruption requests until re-enabled. If the handle is already
         interrupted, clearing interruptions is not allowed.
 
+        While one or more ``hold_interruptions()`` holders are active, assignments
+        update the value restored after the final release; the effective
+        interruption state stays False until then.
+
         Args:
             value (bool): True to allow interruptions, False to disallow.
 
@@ -131,6 +135,11 @@ class SpeechHandle:
             raise RuntimeError(
                 "Cannot set allow_interruptions to False, the SpeechHandle is already interrupted"
             )
+
+        if self._interruption_holds > 0:
+            # Keep the hold effective; remember what to restore on final release.
+            self._interruption_holds_restore = value
+            return
 
         self._allow_interruptions = value
 
@@ -162,7 +171,9 @@ class SpeechHandle:
         """Temporarily disallow interruptions on this speech (counted, restoring).
 
         Nested or overlapping holders compose: the first holder remembers the previous
-        ``allow_interruptions`` value and the last release restores it.
+        ``allow_interruptions`` value and the last release restores it. Assignments to
+        ``allow_interruptions`` during a hold update that restored value; the effective
+        state stays False until the final release.
         ``interrupt(force=True)`` still cuts through a hold.
 
         Yields:

--- a/tests/test_speech_handle_hold_interruptions.py
+++ b/tests/test_speech_handle_hold_interruptions.py
@@ -1,0 +1,53 @@
+"""Public SpeechHandle.hold_interruptions() context manager (issue #7191)."""
+
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents.voice.speech_handle import SpeechHandle
+
+pytestmark = pytest.mark.unit
+
+
+def test_hold_interruptions_disallows_then_restores() -> None:
+    handle = SpeechHandle.create(allow_interruptions=True)
+
+    with handle.hold_interruptions() as held:
+        assert held is handle
+        assert handle.allow_interruptions is False
+        with pytest.raises(RuntimeError, match="does not allow interruptions"):
+            handle.interrupt()
+
+    assert handle.allow_interruptions is True
+    handle.interrupt()
+    assert handle.interrupted
+
+
+def test_hold_interruptions_nested_restores_once() -> None:
+    handle = SpeechHandle.create(allow_interruptions=True)
+
+    with handle.hold_interruptions():
+        assert handle.allow_interruptions is False
+        with handle.hold_interruptions():
+            assert handle.allow_interruptions is False
+        # inner release must not restore while outer still holds
+        assert handle.allow_interruptions is False
+
+    assert handle.allow_interruptions is True
+
+
+def test_hold_interruptions_preserves_prior_false() -> None:
+    handle = SpeechHandle.create(allow_interruptions=False)
+
+    with handle.hold_interruptions():
+        assert handle.allow_interruptions is False
+
+    assert handle.allow_interruptions is False
+
+
+def test_force_interrupt_bypasses_hold() -> None:
+    handle = SpeechHandle.create(allow_interruptions=True)
+
+    with handle.hold_interruptions():
+        handle.interrupt(force=True)
+        assert handle.interrupted

--- a/tests/test_speech_handle_hold_interruptions.py
+++ b/tests/test_speech_handle_hold_interruptions.py
@@ -51,3 +51,50 @@ def test_force_interrupt_bypasses_hold() -> None:
     with handle.hold_interruptions():
         handle.interrupt(force=True)
         assert handle.interrupted
+
+
+def test_allow_interruptions_true_during_hold_restores_after_release() -> None:
+    handle = SpeechHandle.create(allow_interruptions=False)
+
+    with handle.hold_interruptions():
+        assert handle.allow_interruptions is False
+        handle.allow_interruptions = True
+        # assignment is deferred; hold stays effective
+        assert handle.allow_interruptions is False
+        with pytest.raises(RuntimeError, match="does not allow interruptions"):
+            handle.interrupt()
+
+    assert handle.allow_interruptions is True
+    handle.interrupt()
+    assert handle.interrupted
+
+
+def test_allow_interruptions_false_during_nested_holds_restores_after_final() -> None:
+    handle = SpeechHandle.create(allow_interruptions=True)
+
+    with handle.hold_interruptions():
+        assert handle.allow_interruptions is False
+        handle.allow_interruptions = True
+        assert handle.allow_interruptions is False
+        with handle.hold_interruptions():
+            handle.allow_interruptions = False
+            assert handle.allow_interruptions is False
+        # outer still holds; still not interruptible
+        assert handle.allow_interruptions is False
+        with pytest.raises(RuntimeError, match="does not allow interruptions"):
+            handle.interrupt()
+
+    assert handle.allow_interruptions is False
+    with pytest.raises(RuntimeError, match="does not allow interruptions"):
+        handle.interrupt()
+
+
+def test_force_interrupt_still_works_after_deferred_true_assignment() -> None:
+    handle = SpeechHandle.create(allow_interruptions=True)
+
+    with handle.hold_interruptions():
+        handle.allow_interruptions = True
+        assert handle.allow_interruptions is False
+        handle.interrupt(force=True)
+        assert handle.interrupted
+


### PR DESCRIPTION
## Summary

Fixes #7191.

`SpeechHandle._hold_interruptions()` / `_release_interruptions()` already implement counted, restoring per-utterance barge-in protection, but were private. Realtime callers that need one `say()` (or a group of them) to survive server-side turn detection had no supported API: `allow_interruptions=False` is scrubbed under realtime, and a bare setter does not compose across overlapping holders.

This exposes a public context manager that wraps the existing hold/release, and demotes the realtime `input_speech_started` "not interruptable" path from `logger.exception` to `logger.debug`, since that path is reachable by design once holds are supported (`interrupt(force=True)` still cuts through).

## Changes

- `livekit-agents/livekit/agents/voice/speech_handle.py`: add `SpeechHandle.hold_interruptions()` context manager
- `livekit-agents/livekit/agents/voice/agent_activity.py`: debug-level log when realtime barge-in hits a non-interruptable speech
- `tests/test_speech_handle_hold_interruptions.py`: unit coverage for restore, nesting, prior-False preserve, and `force=True`

## Usage

```python
handle = session.say(text)
with handle.hold_interruptions():
    await handle.wait_for_playout()
```

## Test plan

- [x] `uv run --directory livekit-agents pytest ../tests/test_speech_handle_hold_interruptions.py -q` (4 passed)