### PR TITLE
fix(openai): continue a GPT Live backend only once every call in the conversation is answered

### DIFF
--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/gpt_live_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/gpt_live_model.py
@@ -748,7 +748,13 @@ class GPTLiveSession(
             for event_id, (sent_d_id, _) in list(self._continuations_sent.items()):
                 if sent_d_id == d_id:
                     del self._continuations_sent[event_id]
-            self._delegated_responses[d_id] = _DelegatedResponse()
+            created = _DelegatedResponse()
+            if (previous := self._delegated_responses.get(d_id)) is not None:
+                # the calls the replaced response still waits on are open on the backend all
+                # the same, so the new response waits on them too
+                created.call_ids |= previous.call_ids - previous.returned
+                created.rearms = previous.rearms
+            self._delegated_responses[d_id] = created
 
         elif event.type == "response.output_item.done":
             # only the completed item carries the name, call id and arguments together
@@ -823,6 +829,8 @@ class GPTLiveSession(
             if (pending := self._delegated_responses.pop(d_id, None)) is not None:
                 for call_id in pending.call_ids:
                     self._fnc_call_to_delegation.pop(call_id, None)
+                # its open calls held the barrier: release whatever waited behind them
+                self._maybe_continue_response(d_id)
 
     def _maybe_continue_response(self, delegation_id: str | None) -> None:
         # response.create runs the continuation, and only once no call in the conversation is
@@ -859,13 +867,13 @@ class GPTLiveSession(
             logger.error(
                 "gpt-live refused the same continuation repeatedly; a tool call this session "
                 "never tracked is open on the backend, giving up on it",
-                extra={"delegation_id": d_id, "call_ids": sorted(pending.call_ids)},
+                extra={"delegation_id": d_id, "lk.pii.call_ids": sorted(pending.call_ids)},
             )
             return False
         pending.rearms += 1
         logger.warning(
             "gpt-live refused a continuation while a tool call was still open; re-armed",
-            extra={"delegation_id": d_id, "call_ids": sorted(pending.call_ids)},
+            extra={"delegation_id": d_id, "lk.pii.call_ids": sorted(pending.call_ids)},
         )
         current = self._delegated_responses.get(d_id)
         if current is None:
@@ -874,6 +882,10 @@ class GPTLiveSession(
             # a newer response under the same delegation: one continuation serves both
             current.call_ids |= pending.call_ids
             current.returned |= pending.returned
+            current.rearms = max(current.rearms, pending.rearms)
+        # the refusal may arrive after the output that opened the barrier: check now rather
+        # than wait for an output that may never come
+        self._maybe_continue_response(d_id)
         return True
 
     # metrics and errors

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/gpt_live_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/gpt_live_model.py
@@ -753,6 +753,9 @@ class GPTLiveSession(
                 # the calls the replaced response still waits on are open on the backend all
                 # the same, so the new response waits on them too
                 created.call_ids |= previous.call_ids - previous.returned
+                # its answered calls are done with; nothing routes to them any more
+                for call_id in previous.call_ids & previous.returned:
+                    self._fnc_call_to_delegation.pop(call_id, None)
                 created.rearms = previous.rearms
             self._delegated_responses[d_id] = created
 

--- a/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/gpt_live_model.py
+++ b/livekit-plugins/livekit-plugins-openai/livekit/plugins/openai/realtime/gpt_live_model.py
@@ -128,8 +128,11 @@ class _Speech:
 #   response.created ─► response.output_item.done ×N (function calls) ─► response.completed
 #
 # A response completes with its calls unanswered. Each result is queued with response.item.create,
-# and response.create runs the next response, the continuation, once every call has one; a partial
-# batch is rejected. The voice model speaks the continuation's text on its own.
+# and response.create runs the next response, the continuation, once every call has one. The
+# service checks the whole conversation, not one response: a response.create while any call of any
+# delegation is still open is refused with function_call_outputs_required, so the continuation
+# waits for the last open call wherever it is. The voice model speaks the continuation's text on
+# its own.
 @dataclass
 class _DelegatedResponse:
     """The current response of one delegation, and the tool calls it waits on."""
@@ -137,6 +140,16 @@ class _DelegatedResponse:
     call_ids: set[str] = field(default_factory=set)
     returned: set[str] = field(default_factory=set)
     completed: bool = False
+    rearms: int = 0
+    """How often the service refused this response's continuation and it was re-armed."""
+
+
+# the service's refusal of a response.create sent while a call was open
+_CONTINUATION_REFUSED = "function_call_outputs_required"
+
+# a refusal with every tracked call answered means a call this session never saw (dropped for
+# missing fields, or from before a reconnect); re-arming forever would refuse forever
+_MAX_CONTINUATION_REARMS = 3
 
 
 @dataclass
@@ -293,6 +306,9 @@ class GPTLiveSession(
         # since the framework hands a result back by call id alone
         self._delegated_responses: dict[str | None, _DelegatedResponse] = {}
         self._fnc_call_to_delegation: dict[str, str | None] = {}
+        # continuations sent and not yet started, by response.create event id: the delegation
+        # and the response continued, to re-arm one the service refuses
+        self._continuations_sent: dict[str, tuple[str | None, _DelegatedResponse]] = {}
 
         # the newest history item the last ask was about, so an ask never repeats one
         self._asked_item_id: str | None = None
@@ -439,6 +455,7 @@ class GPTLiveSession(
         self._speech.clear()
         self._delegated_responses.clear()
         self._fnc_call_to_delegation.clear()
+        self._continuations_sent.clear()
         self._usage_total = types.Usage()
         self._session_id = None
 
@@ -727,6 +744,10 @@ class GPTLiveSession(
         d_id = envelope.delegation_id
 
         if event.type == "response.created":
+            # the continuation this delegation was waiting on, if any, has started
+            for event_id, (sent_d_id, _) in list(self._continuations_sent.items()):
+                if sent_d_id == d_id:
+                    del self._continuations_sent[event_id]
             self._delegated_responses[d_id] = _DelegatedResponse()
 
         elif event.type == "response.output_item.done":
@@ -804,17 +825,56 @@ class GPTLiveSession(
                     self._fnc_call_to_delegation.pop(call_id, None)
 
     def _maybe_continue_response(self, delegation_id: str | None) -> None:
-        # response.create runs the continuation, and only once the response has finished asking
-        # and every call it made has its answer; a partial batch is rejected
-        pending = self._delegated_responses.get(delegation_id)
-        if pending is None or not pending.completed or not pending.call_ids <= pending.returned:
-            return
-        del self._delegated_responses[delegation_id]
-        if not pending.call_ids:
-            return
-        for call_id in pending.call_ids:
-            self._fnc_call_to_delegation.pop(call_id, None)
-        self.send_event(types.ResponseCreateEvent(event_id=utils.shortuuid("response_create_")))
+        # response.create runs the continuation, and only once no call in the conversation is
+        # open: the service refuses a partial batch, and it counts every delegation's calls, so a
+        # fast response's continuation waits for a slow one's tool. Then every response that has
+        # finished asking continues, oldest first.
+        for pending in self._delegated_responses.values():
+            if not pending.call_ids <= pending.returned:
+                return
+        ready = [(d_id, p) for d_id, p in self._delegated_responses.items() if p.completed]
+        for d_id, pending in ready:
+            del self._delegated_responses[d_id]
+            for call_id in pending.call_ids:
+                self._fnc_call_to_delegation.pop(call_id, None)
+            if not pending.call_ids:
+                continue  # answered in text: nothing to continue
+            event_id = utils.shortuuid("response_create_")
+            self._continuations_sent[event_id] = (d_id, pending)
+            self.send_event(types.ResponseCreateEvent(event_id=event_id))
+
+    def _rearm_refused_continuation(self, error: types.ErrorBody) -> bool:
+        """Put a response whose continuation the service refused back behind the barrier.
+
+        The refusal says a call is still open; the next output to land sends the continuation
+        again. Bounded: a call this session never tracked would be refused forever.
+        """
+        if error.code != _CONTINUATION_REFUSED or not error.client_event_id:
+            return False
+        sent = self._continuations_sent.pop(error.client_event_id, None)
+        if sent is None:
+            return False
+        d_id, pending = sent
+        if pending.rearms >= _MAX_CONTINUATION_REARMS:
+            logger.error(
+                "gpt-live refused the same continuation repeatedly; a tool call this session "
+                "never tracked is open on the backend, giving up on it",
+                extra={"delegation_id": d_id, "call_ids": sorted(pending.call_ids)},
+            )
+            return False
+        pending.rearms += 1
+        logger.warning(
+            "gpt-live refused a continuation while a tool call was still open; re-armed",
+            extra={"delegation_id": d_id, "call_ids": sorted(pending.call_ids)},
+        )
+        current = self._delegated_responses.get(d_id)
+        if current is None:
+            self._delegated_responses[d_id] = pending
+        else:
+            # a newer response under the same delegation: one continuation serves both
+            current.call_ids |= pending.call_ids
+            current.returned |= pending.returned
+        return True
 
     # metrics and errors
 
@@ -861,6 +921,8 @@ class GPTLiveSession(
         )
 
     def _handle_error(self, error: types.ErrorBody) -> None:
+        if self._rearm_refused_continuation(error):
+            return
         logger.error(
             "gpt-live returned an error",
             extra={"lk.pii.error": error.model_dump(exclude_none=True)},

--- a/tests/test_gpt_live_model.py
+++ b/tests/test_gpt_live_model.py
@@ -1220,6 +1220,7 @@ async def test_the_rearm_budget_follows_a_delegation_into_its_next_response(
         session._handle_event(_response_event("d1", {"type": "response.created"}))
         assert session._delegated_responses["d1"].rearms == 1
         assert not session._delegated_responses["d1"].call_ids, "answered calls do not carry"
+        assert "call_1" not in session._fnc_call_to_delegation, "nor does their routing"
     finally:
         await session.aclose()
         await model.aclose()

--- a/tests/test_gpt_live_model.py
+++ b/tests/test_gpt_live_model.py
@@ -1102,6 +1102,129 @@ async def test_a_refused_continuation_is_rearmed_and_sent_with_the_next_output(
         await model.aclose()
 
 
+async def test_a_failed_blocker_releases_the_continuations_behind_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A response that fails with its call unanswered no longer holds the barrier."""
+    ws = _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    try:
+        await session._update_session()
+        await asyncio.sleep(0.05)
+        session._handle_event(_response_event("d1", {"type": "response.created"}))
+        session._handle_event(_response_event("d1", _function_call_done("ready")))
+        session._handle_event(_response_event("d1", _completed("resp_1")))
+        session._handle_event(_response_event("d2", {"type": "response.created"}))
+        session._handle_event(_response_event("d2", _function_call_done("open")))
+        await _answered(session, "ready")
+        assert [e["type"] for e in ws.sent[1:]] == ["response.item.create"]
+
+        session._handle_event(
+            _response_event("d2", {"type": "response.failed", "response": {"id": "resp_2"}})
+        )
+        await asyncio.sleep(0.05)
+        assert [e["type"] for e in ws.sent[1:]] == ["response.item.create", "response.create"]
+        assert not session._delegated_responses and not session._fnc_call_to_delegation
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
+async def test_a_refusal_arriving_after_the_last_output_is_retried_at_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sends and receives are concurrent: the output that opens the barrier can land before
+    the refusal of a continuation sent just earlier. The re-arm checks the barrier itself."""
+    ws = _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    try:
+        await session._update_session()
+        await asyncio.sleep(0.05)
+        session._handle_event(_response_event("d1", {"type": "response.created"}))
+        session._handle_event(_response_event("d1", _function_call_done("call_1")))
+        session._handle_event(_response_event("d1", _completed("resp_1")))
+        await _answered(session, "call_1")
+        [sent] = [e for e in ws.sent if e["type"] == "response.create"]
+
+        session._handle_event(_response_event("d2", {"type": "response.created"}))
+        session._handle_event(_response_event("d2", _function_call_done("late")))
+        session._handle_event(_response_event("d2", _completed("resp_2")))
+        await _answered(session, "late")  # d2 continues; d1's refusal is still in transit
+        assert len([e for e in ws.sent if e["type"] == "response.create"]) == 2
+
+        session._handle_event(_error(sent["event_id"]))
+        await asyncio.sleep(0.05)
+        continuations = [e for e in ws.sent if e["type"] == "response.create"]
+        assert len(continuations) == 3
+        assert continuations[-1]["event_id"] != sent["event_id"]
+        assert "d1" not in session._delegated_responses
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
+async def test_a_new_response_under_a_delegation_inherits_its_open_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """response.created replaces the delegation's entry; the replaced response's open calls
+    are still open on the backend, so the new response waits on them."""
+    ws = _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    try:
+        await session._update_session()
+        await asyncio.sleep(0.05)
+        session._handle_event(_response_event("d1", {"type": "response.created"}))
+        session._handle_event(_response_event("d1", _function_call_done("slow")))
+        session._handle_event(_response_event("d1", {"type": "response.created"}))
+        session._handle_event(_response_event("d1", _function_call_done("fast")))
+        session._handle_event(_response_event("d1", _completed("resp_2")))
+        await _answered(session, "fast")
+        assert [e["type"] for e in ws.sent[1:]] == ["response.item.create"]
+        await _answered(session, "slow")
+        assert [e["type"] for e in ws.sent[1:]] == [
+            "response.item.create",
+            "response.item.create",
+            "response.create",
+        ]
+        assert not session._delegated_responses and not session._fnc_call_to_delegation
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
+async def test_the_rearm_budget_follows_a_delegation_into_its_next_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A re-armed response replaced by a newer one under the same delegation hands its count
+    over, so a delegation that keeps opening responses is still bounded."""
+    ws = _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    try:
+        await session._update_session()
+        await asyncio.sleep(0.05)
+        session._handle_event(_response_event("d1", {"type": "response.created"}))
+        session._handle_event(_response_event("d1", _function_call_done("call_1")))
+        session._handle_event(_response_event("d1", _completed("resp_1")))
+        await _answered(session, "call_1")
+        [sent] = [e for e in ws.sent if e["type"] == "response.create"]
+        # another delegation's open call holds the barrier, so the re-arm cannot resend
+        session._handle_event(_response_event("d2", {"type": "response.created"}))
+        session._handle_event(_response_event("d2", _function_call_done("open")))
+        session._handle_event(_error(sent["event_id"]))
+        assert session._delegated_responses["d1"].rearms == 1
+
+        session._handle_event(_response_event("d1", {"type": "response.created"}))
+        assert session._delegated_responses["d1"].rearms == 1
+        assert not session._delegated_responses["d1"].call_ids, "answered calls do not carry"
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
 async def test_a_continuation_refused_repeatedly_is_given_up_on(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_gpt_live_model.py
+++ b/tests/test_gpt_live_model.py
@@ -987,6 +987,157 @@ async def test_a_response_continues_only_once_every_call_has_its_answer(
         await model.aclose()
 
 
+def _error(client_event_id: str, code: str = "function_call_outputs_required") -> dict[str, Any]:
+    return {
+        "type": "error",
+        "error": {
+            "type": "invalid_request_error",
+            "code": code,
+            "message": "Submit the pending function call outputs before response.create.",
+            "client_event_id": client_event_id,
+        },
+    }
+
+
+async def _answered(session: GPTLiveSession, call_id: str) -> None:
+    await session._append_items(
+        [llm.FunctionCallOutput(call_id=call_id, name="_get_weather", output="ok", is_error=False)]
+    )
+    await asyncio.sleep(0.05)
+
+
+async def test_a_continuation_waits_for_every_open_call_in_the_conversation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The service refuses response.create while any delegation's call is open, so a response
+    whose own calls are answered waits for the others; then each continues, oldest first."""
+    ws = _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    try:
+        await session._update_session()
+        await asyncio.sleep(0.05)
+        session._handle_event(_response_event("d1", {"type": "response.created"}))
+        session._handle_event(_response_event("d1", _function_call_done("slow")))
+        session._handle_event(_response_event("d1", _completed("resp_1")))
+        session._handle_event(_response_event("d2", {"type": "response.created"}))
+        session._handle_event(_response_event("d2", _function_call_done("fast")))
+        session._handle_event(_response_event("d2", _completed("resp_2")))
+
+        await _answered(session, "fast")
+        assert [e["type"] for e in ws.sent[1:]] == ["response.item.create"]
+        assert set(session._delegated_responses) == {"d1", "d2"}
+
+        await _answered(session, "slow")
+        assert [e["type"] for e in ws.sent[1:]] == [
+            "response.item.create",
+            "response.item.create",
+            "response.create",
+            "response.create",
+        ]
+        assert not session._delegated_responses and not session._fnc_call_to_delegation
+        assert len(session._continuations_sent) == 2
+        session._handle_event(_response_event("d1", {"type": "response.created"}))
+        session._handle_event(_response_event("d2", {"type": "response.created"}))
+        assert not session._continuations_sent
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
+async def test_a_text_only_response_neither_blocks_nor_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ws = _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    try:
+        await session._update_session()
+        await asyncio.sleep(0.05)
+        session._handle_event(_response_event("d1", {"type": "response.created"}))
+        session._handle_event(_response_event("d1", _function_call_done("call_1")))
+        session._handle_event(_response_event("d2", {"type": "response.created"}))
+        session._handle_event(_response_event("d2", _completed("resp_2")))
+        await _answered(session, "call_1")
+        assert [e["type"] for e in ws.sent[1:]] == ["response.item.create"]
+        session._handle_event(_response_event("d1", _completed("resp_1")))
+        await asyncio.sleep(0.05)
+        assert [e["type"] for e in ws.sent[1:]] == ["response.item.create", "response.create"]
+        assert not session._delegated_responses
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
+async def test_a_refused_continuation_is_rearmed_and_sent_with_the_next_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ws = _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    errors: list[Any] = []
+    session.on("error", errors.append)
+    try:
+        await session._update_session()
+        await asyncio.sleep(0.05)
+        session._handle_event(_response_event("d1", {"type": "response.created"}))
+        session._handle_event(_response_event("d1", _function_call_done("call_1")))
+        session._handle_event(_response_event("d1", _completed("resp_1")))
+        await _answered(session, "call_1")
+        [sent] = [e for e in ws.sent if e["type"] == "response.create"]
+
+        # a call the barrier had not seen is tracked now, and the service refuses
+        session._handle_event(_response_event("d2", {"type": "response.created"}))
+        session._handle_event(_response_event("d2", _function_call_done("late")))
+        session._handle_event(_error(sent["event_id"]))
+        assert not errors
+        assert session._delegated_responses["d1"].rearms == 1
+
+        session._handle_event(_response_event("d2", _completed("resp_2")))
+        await _answered(session, "late")
+        assert len([e for e in ws.sent if e["type"] == "response.create"]) == 3
+        assert not session._delegated_responses
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
+async def test_a_continuation_refused_repeatedly_is_given_up_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A call the session never tracked keeps the service refusing: after the re-arm budget the
+    refusal is reported like any other error."""
+    ws = _connect_hook(monkeypatch)
+    model = GPTLiveModel(api_key="sk-test")
+    session = model.session()
+    errors: list[Any] = []
+    session.on("error", errors.append)
+    try:
+        await session._update_session()
+        await asyncio.sleep(0.05)
+        session._handle_event(_response_event("d1", {"type": "response.created"}))
+        session._handle_event(_response_event("d1", _function_call_done("call_1")))
+        session._handle_event(_response_event("d1", _completed("resp_1")))
+        await _answered(session, "call_1")
+        for n in range(gpt_live_model._MAX_CONTINUATION_REARMS + 1):
+            [event_id] = [
+                eid for eid, (d_id, _) in session._continuations_sent.items() if d_id == "d1"
+            ]
+            session._handle_event(_error(event_id))
+            if n < gpt_live_model._MAX_CONTINUATION_REARMS:
+                assert not errors
+                session._handle_event(_response_event("d2", {"type": "response.created"}))
+                session._handle_event(_response_event("d2", _function_call_done(f"c{n}")))
+                session._handle_event(_response_event("d2", _completed(f"resp_{n}")))
+                await _answered(session, f"c{n}")
+        assert len(errors) == 1
+        assert "d1" not in session._delegated_responses
+        assert [e for e in ws.sent if e["type"] == "error"] == []
+    finally:
+        await session.aclose()
+        await model.aclose()
+
+
 @pytest.mark.parametrize(
     "reason",
     ["close_requested", "expired", "content", "remote_hangup", "connection_lost", None],


### PR DESCRIPTION
GPT Live refuses `response.create` with `function_call_outputs_required` while any function call in the backend conversation is still unanswered, across delegations (the event carries no delegation id). `_maybe_continue_response` gated the continuation per response, so with two responses in flight the one whose tool finished first sent its continuation while the other's tool was still running; the service refused it, and since that response's bookkeeping had already been dropped, nothing ever continued it. The backend never answered and the voice model waited for good. Seen in production today with a slow `lookup_preferences` overlapping a fast `lookup_plan`:

```
code: function_call_outputs_required
message: Submit the pending function call outputs before response.create.
client_event_id: response_create_d003aedf7086
```

Make the barrier conversation-wide: a continuation goes out only when no tracked response has an open call, and every response that has finished asking then continues, oldest first. Remember each continuation until its `response.created` arrives; when the service refuses one anyway, put the response back behind the barrier so the next output re-sends it, bounded so a call this session never tracked cannot loop.

Regression coverage: two delegations with one slow call, a text-only response that neither blocks nor continues, a refused continuation re-armed and re-sent, and a repeatedly refused one given up on. The GPT Live and duplex adapter suites pass (101 tests); `ruff check` and `ruff format --check` are clean. I could not run `make type-check` locally (no uv).
