### PR TITLE
fix(ipc): ThreadJobExecutor.aclose() hangs when the runner exits before its ack is read

### DIFF
--- a/livekit-agents/livekit/agents/ipc/job_thread_executor.py
+++ b/livekit-agents/livekit/agents/ipc/job_thread_executor.py
@@ -289,6 +289,14 @@ class ThreadJobExecutor:
 
         await self._join_fut
 
+        # the thread closes its end of the duplex before signaling the join, so the monitor
+        # task ends on its own once it has read what the thread sent last (ShutdownRequestAck
+        # and ShuttingDown on a shutdown). let it get there instead of cancelling it with those
+        # messages still unread; the timeout only covers a thread that died without closing
+        # its end of the channel
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(monitor_task), timeout=1.0)
+
         await utils.aio.cancel_and_wait(ping_task, monitor_task)
         await utils.aio.cancel_and_wait(*self._inference_tasks)
 
@@ -299,39 +307,47 @@ class ThreadJobExecutor:
 
     @utils.log_exceptions(logger=logger)
     async def _monitor_task(self) -> None:
-        while True:
-            try:
-                msg = await channel.arecv_message(self._pch, proto.IPC_MESSAGES)
-            except utils.aio.duplex_unix.DuplexClosed:
-                break
+        try:
+            while True:
+                try:
+                    msg = await channel.arecv_message(self._pch, proto.IPC_MESSAGES)
+                except utils.aio.duplex_unix.DuplexClosed:
+                    break
 
-            if isinstance(msg, proto.PongResponse):
-                delay = utils.time_ms() - msg.timestamp
-                if delay > self._opts.high_ping_threshold * 1000:
-                    logger.warning(
-                        "job executor is unresponsive",
-                        extra={"delay": delay, **self.logging_extra()},
+                if isinstance(msg, proto.PongResponse):
+                    delay = utils.time_ms() - msg.timestamp
+                    if delay > self._opts.high_ping_threshold * 1000:
+                        logger.warning(
+                            "job executor is unresponsive",
+                            extra={"delay": delay, **self.logging_extra()},
+                        )
+
+                if isinstance(msg, proto.ShutdownRequestAck):
+                    if not self._shutdown_ack_fut.done():
+                        self._shutdown_ack_fut.set_result(None)
+
+                if isinstance(msg, proto.ShuttingDown):
+                    if not self._shutting_down_fut.done():
+                        self._shutting_down_fut.set_result(None)
+
+                if isinstance(msg, proto.Exiting):
+                    logger.debug(
+                        "job exiting", extra={"reason": msg.reason, **self.logging_extra()}
                     )
 
-            if isinstance(msg, proto.ShutdownRequestAck):
-                if not self._shutdown_ack_fut.done():
-                    self._shutdown_ack_fut.set_result(None)
-
-            if isinstance(msg, proto.ShuttingDown):
-                if not self._shutting_down_fut.done():
-                    self._shutting_down_fut.set_result(None)
-
-            if isinstance(msg, proto.Exiting):
-                logger.debug("job exiting", extra={"reason": msg.reason, **self.logging_extra()})
-
-            if isinstance(msg, proto.InferenceRequest):
-                task = asyncio.create_task(self._do_inference_task(msg))
-                self._inference_tasks.add(task)
-                task.add_done_callback(self._inference_tasks.discard)
-
-        # resolve pending futures when the channel closes
-        if not self._shutdown_ack_fut.done():
-            self._shutdown_ack_fut.set_result(None)
+                if isinstance(msg, proto.InferenceRequest):
+                    task = asyncio.create_task(self._do_inference_task(msg))
+                    self._inference_tasks.add(task)
+                    task.add_done_callback(self._inference_tasks.discard)
+        finally:
+            # this task is the sole reader of the IPC channel; once it ends, the thread is gone
+            # (channel closed) or being torn down (cancelled). resolve the shutdown futures here
+            # so aclose() never waits for an ack or a ShuttingDown that can't arrive anymore
+            # (same as SupervisedProc._on_read_ipc_done)
+            if not self._shutdown_ack_fut.done():
+                self._shutdown_ack_fut.set_result(None)
+            if not self._shutting_down_fut.done():
+                self._shutting_down_fut.set_result(None)
 
     @utils.log_exceptions(logger=logger)
     async def _ping_task(self) -> None:

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -610,6 +610,79 @@ async def test_job_graceful_shutdown():
     assert start_args.shutdown_counter.value == 1
 
 
+def _create_thread_proc(
+    *,
+    close_timeout: float,
+    job_entrypoint_fnc: Callable[[JobContext], object] = _job_entrypoint,
+) -> tuple[ipc.job_thread_executor.ThreadJobExecutor, _StartArgs]:
+    # the runner is a thread of the test process, so the mp primitives of _StartArgs are plain
+    # in-process synchronization here
+    start_args = _new_start_args(mp.get_context("spawn"))
+    loop = asyncio.get_running_loop()
+    proc = ipc.job_thread_executor.ThreadJobExecutor(
+        initialize_process_fnc=_initialize_proc,
+        job_entrypoint_fnc=job_entrypoint_fnc,
+        session_end_fnc=None,
+        simulation_end_fnc=None,
+        inference_executor=None,
+        initialize_timeout=20.0,
+        close_timeout=close_timeout,
+        session_end_timeout=300.0,
+        ping_interval=2.5,
+        high_ping_threshold=1.0,
+        http_proxy=None,
+        loop=loop,
+    )
+    proc.user_arguments = start_args
+    return proc, start_args
+
+
+async def test_thread_shutdown_no_job():
+    proc, start_args = _create_thread_proc(close_timeout=10.0)
+    await proc.start()
+    await proc.initialize()
+    # bounded: a thread runner can't be killed, so a regression here would otherwise hang
+    await asyncio.wait_for(proc.aclose(), timeout=30.0)
+
+    assert proc.status == ipc.job_executor.JobStatus.SUCCESS
+    assert start_args.shutdown_counter.value == 0, "shutdown_cb isn't called when there is no job"
+
+
+async def test_thread_shutdown_no_job_join_before_ack_is_read():
+    """Regression test: an idle thread runner acks the ShutdownRequest, sends ShuttingDown
+    and exits at once. When the loop is busy at that moment, the join is observed before those
+    two messages are read, and aclose() used to cancel their only reader: the ack was reported
+    missing after close_timeout, and the wait for ShuttingDown never returned."""
+    proc, start_args = _create_thread_proc(close_timeout=2.0)
+    await proc.start()
+    await proc.initialize()
+
+    close_task = asyncio.create_task(proc.aclose())
+    await asyncio.sleep(0)  # aclose() has sent the ShutdownRequest and awaits the ack
+    time.sleep(0.5)  # block the loop while the runner acks, sends ShuttingDown and exits
+
+    started_at = time.monotonic()
+    await asyncio.wait_for(close_task, timeout=5.0)
+    assert time.monotonic() - started_at < 1.0, "aclose() waited for an ack that was sent"
+    assert proc.status == ipc.job_executor.JobStatus.SUCCESS
+    assert start_args.shutdown_counter.value == 0
+
+
+async def test_thread_job_graceful_shutdown():
+    proc, start_args = _create_thread_proc(close_timeout=10.0)
+    start_args.shutdown_simulate_work_time = 0.3
+    await proc.start()
+    await proc.initialize()
+
+    fake_job = _generate_fake_job()
+    await proc.launch_job(fake_job)
+    await _poll_until(lambda: start_args.entrypoint_counter.value >= 1)
+    await asyncio.wait_for(proc.aclose(), timeout=30.0)
+
+    assert proc.status == ipc.job_executor.JobStatus.SUCCESS
+    assert start_args.shutdown_counter.value == 1
+
+
 def test_log_queue_drains_before_stop():
     """All log records must be received by the listener even when stop() is
     called right after the sender closes its end.  This reproduces a race where


### PR DESCRIPTION
### Bug description
With `JobExecutorType.THREAD`, a graceful shutdown of a worker that has idle prewarmed runners logs `job did not ack shutdown in time` for most of them and then **never exits**. `drain()` has already returned by then, so `drain_timeout` doesn't help. Only a second signal ends the process. On a 16-core host (so 16 idle runners) I've been consistently reproducing this on every shutdown.

### Why
`ThreadJobExecutor._main_task()` cancels `_monitor_task` as soon as the runner thread joins. An idle runner replies `ShutdownRequestAck` + `ShuttingDown` and exits right away, and its join callback (`call_soon_threadsafe`) is queued ahead of the socket read, so the monitor is cancelled with both messages still unread in the `StreamReader`. Nothing else resolves `_shutting_down_fut`, and `aclose()` awaits it with no timeout right after the ack timeout. `SupervisedProc` already handles this case (`_on_read_ipc_done` resolves both futures when its reader ends), but the thread executor never got the equivalent and has no kill path to fall back on. The result is the parent process hangs indefinetly instead of dying.

### Fix
Simple change at [job_thread_executor.py](https://github.com/pabloFuente/agents/commit/7d3af0da22c997ad24176f3a2095a550cf6dcbbd#diff-cc3bc606f0a8dc00d841c30b1e5ac9f6a59e3476e0776c31b77e3d8200f9a64a)
- After the join, let `_monitor_task` finish on its own (bounded to 1 s) before cancelling it. The thread closes its end of the channel before joining, so the monitor reads the pending   messages and ends on `DuplexClosed`.
- Resolve `_shutdown_ack_fut` and `_shutting_down_fut` in a `finally` of `_monitor_task`, same as `SupervisedProc`, so a cancelled or closed reader can never leave `aclose()` waiting.

### Tests
`tests/test_ipc.py` had no `ThreadJobExecutor` coverage at all. Added `test_thread_shutdown_no_job`, `test_thread_job_graceful_shutdown` and `test_thread_shutdown_no_job_join_before_ack_is_read`, which reproduces the race deterministically by blocking the loop for 0.5 s right after `aclose()` sends the `ShutdownRequest`. All three fail on `main` with `TimeoutError` and pass with this change.

 ### Minimal reproducible example 
The minimal worker below is a proof of the bug: THREAD executor, 32 idle runners, no LiveKit server needed, SIGTERM once the runners are up. On `main` 27 of the 32 runners log **`did not ack`** and the process never exits. With this change it exits in about a second with no errors.

<details>
<summary>repro.py</summary>

```python
import logging
import sys
from livekit.agents import AgentServer, JobContext, JobExecutorType, cli
from livekit.agents.worker import ServerType

logging.basicConfig(level=logging.INFO)

async def entrypoint(ctx: JobContext) -> None:
    pass

if __name__ == "__main__":
    server = AgentServer(
        job_executor_type=JobExecutorType.THREAD,
        num_idle_processes=32,  # the more idle runners, the more likely one loses the race
        ws_url="ws://127.0.0.1:7880",  # nothing listens here, on purpose
        api_key="devkey",
        api_secret="secret",
        max_retry=sys.maxsize,  # keep retrying the connection instead of giving up
    )
    server.rtc_session(type=ServerType.ROOM, agent_name="repro")(entrypoint)
    cli.run_app(server)
```

```sh
uv run python repro.py start  # wait until "job runner initialized" was logged 32 times
kill -TERM <pid>              # or Ctrl+C
```

</details>