### PR TITLE
fix(openai): preserve the GPT Live cumulative usage watermark

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/gpt_live_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/gpt_live_model.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import contextlib
 import json
+import math
 import os
 import time
 from collections.abc import AsyncIterable
@@ -837,6 +838,14 @@ class GPTLiveSession(
 
     def _handle_usage(self, usage: types.Usage) -> None:
         # reported cumulatively for the whole session, so only the delta goes to the collectors
+        seconds = usage.seconds
+        if (
+            isinstance(seconds, bool)
+            or not isinstance(seconds, (int, float))
+            or not math.isfinite(seconds)
+            or seconds <= self._usage_total.seconds
+        ):
+            return
         previous, self._usage_total = self._usage_total, usage
         self.emit(
             "metrics_collected",

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/gpt_live_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/gpt_live_model.py
@@ -4,8 +4,8 @@ import asyncio
 import base64
 import contextlib
 import json
-import math
 import os
+import sys
 import time
 from collections.abc import AsyncIterable
 from dataclasses import dataclass, field, replace
@@ -75,6 +75,15 @@ Role = Literal["user", "assistant"]
 GPTLiveVoices = Literal["aster", "beacon", "cinder", "marin", "stone", "vesper"]
 
 lk_oai_debug = int(os.getenv("LK_OPENAI_DEBUG", 0))
+
+
+def _valid_usage_seconds(value: object) -> bool:
+    """Accept durations representable as finite, nonnegative metric values."""
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and 0 <= value <= sys.float_info.max
+    )
 
 
 class ResponsesDelegationOptions(TypedDict, total=False):
@@ -580,6 +589,12 @@ class GPTLiveSession(
         if lk_oai_debug and etype != "session.output_audio.delta":
             logger.debug("gpt-live server event", extra={"lk.pii.event": event})
 
+        if etype in ("session.usage.updated", "session.closed"):
+            usage = event.get("usage")
+            if not isinstance(usage, dict) or not _valid_usage_seconds(usage.get("seconds", 0)):
+                # OpenAI's construct() still coerces integers to floats, which can overflow.
+                event = {**event, "usage": {}}
+
         if etype == "session.started":
             self._handle_session_started(types.SessionStartedEvent.construct(**event))
         elif etype == "session.output_audio.delta":
@@ -839,12 +854,7 @@ class GPTLiveSession(
     def _handle_usage(self, usage: types.Usage) -> None:
         # reported cumulatively for the whole session, so only the delta goes to the collectors
         seconds = usage.seconds
-        if (
-            isinstance(seconds, bool)
-            or not isinstance(seconds, (int, float))
-            or not math.isfinite(seconds)
-            or seconds <= self._usage_total.seconds
-        ):
+        if not _valid_usage_seconds(seconds) or seconds <= self._usage_total.seconds:
             return
         previous, self._usage_total = self._usage_total, usage
         self.emit(

--- a/tests/test_gpt_live_model.py
+++ b/tests/test_gpt_live_model.py
@@ -1064,6 +1064,35 @@ async def test_invalid_usage_does_not_lower_or_poison_the_cumulative_watermark(
         await model.aclose()
 
 
+@pytest.mark.parametrize(
+    "seconds", [10**400, -(10**400), True, False, "12", float("nan"), float("inf")]
+)
+async def test_invalid_wire_usage_preserves_metrics_and_acknowledges_close(
+    monkeypatch: pytest.MonkeyPatch, seconds: Any
+) -> None:
+    """Malformed usage must be rejected before the event parser coerces numeric fields."""
+    _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    collected: list[RealtimeModelMetrics] = []
+    session.on("metrics_collected", collected.append)
+    try:
+        await session._update_session()
+        await session._session_started_fut
+        for value in (seconds, 10, seconds, 12):
+            event = {"type": "session.usage.updated", "usage": {"seconds": value}}
+            original = event["usage"].copy()
+            session._handle_event(event)
+            assert event["usage"] == original
+        assert [metric.session_duration for metric in collected] == [10, 2]
+        session._handle_event({"type": "session.closed", "usage": {"seconds": seconds}})
+        assert session._session_closed_fut.done()
+        assert [metric.session_duration for metric in collected] == [10, 2]
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
 def _user_events(session: GPTLiveSession) -> list[tuple[str, Any]]:
     events: list[tuple[str, Any]] = []
     for name in (

--- a/tests/test_gpt_live_model.py
+++ b/tests/test_gpt_live_model.py
@@ -1039,6 +1039,31 @@ async def test_a_delegated_model_is_billed_under_its_own_name(
         await model.aclose()
 
 
+@pytest.mark.parametrize(
+    "seconds", [10, 8, 0, -1, True, float("nan"), float("inf"), float("-inf"), "invalid", None]
+)
+async def test_invalid_usage_does_not_lower_or_poison_the_cumulative_watermark(
+    monkeypatch: pytest.MonkeyPatch, seconds: Any
+) -> None:
+    """Only increasing, finite duration reports can advance the cumulative watermark."""
+    _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    collected: list[RealtimeModelMetrics] = []
+    session.on("metrics_collected", collected.append)
+    try:
+        await session._update_session()
+        await session._session_started_fut
+        for value in (10, seconds, 12, 12):
+            session._handle_event({"type": "session.usage.updated", "usage": {"seconds": value}})
+        assert [metric.session_duration for metric in collected] == [10, 2]
+        session._handle_event({"type": "session.closed", "usage": {"seconds": 12.5}})
+        assert [metric.session_duration for metric in collected] == [10, 2, 0.5]
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
 def _user_events(session: GPTLiveSession) -> list[tuple[str, Any]]:
     events: list[tuple[str, Any]] = []
     for name in (


### PR DESCRIPTION
GPT Live usage is cumulative, but every report currently replaces the watermark on upstream. Reports of 10, 8, and 12 seconds produce deltas of 10, 0, and 4 seconds, overcounting usage. Invalid values can also contaminate later metrics or prevent the final close event from acknowledging shutdown.

Advance the watermark only for finite, nonnegative numeric durations strictly greater than the previous total. Validate raw usage before OpenAI's event constructor coerces values: oversized integers otherwise raise during conversion, and booleans can become numeric durations. Invalid usage is ignored while the enclosing `session.closed` event still completes its acknowledgement. The original event payload is preserved.

Regression coverage includes duplicate/regressive reports, malformed and non-finite values, oversized positive and negative integers, boolean coercion, and final-close usage. The GPT Live and duplex adapter suites pass (114 tests), as does `make check`.