### PR TITLE
fix(openai): keep GPT Live user turns open while input speech continues

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/gpt_live_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/gpt_live_model.py
@@ -12,10 +12,9 @@ from typing import Any, Literal, TypedDict
 from urllib.parse import urlparse, urlunparse
 
 import aiohttp
-import numpy as np
 
 from livekit import rtc
-from livekit.agents import APIConnectionError, APIError, llm, utils
+from livekit.agents import APIConnectionError, APIError, inference, llm, utils, vad
 from livekit.agents.metrics import LLMMetrics, RealtimeModelMetrics
 from livekit.agents.metrics.base import Metadata
 from livekit.agents.types import (
@@ -50,6 +49,8 @@ _SILENCE_RMS = 0.0006
 # long enough that a pause between sentences does not split an utterance in two
 _MIN_SILENCE_DURATION = 0.8
 _MIN_SILENCE_MS = _MIN_SILENCE_DURATION * 1000
+_INPUT_SPEECH_THRESHOLD = 0.5
+_INPUT_SPEECH_CONTINUATION_THRESHOLD = 0.35
 
 # the asks generate_reply sends as commentary. each ends with the same two sentences, which make
 # the model speak now rather than wait for the caller; what precedes them says what to speak
@@ -119,8 +120,10 @@ class _Speech:
     text: str = ""
     end_ms: int | None = None
     started_at: float = field(default_factory=time.time)
-    quiet_ms: int = 0
-    """Consecutive silent input audio pushed since the user's last fragment."""
+    quiet_ms: float = 0
+    """Consecutive non-speech input processed since the user's last fragment."""
+    input_audio_ms: float = 0
+    """Input already queued when this fragment arrived; delayed VAD results cannot count it."""
 
 
 # Responses delegation hands work to a backend Responses model, whose events arrive wrapped in
@@ -275,6 +278,13 @@ class GPTLiveSession(
         self._msg_ch = utils.aio.Chan[types.ClientEvent | dict[str, Any]]()
         self._audio_ch = utils.aio.Chan[llm.DuplexAudioFrame]()
         self._input_resampler: rtc.AudioResampler | None = None
+        self._input_vad: vad.VADStream | None = None
+        self._input_vad_task: asyncio.Task[None] | None = None
+        self._input_audio_ms = 0.0
+        self._input_vad_ms = 0.0
+        self._input_speaking = False
+        self._input_muted = False
+        self._sent_input_muted = False
 
         # session.start opens a connection and carries the config that is immutable after it
         self._session_start_sent = False
@@ -307,8 +317,20 @@ class GPTLiveSession(
     # outbound
 
     def send_event(self, event: types.ClientEvent | dict[str, Any]) -> None:
+        if self._msg_ch.closed:
+            return
         with contextlib.suppress(utils.aio.channel.ChanClosed):
+            event_type = event.get("type") if isinstance(event, dict) else event.type
+            if event_type in ("session.input_audio.mute", "session.input_audio.unmute"):
+                if self._input_resampler is not None:
+                    for frame in self._input_resampler.flush():
+                        self._process_input_audio(frame)
+                    self._input_resampler = None
+                for frame in self._bstream.flush():
+                    self._queue_input_audio(frame)
             self._msg_ch.send_nowait(event)
+            if event_type in ("session.input_audio.mute", "session.input_audio.unmute"):
+                self._input_muted = event_type == "session.input_audio.mute"
 
     def _build_delegation(self) -> types.Delegation:
         if self._opts.delegation == "client":
@@ -393,7 +415,7 @@ class GPTLiveSession(
                 try:
                     ws_conn = await self._create_ws_conn()
                     if reconnecting:
-                        self._reset_for_reconnect()
+                        await self._reset_for_reconnect()
                         self.emit("session_reconnected", llm.RealtimeSessionReconnectedEvent())
                     try:
                         await self._run_ws(ws_conn)
@@ -427,9 +449,10 @@ class GPTLiveSession(
                     raise error from None
                 reconnecting = True
         finally:
+            await self._close_input_vad()
             self._audio_ch.close()
 
-    def _reset_for_reconnect(self) -> None:
+    async def _reset_for_reconnect(self) -> None:
         # a new connection is a new session, reseeded from the history; the rest of what the
         # dropped one was carrying never arrives
         self._bstream.clear()
@@ -442,6 +465,7 @@ class GPTLiveSession(
         self._fnc_call_to_delegation.clear()
         self._usage_total = types.Usage()
         self._session_id = None
+        await self._close_input_vad()
 
     async def _create_ws_conn(self) -> aiohttp.ClientWebSocketResponse:
         headers = {
@@ -498,6 +522,9 @@ class GPTLiveSession(
             start = self._session_start_event()
             self._session_start_sent = True
             await self._ws_send(ws_conn, start)
+            if self._sent_input_muted:
+                await self._session_started_fut
+                await self._ws_send(ws_conn, types.InputAudioMuteEvent())
 
             async for msg in self._msg_ch:
                 # the protocol asks for session.started before any audio or command goes out
@@ -570,6 +597,8 @@ class GPTLiveSession(
             logger.debug("gpt-live client event", extra={"lk.pii.event": raw})
         try:
             await ws_conn.send_str(json.dumps(raw))
+            if raw.get("type") in ("session.input_audio.mute", "session.input_audio.unmute"):
+                self._sent_input_muted = raw["type"] == "session.input_audio.mute"
         except (aiohttp.ClientError, ConnectionError, asyncio.TimeoutError):
             raise APIConnectionError("GPT-Live send failed") from None
 
@@ -664,6 +693,8 @@ class GPTLiveSession(
                 self.emit("input_speech_started", llm.InputSpeechStartedEvent())
         speech.text += event.delta
         speech.quiet_ms = 0
+        if role == "user":
+            speech.input_audio_ms = self._input_audio_ms
         if event.end_ms is not None:
             speech.end_ms = max(speech.end_ms or 0, event.end_ms)
         if isinstance(message := self._history.get_by_id(speech.message_id), llm.ChatMessage):
@@ -902,15 +933,8 @@ class GPTLiveSession(
         return self._tools.copy()
 
     def push_audio(self, frame: rtc.AudioFrame) -> None:
-        # the caller's turn ends after sustained silent input since their last fragment
-        if (speech := self._speech.get("user")) is not None:
-            samples = np.frombuffer(frame.data, dtype=np.int16).astype(np.float32) / 32768
-            rms = float(np.sqrt(np.mean(samples * samples))) if samples.size else 0
-            speech.quiet_ms = (
-                speech.quiet_ms + round(frame.duration * 1000) if rms <= _SILENCE_RMS else 0
-            )
-            if speech.quiet_ms >= _MIN_SILENCE_MS:
-                self._end_speech("user")
+        if self._closing:
+            return
 
         if self._input_resampler and frame.sample_rate != self._input_resampler._input_rate:
             self._input_resampler = None
@@ -922,10 +946,68 @@ class GPTLiveSession(
             )
         frames = self._input_resampler.push(frame) if self._input_resampler else [frame]
         for f in frames:
-            for nf in self._bstream.write(f.data.tobytes()):
-                self.send_event(
-                    types.InputAudioAppendEvent(audio=base64.b64encode(nf.data).decode("utf-8"))
-                )
+            self._process_input_audio(f)
+
+    def _process_input_audio(self, f: rtc.AudioFrame) -> None:
+        """Feed normalized audio to the local detector and the ordered provider queue."""
+        if self._input_vad is None:
+            self._input_vad = inference.VAD(
+                activation_threshold=_INPUT_SPEECH_THRESHOLD,
+                deactivation_threshold=_INPUT_SPEECH_CONTINUATION_THRESHOLD,
+            ).stream()
+            self._input_vad_task = asyncio.create_task(
+                self._detect_input_speech(self._input_vad), name="GPTLiveSession._input_vad"
+            )
+        self._input_audio_ms += f.duration * 1000
+        self._input_vad.push_frame(
+            rtc.AudioFrame.create(f.sample_rate, f.num_channels, f.samples_per_channel)
+            if self._input_muted
+            else f
+        )
+        for nf in self._bstream.write(f.data.tobytes()):
+            self._queue_input_audio(nf)
+
+    def _queue_input_audio(self, frame: rtc.AudioFrame) -> None:
+        """Queue an input frame, including partial frames before a mute transition."""
+        self.send_event(types.InputAudioAppendEvent(audio=base64.b64encode(frame.data).decode()))
+
+    @utils.log_exceptions(logger=logger)
+    async def _detect_input_speech(self, stream: vad.VADStream) -> None:
+        """Finalize transcripts after non-speech input, excluding already queued audio."""
+        async for event in stream:
+            if event.type != vad.VADEventType.INFERENCE_DONE:
+                continue
+            previous_ms = self._input_vad_ms
+            self._input_vad_ms += sum(frame.duration for frame in event.frames) * 1000
+            threshold = (
+                _INPUT_SPEECH_CONTINUATION_THRESHOLD
+                if self._input_speaking
+                else _INPUT_SPEECH_THRESHOLD
+            )
+            self._input_speaking = event.probability >= threshold
+            if self._closing or (speech := self._speech.get("user")) is None:
+                continue
+            duration_ms = max(0.0, self._input_vad_ms - max(previous_ms, speech.input_audio_ms))
+            if not duration_ms:
+                continue
+            speech.quiet_ms = 0 if self._input_speaking else speech.quiet_ms + duration_ms
+            if speech.quiet_ms >= _MIN_SILENCE_MS - 1e-6:
+                self._end_speech("user")
+
+    async def _close_input_vad(self) -> None:
+        """Detach and settle the detector before replacing its input timeline."""
+        stream, self._input_vad = self._input_vad, None
+        task, self._input_vad_task = self._input_vad_task, None
+        self._input_audio_ms = self._input_vad_ms = 0.0
+        self._input_speaking = False
+        if task is not None:
+            task.cancel()
+        try:
+            if task is not None:
+                await asyncio.gather(task, return_exceptions=True)
+        finally:
+            if stream is not None:
+                await stream.aclose()
 
     def append_instructions(self, text: str, *, delegation_id: str | None = None) -> None:
         """Add a standing rule to the model's instructions, capped at 500 tokens."""

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/gpt_live_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/gpt_live_model.py
@@ -12,6 +12,7 @@ from typing import Any, Literal, TypedDict
 from urllib.parse import urlparse, urlunparse
 
 import aiohttp
+import numpy as np
 
 from livekit import rtc
 from livekit.agents import APIConnectionError, APIError, llm, utils
@@ -119,7 +120,7 @@ class _Speech:
     end_ms: int | None = None
     started_at: float = field(default_factory=time.time)
     quiet_ms: int = 0
-    """Input audio pushed since the user's last fragment."""
+    """Consecutive silent input audio pushed since the user's last fragment."""
 
 
 # Responses delegation hands work to a backend Responses model, whose events arrive wrapped in
@@ -901,9 +902,13 @@ class GPTLiveSession(
         return self._tools.copy()
 
     def push_audio(self, frame: rtc.AudioFrame) -> None:
-        # the caller's turn ends on their own audio: this much pushed since their last fragment
+        # the caller's turn ends after sustained silent input since their last fragment
         if (speech := self._speech.get("user")) is not None:
-            speech.quiet_ms += round(frame.duration * 1000)
+            samples = np.frombuffer(frame.data, dtype=np.int16).astype(np.float32) / 32768
+            rms = float(np.sqrt(np.mean(samples * samples))) if samples.size else 0
+            speech.quiet_ms = (
+                speech.quiet_ms + round(frame.duration * 1000) if rms <= _SILENCE_RMS else 0
+            )
             if speech.quiet_ms >= _MIN_SILENCE_MS:
                 self._end_speech("user")
 

--- a/tests/test_gpt_live_model.py
+++ b/tests/test_gpt_live_model.py
@@ -1097,7 +1097,7 @@ async def test_fragments_are_forwarded_and_mirrored_as_growing_messages(
 
 
 async def test_the_callers_turn_ends_on_their_own_audio(monkeypatch: pytest.MonkeyPatch) -> None:
-    """There are no turn events: the caller's fragments accumulate, and a second of their audio
+    """There are no turn events: the caller's fragments accumulate, and a second of silent input audio
     pushed with no new fragment ends the turn."""
     _connect_hook(monkeypatch)
 
@@ -1137,6 +1137,37 @@ async def test_the_callers_turn_ends_on_their_own_audio(monkeypatch: pytest.Monk
         assert (final.transcript, final.is_final) == (" What is the", True)
         assert final.item_id == interim.item_id
         assert final.turn_started_at == interim.turn_started_at
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
+@pytest.mark.parametrize("quiet_frames_before_speech", [0, 5])
+async def test_continuing_input_speech_resets_the_user_turn_silence(
+    monkeypatch: pytest.MonkeyPatch, quiet_frames_before_speech: int
+) -> None:
+    """Transcript delivery can pause while input speech continues."""
+    _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    events: list[llm.InputTranscriptionCompleted] = []
+    session.on("input_audio_transcription_completed", events.append)
+    try:
+        await session._update_session()
+        await session._session_started_fut
+        session._handle_event(_transcript("user", "Keep listening.", 100))
+        for _ in range(quiet_frames_before_speech):
+            session.push_audio(_pcm(0.0))
+        for _ in range(15):
+            session.push_audio(_pcm(0.2))
+        assert not [event for event in events if event.is_final]
+
+        frames = int(gpt_live_model._MIN_SILENCE_MS // 100)
+        for _ in range(frames - 1):
+            session.push_audio(_pcm(0.0))
+        assert not [event for event in events if event.is_final]
+        session.push_audio(_pcm(0.0))
+        assert [event.transcript for event in events if event.is_final] == ["Keep listening."]
     finally:
         await session.aclose()
         await model.aclose()

--- a/tests/test_gpt_live_model.py
+++ b/tests/test_gpt_live_model.py
@@ -6,6 +6,8 @@ import contextlib
 import json
 import logging
 import time
+import wave
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -14,7 +16,7 @@ import numpy as np
 import pytest
 
 from livekit import rtc
-from livekit.agents import APIConnectionError, APIConnectOptions, APIError, llm
+from livekit.agents import APIConnectionError, APIConnectOptions, APIError, llm, utils, vad
 from livekit.agents.metrics import LLMMetrics, RealtimeModelMetrics
 from livekit.plugins.openai.realtime import gpt_live_model
 from livekit.plugins.openai.realtime.gpt_live_model import (
@@ -25,6 +27,60 @@ from livekit.plugins.openai.realtime.gpt_live_model import (
 from livekit.plugins.openai.tools import WebSearch
 
 pytestmark = pytest.mark.unit
+
+
+_NATIVE_INPUT_VAD = gpt_live_model.inference.VAD
+
+
+class _FakeInputVADStream:
+    """Deterministic speech probabilities for the square waves in these protocol tests."""
+
+    def __init__(self) -> None:
+        self.events = utils.aio.Chan[vad.VADEvent]()
+        self.frames: list[rtc.AudioFrame] = []
+        self.closed = False
+
+    def push_frame(self, frame: rtc.AudioFrame) -> None:
+        self.frames.append(frame)
+        samples = np.asarray(frame.data, dtype=np.float32) / 32768
+        probability = 0.9 if np.max(np.abs(samples), initial=0) > 0.01 else 0.0
+        self.events.send_nowait(
+            vad.VADEvent(
+                type=vad.VADEventType.INFERENCE_DONE,
+                samples_index=0,
+                timestamp=0,
+                speech_duration=0,
+                silence_duration=0,
+                probability=probability,
+                frames=[frame],
+            )
+        )
+
+    def __aiter__(self):
+        return self.events.__aiter__()
+
+    async def aclose(self) -> None:
+        self.closed = True
+        self.events.close()
+
+
+@pytest.fixture(autouse=True)
+def _fake_input_vad(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        gpt_live_model.inference,
+        "VAD",
+        lambda **kwargs: SimpleNamespace(stream=_FakeInputVADStream),
+    )
+
+
+async def _wait_for_input_detection(session: GPTLiveSession, *, pending_ms: float = 0) -> None:
+    """Wait for queued inference without relying on fixed scheduling delays."""
+
+    async def wait() -> None:
+        while session._input_vad_ms + pending_ms + 1e-6 < session._input_audio_ms:
+            await asyncio.sleep(0.001)
+
+    await asyncio.wait_for(wait(), timeout=5)
 
 
 class _FakeWS:
@@ -1125,9 +1181,11 @@ async def test_the_callers_turn_ends_on_their_own_audio(monkeypatch: pytest.Monk
         frames = int(gpt_live_model._MIN_SILENCE_MS // 100)
         for _ in range(frames - 1):
             session.push_audio(_silence(100))
+        await _wait_for_input_detection(session)
         assert len(events) == 3  # quiet, but not yet for the whole pause
 
         session.push_audio(_silence(100))
+        await _wait_for_input_detection(session)
         assert [name for name, _ in events[-2:]] == [
             "input_audio_transcription_completed",
             "input_speech_stopped",
@@ -1160,14 +1218,278 @@ async def test_continuing_input_speech_resets_the_user_turn_silence(
             session.push_audio(_pcm(0.0))
         for _ in range(15):
             session.push_audio(_pcm(0.2))
+        await _wait_for_input_detection(session)
         assert not [event for event in events if event.is_final]
 
         frames = int(gpt_live_model._MIN_SILENCE_MS // 100)
         for _ in range(frames - 1):
             session.push_audio(_pcm(0.0))
+        await _wait_for_input_detection(session)
         assert not [event for event in events if event.is_final]
         session.push_audio(_pcm(0.0))
+        await _wait_for_input_detection(session)
         assert [event.transcript for event in events if event.is_final] == ["Keep listening."]
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
+@pytest.mark.parametrize("noise_rms", [0.002, 0.02])
+@pytest.mark.parametrize("sample_rate", [24000, 48000])
+async def test_native_input_vad_finalizes_a_turn_during_microphone_noise(
+    monkeypatch: pytest.MonkeyPatch, noise_rms: float, sample_rate: int
+) -> None:
+    """Exercise the bundled speech model with nonzero noise, not the protocol stub."""
+    monkeypatch.setattr(gpt_live_model.inference, "VAD", _NATIVE_INPUT_VAD)
+    _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    events = _user_events(session)
+    stream = task = None
+    try:
+        await session._update_session()
+        await session._session_started_fut
+        session._handle_event(_transcript("user", "Hello.", 0))
+        rng = np.random.default_rng(42)
+        for _ in range(20):
+            samples = np.clip(
+                rng.normal(0, noise_rms * 32768, sample_rate // 10), -32768, 32767
+            ).astype(np.int16)
+            session.push_audio(rtc.AudioFrame(samples.tobytes(), sample_rate, 1, len(samples)))
+        stream, task = session._input_vad, session._input_vad_task
+        await _wait_for_input_detection(session, pending_ms=32)
+        assert [
+            ev.transcript
+            for name, ev in events
+            if name == "input_audio_transcription_completed" and ev.is_final
+        ] == ["Hello."]
+        assert [name for name, _ in events].count("input_speech_stopped") == 1
+    finally:
+        await session.aclose()
+        await model.aclose()
+    assert task is not None and task.done()
+    assert stream is not None and stream._task.done() and stream._metrics_task.done()
+
+
+@pytest.mark.parametrize("mute", [False, True])
+async def test_native_input_vad_keeps_real_speech_open_until_pause_or_mute(
+    monkeypatch: pytest.MonkeyPatch, mute: bool
+) -> None:
+    monkeypatch.setattr(gpt_live_model.inference, "VAD", _NATIVE_INPUT_VAD)
+    _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    events = _user_events(session)
+    with wave.open(
+        str(Path(__file__).parent / "test_realtime/weather_question.wav"), "rb"
+    ) as audio:
+        audio_bytes = audio.readframes(audio.getnframes())
+    chunk_bytes = 2400 * 2
+    frames = [
+        rtc.AudioFrame(chunk, 24000, 1, len(chunk) // 2)
+        for offset in range(0, len(audio_bytes), chunk_bytes)
+        if (chunk := audio_bytes[offset : offset + chunk_bytes])
+    ]
+    try:
+        await session._update_session()
+        await session._session_started_fut
+        started = False
+        for frame in frames * 3:
+            session.push_audio(frame)
+            await _wait_for_input_detection(session, pending_ms=32)
+            if session._input_speaking and not started:
+                session._handle_event(_transcript("user", "What is the weather?", 0))
+                started = True
+        assert started
+        assert not [event for name, event in events if name == "input_speech_stopped"]
+        if mute:
+            session.mute_input()
+            for frame in frames * 2:
+                session.push_audio(frame)
+        else:
+            for _ in range(20):
+                session.push_audio(_pcm(0))
+        await _wait_for_input_detection(session, pending_ms=32)
+        assert [name for name, _ in events].count("input_speech_stopped") == 1
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
+@pytest.mark.parametrize("sample_rate", [24000, 48000])
+async def test_muted_input_closes_a_turn_and_unmute_restores_speech_detection(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_rate: int,
+) -> None:
+    def frame(level: float, duration_ms: int = 100) -> rtc.AudioFrame:
+        samples = np.full(sample_rate * duration_ms // 1000, int(level * 32767), dtype=np.int16)
+        return rtc.AudioFrame(samples.tobytes(), sample_rate, 1, len(samples))
+
+    ws = _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    events = _user_events(session)
+    try:
+        await session._update_session()
+        await session._session_started_fut
+        session._handle_event(_transcript("user", "Before mute.", 0))
+        session.push_audio(frame(0.2, duration_ms=60))
+        session.mute_input()
+        stream = session._input_vad
+        pre_mute_frames = len(stream.frames)
+        for _ in range(10):
+            session.push_audio(frame(0.2))
+        await _wait_for_input_detection(session)
+        assert [
+            ev.transcript
+            for name, ev in events
+            if name == "input_audio_transcription_completed" and ev.is_final
+        ] == ["Before mute."]
+        assert stream is not None
+        assert all(not np.any(frame.data) for frame in stream.frames[pre_mute_frames:])
+        mute_index = next(
+            i for i, ev in enumerate(ws.sent) if ev["type"] == "session.input_audio.mute"
+        )
+        assert all(ev["type"] == "session.input_audio.append" for ev in ws.sent[1:mute_index])
+        assert (
+            sum(len(base64.b64decode(ev["audio"])) for ev in ws.sent[1:mute_index])
+            == 24000 * 60 // 1000 * 2
+        )
+
+        session.push_audio(frame(0.2, duration_ms=40))
+        session.unmute_input()
+        session._handle_event({"type": "session.input_audio.muted"})  # delayed ack
+        session._handle_event(_transcript("user", "After unmute.", 1000))
+        for _ in range(15):
+            session.push_audio(frame(0.2))
+        await _wait_for_input_detection(session)
+        assert "user" in session._speech
+        for _ in range(10):
+            session.push_audio(frame(0.0))
+        await _wait_for_input_detection(session)
+        assert [name for name, _ in events].count("input_speech_stopped") == 2
+        types_sent = [ev["type"] for ev in ws.sent]
+        unmute_index = types_sent.index("session.input_audio.unmute")
+        assert len(base64.b64decode(ws.sent[unmute_index - 1]["audio"])) == 24000 * 40 // 1000 * 2
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
+async def test_reconnect_settles_old_input_detection_and_replays_mute_before_audio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sockets = [_LifecycleWS(), _LifecycleWS()]
+    connections = iter(sockets)
+
+    async def connect(self: GPTLiveSession) -> _LifecycleWS:
+        return next(connections)
+
+    monkeypatch.setattr(GPTLiveSession, "_create_ws_conn", connect)
+    model = GPTLiveModel(
+        api_key="sk-test", conn_options=APIConnectOptions(max_retry=1, retry_interval=0)
+    )
+    session = model.session()
+    old_stream = old_task = new_stream = new_task = None
+    try:
+        await session._update_session()
+        await asyncio.wait_for(sockets[0].started.wait(), timeout=1)
+        await session._session_started_fut
+        session.mute_input()
+        session.push_audio(_pcm(0.2))
+        await _wait_for_input_detection(session)
+        old_stream, old_task = session._input_vad, session._input_vad_task
+        await sockets[0].close()
+        await asyncio.wait_for(sockets[1].started.wait(), timeout=1)
+        await session._session_started_fut
+        assert old_stream.closed and old_task.done()
+        session._handle_event(_transcript("user", "New connection.", 0))
+        for _ in range(8):
+            session.push_audio(_pcm(0.2))
+        await _wait_for_input_detection(session)
+        new_stream, new_task = session._input_vad, session._input_vad_task
+        assert new_stream is not old_stream
+        assert [event["type"] for event in sockets[1].sent[:3]] == [
+            "session.start",
+            "session.input_audio.mute",
+            "session.input_audio.append",
+        ]
+        assert all(not np.any(frame.data) for frame in new_stream.frames)
+        assert "user" not in session._speech
+    finally:
+        for ws in sockets:
+            ws.emit({"type": "session.closed", "usage": {"seconds": 0}})
+        await session.aclose()
+        await model.aclose()
+    assert new_stream.closed and new_task.done()
+
+
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_closing_with_input_in_flight_settles_the_native_detector(
+    monkeypatch: pytest.MonkeyPatch, cancel: bool
+) -> None:
+    monkeypatch.setattr(gpt_live_model.inference, "VAD", _NATIVE_INPUT_VAD)
+    ws = _LifecycleWS()
+
+    async def connect(self: GPTLiveSession) -> _LifecycleWS:
+        return ws
+
+    monkeypatch.setattr(GPTLiveSession, "_create_ws_conn", connect)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    close = None
+    try:
+        await session._update_session()
+        await asyncio.wait_for(ws.started.wait(), timeout=1)
+        await session._session_started_fut
+        audio = _pcm(0.2)
+        session.push_audio(rtc.AudioFrame(audio.data, 48000, 1, audio.samples_per_channel))
+        stream, task = session._input_vad, session._input_vad_task
+        close = asyncio.create_task(session.aclose())
+        await asyncio.wait_for(ws.close_requested.wait(), timeout=1)
+        if cancel:
+            close.cancel()
+        else:
+            ws.emit({"type": "session.closed", "usage": {"seconds": 0}})
+        await asyncio.wait_for(close, timeout=1)
+        assert task.done() and stream._task.done() and stream._metrics_task.done()
+        session.push_audio(_pcm(0.2))
+        session.mute_input()
+        session.unmute_input()
+        assert session._input_vad is None
+    finally:
+        if close is not None:
+            close.cancel()
+            await asyncio.gather(close, return_exceptions=True)
+        await session.aclose()
+        await model.aclose()
+
+
+async def test_pending_input_detection_cannot_finalize_a_newer_fragment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    events = _user_events(session)
+    try:
+        await session._update_session()
+        await session._session_started_fut
+        session._handle_event(_transcript("user", "First", 0))
+        for _ in range(10):
+            session.push_audio(_pcm(0))
+        session._handle_event(_transcript("user", " fragment.", 200))
+        await _wait_for_input_detection(session)
+        assert "user" in session._speech
+        assert not [ev for name, ev in events if name == "input_speech_stopped"]
+        for _ in range(8):
+            session.push_audio(_pcm(0))
+        await _wait_for_input_detection(session)
+        assert [
+            ev.transcript
+            for name, ev in events
+            if name == "input_audio_transcription_completed" and ev.is_final
+        ] == ["First fragment."]
     finally:
         await session.aclose()
         await model.aclose()


### PR DESCRIPTION
`GPTLiveSession.push_audio()` counts every input frame toward the silence interval on upstream, so delayed transcript delivery can finalize a user turn while the caller is still speaking.

Use the SDK's bundled local Silero VAD to distinguish microphone speech from background noise. Speech probabilities use hysteresis, and 0.8 seconds of non-speech input finalizes the current transcript. Each fragment records the input already queued when it arrived, so delayed inference cannot count older audio against a newer fragment.

Mirror input muting into the detector, flush buffered audio before mute/unmute commands, and restore the last sent mute state before queued audio on reconnect. Detector streams are created lazily and settled during reconnect, normal shutdown, and cancellation. This uses an existing SDK dependency; the model-output audio gate is unchanged.

Regression coverage includes recorded speech, nonzero microphone noise at 24/48 kHz, continued speech, mute/unmute ordering, delayed acknowledgements and inference, reconnect, and shutdown. The GPT Live and duplex adapter suites pass (111 tests), as does `make check`.