### PR TITLE
feat(plugins-tavus): default to the stock Lucy face when no face or pal is given

### DIFF
--- a/livekit-plugins/livekit-plugins-tavus/livekit/plugins/tavus/api.py
+++ b/livekit-plugins/livekit-plugins-tavus/livekit/plugins/tavus/api.py
@@ -98,7 +98,10 @@ class TavusAPI:
             or NOT_GIVEN
         )
 
-        if not pal_id:
+        # extra_payload overrides the payload wholesale, so a pal named there counts
+        # as user-supplied when deciding whether to fill in the stock face.
+        extra = dict(extra_payload) if utils.is_given(extra_payload) else {}
+        if not pal_id and not extra.get("pal_id"):
             # no pal supplied — use the default stock pal and, unless overridden, its stock face
             pal_id = DEFAULT_PAL_ID
             face_id = face_id or DEFAULT_FACE_ID
@@ -108,8 +111,7 @@ class TavusAPI:
         # a user-supplied pal carries its own default face, so only send face_id when we have one
         if face_id:
             payload["face_id"] = face_id
-        if utils.is_given(extra_payload):
-            payload.update(extra_payload)
+        payload.update(extra)
 
         if "conversation_name" not in payload:
             payload["conversation_name"] = utils.shortuuid("lk_conversation_")

--- a/livekit-plugins/livekit-plugins-tavus/livekit/plugins/tavus/api.py
+++ b/livekit-plugins/livekit-plugins-tavus/livekit/plugins/tavus/api.py
@@ -24,6 +24,8 @@ class TavusException(Exception):
 DEFAULT_API_URL = "https://tavusapi.com/v2"
 # Stock Tavus PAL. Use create_pal() to create a PAL with the appearance you'd like.
 DEFAULT_PAL_ID = "pb87e71797da"
+# Stock Tavus face ("Lucy - Home", phoenix-4.5) used with DEFAULT_PAL_ID when no face is given.
+DEFAULT_FACE_ID = "r4067604db72"
 
 
 def _coalesce_with_deprecated(
@@ -97,12 +99,13 @@ class TavusAPI:
         )
 
         if not pal_id:
-            # no pal supplied — use the default stock pal (carries its own face)
+            # no pal supplied — use the default stock pal and, unless overridden, its stock face
             pal_id = DEFAULT_PAL_ID
+            face_id = face_id or DEFAULT_FACE_ID
 
         properties = properties or {}
         payload: dict[str, Any] = {"pal_id": pal_id, "properties": properties}
-        # send face_id only when given; otherwise the pal's default_face_id is used
+        # a user-supplied pal carries its own default face, so only send face_id when we have one
         if face_id:
             payload["face_id"] = face_id
         if utils.is_given(extra_payload):

--- a/livekit-plugins/livekit-plugins-tavus/tests/test_tavus.py
+++ b/livekit-plugins/livekit-plugins-tavus/tests/test_tavus.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from livekit.agents.utils import http_context
-from livekit.plugins.tavus.api import DEFAULT_PAL_ID, TavusAPI
+from livekit.plugins.tavus.api import DEFAULT_FACE_ID, DEFAULT_PAL_ID, TavusAPI
 from livekit.plugins.tavus.avatar import AvatarSession
 
 pytestmark = pytest.mark.unit
@@ -118,14 +118,24 @@ async def test_pal_id_only_skips_pal_creation_and_omits_face():
     assert "face_id" not in payload
 
 
-async def test_defaults_to_stock_pal_when_neither_given():
+async def test_defaults_to_stock_pal_and_face_when_neither_given():
     api = _api()
     with patch.object(api, "_post", new=_mock_post()) as m:
         await api.create_conversation()
     assert "pals" not in [c.args[0] for c in m.call_args_list]  # no pal is created
     payload = m.call_args.args[1]
     assert payload["pal_id"] == DEFAULT_PAL_ID
-    assert "face_id" not in payload
+    assert payload["face_id"] == DEFAULT_FACE_ID
+
+
+async def test_env_face_wins_over_default_face(monkeypatch):
+    monkeypatch.setenv("TAVUS_FACE_ID", "envf")
+    api = _api()
+    with patch.object(api, "_post", new=_mock_post()) as m:
+        await api.create_conversation()
+    payload = m.call_args.args[1]
+    assert payload["pal_id"] == DEFAULT_PAL_ID
+    assert payload["face_id"] == "envf"
 
 
 async def test_avatar_session_resolves_new_and_deprecated_args():

--- a/livekit-plugins/livekit-plugins-tavus/tests/test_tavus.py
+++ b/livekit-plugins/livekit-plugins-tavus/tests/test_tavus.py
@@ -128,6 +128,16 @@ async def test_defaults_to_stock_pal_and_face_when_neither_given():
     assert payload["face_id"] == DEFAULT_FACE_ID
 
 
+async def test_extra_payload_pal_keeps_its_own_face():
+    api = _api()
+    with patch.object(api, "_post", new=_mock_post()) as m:
+        await api.create_conversation(extra_payload={"pal_id": "custom-pal"})
+    payload = m.call_args.args[1]
+    # extra_payload replaces the pal, so the stock face must not be attached to it
+    assert payload["pal_id"] == "custom-pal"
+    assert "face_id" not in payload
+
+
 async def test_env_face_wins_over_default_face(monkeypatch):
     monkeypatch.setenv("TAVUS_FACE_ID", "envf")
     api = _api()


### PR DESCRIPTION
Replaces #7209, which had commits authored under the wrong git identity and so could not pass the CLA check. Content is identical (same tree), including the fix for the review feedback there.

## Summary

When neither `face_id` nor `pal_id` is supplied, the plugin falls back to the stock pal (`DEFAULT_PAL_ID`) and omitted `face_id`, so the pal's own default face was used — currently Luna (`r9d30b0e55ac`, phoenix-3). This adds `DEFAULT_FACE_ID = "r4067604db72"` (stock "Lucy - Home", phoenix-4.5) and sends it explicitly in that fully-default case.

Existing behaviour is preserved everywhere else:
- a user-supplied `pal_id` still carries its own default face (`face_id` stays omitted)
- a `pal_id` supplied via `extra_payload` likewise keeps its own face — `extra_payload` overrides the payload, so the effective pal is resolved from both sources before the face is defaulted
- an explicit `face_id`, or `TAVUS_FACE_ID` / deprecated `TAVUS_REPLICA_ID`, still wins

## Test plan

- `test_defaults_to_stock_pal_and_face_when_neither_given` asserts `face_id == DEFAULT_FACE_ID`
- `test_extra_payload_pal_keeps_its_own_face` covers the `extra_payload` pal case
- `test_env_face_wins_over_default_face` covers `TAVUS_FACE_ID` overriding the default
- existing `test_pal_id_only_skips_pal_creation_and_omits_face` still guards the named-pal case
- `pytest livekit-plugins/livekit-plugins-tavus/tests/test_tavus.py`: 8 passed, 3 failed — the 3 failures (`*_still_work_and_warn`, `test_avatar_session_resolves_new_and_deprecated_args`) are pre-existing on `main` (same 3 fail on an untouched checkout) and unrelated: they expect `DeprecationWarning` while the code emits `logger.warning`
- `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)