### PR TITLE
feat(voice): log which participant RoomIO links to

### DIFF
--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -329,6 +329,11 @@ class RoomIO:
         if self._user_tr_output:
             self._user_tr_output.set_participant(participant_identity)
 
+        logger.info(
+            "RoomIO linked to participant",
+            extra={"participant": participant_identity, "room": self._room.name},
+        )
+
     def unset_participant(self) -> None:
         self._participant_identity = None
         self._participant_available_fut = asyncio.Future[rtc.RemoteParticipant]()

--- a/livekit-agents/livekit/agents/voice/room_io/room_io.py
+++ b/livekit-agents/livekit/agents/voice/room_io/room_io.py
@@ -8,6 +8,7 @@ from livekit import api, rtc
 from ... import utils
 from ...job import get_job_context
 from ...log import logger
+from ...telemetry import trace_types
 from ...types import (
     ATTRIBUTE_AGENT_STATE,
     ATTRIBUTE_PUBLISH_ON_BEHALF,
@@ -331,7 +332,10 @@ class RoomIO:
 
         logger.info(
             "RoomIO linked to participant",
-            extra={"participant": participant_identity, "room": self._room.name},
+            extra={
+                trace_types.ATTR_PARTICIPANT_IDENTITY: participant_identity,
+                trace_types.ATTR_ROOM_NAME: self._room.name,
+            },
         )
 
     def unset_participant(self) -> None:


### PR DESCRIPTION
## Motivation

RoomIO feeds the agent's pipeline from a single linked participant, but the linking decision is currently silent — there is no log at any level saying which participant was linked.

This makes a mislinked agent very hard to diagnose: with autosubscribe the agent still subscribes to every track in the room, so RTC-level subscriptions look healthy while the pipeline receives zero frames. We hit exactly this in a customer session where a listen-only observer participant (STANDARD kind, no published tracks) joined the room ~500ms before the SIP caller: the agent linked to the observer, heard nothing for the entire call, and the only clue was the absence of any user activity.

## Change

Log the linked participant identity at info level in `RoomIO.set_participant`, which covers both the initial automatic link and any later switch.

```
RoomIO linked to participant {"participant": "sip_+13146206985", "room": "..."}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)