### PR TITLE
fix: prevent llm fallback retries after output

### DIFF
--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -197,6 +197,8 @@ class FallbackLLMStream(LLMStream):
                     retry_interval=self._fallback_adapter._retry_interval,
                 ),
             ) as stream:
+                if not check_recovery:
+                    stream._retry_on_chunk_sent = self._fallback_adapter._retry_on_chunk_sent
                 should_set_current = not check_recovery
                 async for chunk in stream:
                     if should_set_current:

--- a/livekit-agents/livekit/agents/llm/fallback_adapter.py
+++ b/livekit-agents/livekit/agents/llm/fallback_adapter.py
@@ -287,7 +287,7 @@ class FallbackLLMStream(LLMStream):
                         self._event_ch.send_nowait(result)
 
                     return
-                except Exception:  # exceptions already logged inside _try_generate
+                except Exception as e:  # exceptions already logged inside _try_generate
                     if llm_status.available:
                         llm_status.available = False
                         self._fallback_adapter.emit(
@@ -298,6 +298,9 @@ class FallbackLLMStream(LLMStream):
                     if text_sent or tool_calls_sent:
                         extra = {"text_sent": text_sent, "tool_calls_sent": tool_calls_sent}
                         if not self._fallback_adapter._retry_on_chunk_sent:
+                            if isinstance(e, APIError):
+                                # Prevent LLMStream's outer retry loop from replaying output.
+                                e.retryable = False
                             logger.error(
                                 f"{llm.label} failed after sending chunk, skip retrying. "
                                 "Set `retry_on_chunk_sent` to `True` to enable retrying after chunks are sent.",

--- a/livekit-agents/livekit/agents/llm/llm.py
+++ b/livekit-agents/livekit/agents/llm/llm.py
@@ -224,6 +224,18 @@ class LLM(
         await self.aclose()
 
 
+class _LLMEventChannel(aio.Chan[ChatChunk]):
+    def __init__(self) -> None:
+        super().__init__()
+        self.output_sent = False
+
+    def send_nowait(self, value: ChatChunk) -> None:
+        super().send_nowait(value)
+        # A provider can raise before the consumer or metrics task reads the chunk.
+        if value.delta and (value.delta.content or value.delta.tool_calls):
+            self.output_sent = True
+
+
 class LLMStream(ABC):
     _llm_request_span_name: ClassVar[str] = "llm_request"
 
@@ -240,7 +252,8 @@ class LLMStream(ABC):
         self._tools = tools
         self._conn_options = conn_options
 
-        self._event_ch = aio.Chan[ChatChunk]()
+        self._event_ch = _LLMEventChannel()
+        self._retry_on_chunk_sent = True
         self._tee_aiter = aio.itertools.tee(self._event_ch, 2)
         self._event_aiter, monitor_aiter = self._tee_aiter
         self._current_attempt_has_error = False
@@ -315,6 +328,9 @@ class LLMStream(ABC):
                 # 499 (Client Closed Request) - close gracefully without raising
                 if isinstance(e, APIStatusError) and e.status_code == 499:
                     return
+
+                if not self._retry_on_chunk_sent and self._event_ch.output_sent:
+                    e.retryable = False
 
                 retry_interval = self._conn_options._interval_for_retry(i)
 

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -5,13 +5,203 @@ from typing import Any
 
 import pytest
 
-from livekit.agents import APIConnectionError
-from livekit.agents.llm import ChatContext, FallbackAdapter, LLMStream, Tool
+from livekit.agents import APIConnectionError, APIError, APIStatusError, APITimeoutError
+from livekit.agents.llm import (
+    ChatChunk,
+    ChatContext,
+    ChoiceDelta,
+    CompletionUsage,
+    FallbackAdapter,
+    FunctionToolCall,
+    LLMError,
+    LLMStream,
+    Tool,
+)
 from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, APIConnectOptions
 
 from .fake_llm import FakeLLM, FakeLLMResponse
 
 pytestmark = [pytest.mark.unit]
+
+
+class _RetryLLM(FakeLLM):
+    def __init__(
+        self,
+        chunk: ChatChunk | None,
+        error: Exception | None,
+        *,
+        success_chunk: ChatChunk | None = None,
+    ) -> None:
+        super().__init__()
+        self.chunk = chunk
+        self.error = error
+        self.success_chunk = success_chunk or chunk or _TEXT_CHUNK
+        self.requests = 0
+        self.attempts = 0
+
+    def chat(
+        self,
+        *,
+        chat_ctx: ChatContext,
+        tools: list[Tool] | None = None,
+        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+        **kwargs: Any,
+    ) -> LLMStream:
+        self.requests += 1
+        return _RetryLLMStream(
+            self, chat_ctx=chat_ctx, tools=tools or [], conn_options=conn_options
+        )
+
+
+class _RetryLLMStream(LLMStream):
+    async def _run(self) -> None:
+        assert isinstance(self._llm, _RetryLLM)
+        self._llm.attempts += 1
+        if self._llm.attempts == 1:
+            if self._llm.chunk is not None:
+                self._event_ch.send_nowait(self._llm.chunk)
+            if self._llm.error is not None:
+                raise self._llm.error
+        else:
+            self._event_ch.send_nowait(self._llm.success_chunk)
+
+
+async def _close_retry_adapter(adapter: FallbackAdapter) -> None:
+    await asyncio.gather(
+        *(status.recovering_task for status in adapter._status if status.recovering_task)
+    )
+    await adapter.aclose()
+
+
+_TEXT_CHUNK = ChatChunk(id="text", delta=ChoiceDelta(content="The answer."))
+_TOOL_CHUNK = ChatChunk(
+    id="tool",
+    delta=ChoiceDelta(
+        tool_calls=[FunctionToolCall(call_id="call-1", name="transfer_call", arguments="{}")]
+    ),
+)
+
+
+# Based on @dtran26's diagnosis and reproducer: livekit/agents-js#2477.
+@pytest.mark.parametrize("chunk", [_TEXT_CHUNK, _TOOL_CHUNK], ids=["text", "tool"])
+@pytest.mark.parametrize("with_fallback", [False, True], ids=["outer", "fallback"])
+@pytest.mark.parametrize("error_kind", ["timeout", "status", "nonretryable", "unexpected"])
+async def test_no_retry_after_output(
+    chunk: ChatChunk, with_fallback: bool, error_kind: str
+) -> None:
+    error: Exception
+    if error_kind == "status":
+        error = APIStatusError("After output", status_code=503, request_id="request-1")
+    elif error_kind == "unexpected":
+        error = ValueError("After output")
+    else:
+        error = APITimeoutError("After output", retryable=error_kind != "nonretryable")
+    primary = _RetryLLM(chunk, error)
+    fallback = _RetryLLM(chunk, None)
+    adapter = FallbackAdapter([primary, fallback] if with_fallback else [primary])
+    errors: list[LLMError] = []
+    adapter.on("error", errors.append)
+    chunks: list[ChatChunk] = []
+    try:
+        with pytest.raises(type(error)) as exc_info:
+            async with adapter.chat(
+                chat_ctx=ChatContext.empty(),
+                conn_options=APIConnectOptions(max_retry=3, retry_interval=0),
+            ) as stream:
+                async for result in stream:
+                    chunks.append(result)
+
+        assert chunks == [chunk]
+        assert primary.requests == primary.attempts == 1
+        assert fallback.requests == 0
+        assert exc_info.value is error
+        assert len(errors) == 1
+        assert errors[0].error is error
+        assert not errors[0].recoverable
+        if isinstance(error, APIError):
+            assert not error.retryable
+    finally:
+        await _close_retry_adapter(adapter)
+
+
+@pytest.mark.parametrize(
+    "chunk",
+    [
+        None,
+        ChatChunk(id="role", delta=ChoiceDelta(role="assistant")),
+        ChatChunk(id="empty", delta=ChoiceDelta(content="")),
+        ChatChunk(
+            id="usage",
+            usage=CompletionUsage(completion_tokens=0, prompt_tokens=1, total_tokens=1),
+        ),
+    ],
+    ids=["no-output", "role", "empty-text", "usage"],
+)
+@pytest.mark.parametrize("retry_path", ["child", "fallback", "outer"])
+async def test_retries_before_output(chunk: ChatChunk | None, retry_path: str) -> None:
+    error = APITimeoutError("Before output")
+    primary = _RetryLLM(chunk, error, success_chunk=_TEXT_CHUNK)
+    fallback = _RetryLLM(_TEXT_CHUNK, None)
+    adapter = FallbackAdapter(
+        [primary, fallback] if retry_path == "fallback" else [primary],
+        max_retry_per_llm=1 if retry_path == "child" else 0,
+        retry_interval=0,
+    )
+    errors: list[LLMError] = []
+    adapter.on("error", errors.append)
+    try:
+        async with adapter.chat(
+            chat_ctx=ChatContext.empty(),
+            conn_options=APIConnectOptions(
+                max_retry=3 if retry_path == "outer" else 0, retry_interval=0
+            ),
+        ) as stream:
+            chunks = [result async for result in stream]
+
+        expected = ([chunk] if chunk is not None else []) + [_TEXT_CHUNK]
+        assert chunks == expected
+        assert error.retryable
+        if retry_path == "child":
+            assert primary.requests == 1
+            assert primary.attempts == 2
+        elif retry_path == "fallback":
+            assert fallback.requests == 1
+        else:
+            assert primary.requests >= 2
+        assert len(errors) == (1 if retry_path == "outer" else 0)
+        assert all(event.recoverable for event in errors)
+    finally:
+        await _close_retry_adapter(adapter)
+
+
+@pytest.mark.parametrize("chunk", [_TEXT_CHUNK, _TOOL_CHUNK], ids=["text", "tool"])
+@pytest.mark.parametrize("with_fallback", [False, True], ids=["outer", "fallback"])
+async def test_retry_after_output_when_enabled(chunk: ChatChunk, with_fallback: bool) -> None:
+    error = APITimeoutError("After output")
+    primary = _RetryLLM(chunk, error)
+    fallback = _RetryLLM(chunk, None)
+    adapter = FallbackAdapter(
+        [primary, fallback] if with_fallback else [primary], retry_on_chunk_sent=True
+    )
+    errors: list[LLMError] = []
+    adapter.on("error", errors.append)
+    try:
+        async with adapter.chat(
+            chat_ctx=ChatContext.empty(),
+            conn_options=APIConnectOptions(max_retry=3, retry_interval=0),
+        ) as stream:
+            chunks = [result async for result in stream]
+
+        assert chunks == [chunk, chunk]
+        assert error.retryable
+        assert len(errors) == (0 if with_fallback else 1)
+        assert all(event.recoverable for event in errors)
+        if with_fallback:
+            assert fallback.requests == 1
+        else:
+            assert primary.requests >= 2
+    finally:
+        await _close_retry_adapter(adapter)
 
 
 class PrewarmableLLM(FakeLLM):

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -86,8 +86,9 @@ _TOOL_CHUNK = ChatChunk(
 @pytest.mark.parametrize("chunk", [_TEXT_CHUNK, _TOOL_CHUNK], ids=["text", "tool"])
 @pytest.mark.parametrize("with_fallback", [False, True], ids=["outer", "fallback"])
 @pytest.mark.parametrize("error_kind", ["timeout", "status", "nonretryable", "unexpected"])
+@pytest.mark.parametrize("child_retries", [0, 1])
 async def test_no_retry_after_output(
-    chunk: ChatChunk, with_fallback: bool, error_kind: str
+    chunk: ChatChunk, with_fallback: bool, error_kind: str, child_retries: int
 ) -> None:
     error: Exception
     if error_kind == "status":
@@ -98,7 +99,9 @@ async def test_no_retry_after_output(
         error = APITimeoutError("After output", retryable=error_kind != "nonretryable")
     primary = _RetryLLM(chunk, error)
     fallback = _RetryLLM(chunk, None)
-    adapter = FallbackAdapter([primary, fallback] if with_fallback else [primary])
+    adapter = FallbackAdapter(
+        [primary, fallback] if with_fallback else [primary], max_retry_per_llm=child_retries
+    )
     errors: list[LLMError] = []
     adapter.on("error", errors.append)
     chunks: list[ChatChunk] = []
@@ -176,12 +179,17 @@ async def test_retries_before_output(chunk: ChatChunk | None, retry_path: str) -
 
 @pytest.mark.parametrize("chunk", [_TEXT_CHUNK, _TOOL_CHUNK], ids=["text", "tool"])
 @pytest.mark.parametrize("with_fallback", [False, True], ids=["outer", "fallback"])
-async def test_retry_after_output_when_enabled(chunk: ChatChunk, with_fallback: bool) -> None:
+@pytest.mark.parametrize("child_retries", [0, 1])
+async def test_retry_after_output_when_enabled(
+    chunk: ChatChunk, with_fallback: bool, child_retries: int
+) -> None:
     error = APITimeoutError("After output")
     primary = _RetryLLM(chunk, error)
     fallback = _RetryLLM(chunk, None)
     adapter = FallbackAdapter(
-        [primary, fallback] if with_fallback else [primary], retry_on_chunk_sent=True
+        [primary, fallback] if with_fallback else [primary],
+        retry_on_chunk_sent=True,
+        max_retry_per_llm=child_retries,
     )
     errors: list[LLMError] = []
     adapter.on("error", errors.append)
@@ -194,14 +202,33 @@ async def test_retry_after_output_when_enabled(chunk: ChatChunk, with_fallback: 
 
         assert chunks == [chunk, chunk]
         assert error.retryable
-        assert len(errors) == (0 if with_fallback else 1)
+        assert len(errors) == (0 if with_fallback or child_retries else 1)
         assert all(event.recoverable for event in errors)
-        if with_fallback:
+        if child_retries:
+            assert primary.requests == 1
+            assert primary.attempts == 2
+            assert fallback.requests == 0
+        elif with_fallback:
             assert fallback.requests == 1
         else:
             assert primary.requests >= 2
     finally:
         await _close_retry_adapter(adapter)
+
+
+@pytest.mark.parametrize("chunk", [_TEXT_CHUNK, _TOOL_CHUNK], ids=["text", "tool"])
+async def test_direct_provider_retries_after_output(chunk: ChatChunk) -> None:
+    provider = _RetryLLM(chunk, APITimeoutError("After output"))
+    try:
+        async with provider.chat(
+            chat_ctx=ChatContext.empty(), conn_options=APIConnectOptions(max_retry=1)
+        ) as stream:
+            chunks = [result async for result in stream]
+        assert chunks == [chunk, chunk]
+        assert provider.requests == 1
+        assert provider.attempts == 2
+    finally:
+        await provider.aclose()
 
 
 class PrewarmableLLM(FakeLLM):


### PR DESCRIPTION
Child and outer retries could replay text or tool calls after provider output. Both now use the shared retry guard when `retry_on_chunk_sent=False`. Preserve pre-output, metadata-only, and explicit opt-in retries.

Addresses [AGT-3492](https://linear.app/livekit/issue/AGT-3492). Builds on @dtran26's diagnosis and reproducers in [agents-js#2477](https://github.com/livekit/agents-js/issues/2477) and the outer-retry fix in [agents-js#2480](https://github.com/livekit/agents-js/pull/2480).

<details>
<summary>Initial prompt and agent context</summary>

**Model:** GPT-6

> Fix the Python LLM fallback adapter’s outer retry bug in livekit/agents.
>
> We investigated livekit/agents-js#2477 and confirmed that Python shares one part of the bug: when a provider emits text or tool calls, then raises a retryable APIError, retry_on_chunk_sent=False stops provider fallback but does not stop LLMStream’s outer retry loop. Generation restarts and appends duplicate output.
>
> Verified Python revision: 4de62322fa84b7c1736370ff3ebbd66b5d0ffe6f. Fetch current main and check whether this still applies.
>
> Relevant paths:
> - livekit-agents/livekit/agents/llm/fallback_adapter.py: _run re-raises the original error after output without changing retryability.
> - livekit-agents/livekit/agents/llm/llm.py: _main_task retries that error.
> - AgentSession passes connection options with max_retry=3 by default. Direct adapter.chat() defaults to zero outer retries.
>
> A controlled provider reproduces this without credentials or network calls:
> 1. First request emits “The answer.”, then raises APITimeoutError(retryable=True).
> 2. Next request succeeds with “The answer.”
> 3. With retry_on_chunk_sent=False and outer max_retry=3, output becomes “The answer.The answer.”
> Tool-call emissions duplicate through the same path.
>
> Python already isolates errors by stream, accepts successful child retries, and cancels active children correctly. Those JS-specific failures do not need porting. Python’s Inference provider marks errors non-retryable after output, but custom providers can expose the adapter bug.
>
> Please:
> - Find or create a Linear ticket before creating the branch.
> - Reproduce the bug, then make the smallest coherent fix.
> - Cover text and tool-call replay, preserve pre-output retries and metadata-only behavior, and preserve explicit retry_on_chunk_sent=True.
> - Run relevant tests and required checks.
> - Leave unrelated working-tree changes untouched.
>
> Local investigation:
> - /tmp/agents-js-2477-investigation/python-parity.md
> - /tmp/agents-js-2477-investigation/python_parity.py
> The harness asserts the observed bug; update expectations for regression tests.
>
> Related Node fix: https://github.com/livekit/agents-js/pull/2480
> Original diagnosis and reproducer: https://github.com/livekit/agents-js/issues/2477 by [dtran26.](dtran26.) Preserve contributor credit if that work shapes the fix.
>
> Do not post comments, replies, or resolve threads on my behalf.

> let's create a draft PR.

</details>
