### PR TITLE
fix: refuse to start a DuplexModel under a text simulation

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -308,6 +308,14 @@ class AgentActivity(RecognitionHooks):
             )
             self._session._warned_realtime_audio_redaction = True
 
+        # a duplex model has no text modality, and the adapter resolves each reply from the audio
+        # the model produces; without audio a text simulation would only time out on turn one
+        if self._text_only and isinstance(self.llm, llm.DuplexRealtimeAdapter):
+            raise RuntimeError(
+                "a DuplexModel speaks only through audio, so it cannot run under a text "
+                "simulation; run `lk agent simulate audio` instead"
+            )
+
         if self._rt_turn_detection_enabled and not self.allow_interruptions:
             raise ValueError(
                 "the RealtimeModel uses a server-side turn detection, "

--- a/tests/test_duplex_adapter.py
+++ b/tests/test_duplex_adapter.py
@@ -934,3 +934,25 @@ async def test_a_failed_audio_stream_reports_an_unrecoverable_error(duplex) -> N
     assert [e.recoverable for e in errors] == [False]
     assert isinstance(errors[0].error, _Boom)
     assert errors[0].label == fake.duplex_model.label
+
+
+# a duplex model has no text modality: it hears and speaks only audio, and the adapter resolves a
+# reply from the sound the model produces. under a text simulation there is no audio, so the
+# session refuses to start rather than time out on the first turn
+
+
+async def test_a_duplex_model_refuses_a_text_simulation(monkeypatch: pytest.MonkeyPatch) -> None:
+    from livekit.agents.voice import Agent, AgentSession
+
+    monkeypatch.setattr(AgentSession, "_text_only", property(lambda self: True))
+    session = AgentSession(llm=_FakeDuplexModel())
+    with pytest.raises(RuntimeError, match="text simulation"):
+        await session.start(Agent(instructions="hi"))
+
+
+async def test_a_duplex_model_starts_outside_a_text_simulation() -> None:
+    from livekit.agents.voice import Agent, AgentSession
+
+    session = AgentSession(llm=_FakeDuplexModel())
+    await session.start(Agent(instructions="hi"))
+    await session.aclose()


### PR DESCRIPTION
## Problem

A duplex model such as `GPTLiveModel` hears and speaks only audio, and `DuplexRealtimeAdapter` resolves each reply from the audio the model produces. A text simulation (`lk agent simulate` without `audio`) disables audio I/O, so the first reply never opens and every scenario fails on turn one with:

```
failed to generate a reply: the model did not start speaking when asked
```

That message arrives after a 10 second timeout and says nothing about the cause. Reproduced with a GPT-Live agent: all scenarios failed identically in text mode and passed in `lk agent simulate audio`.

## Fix

`AgentActivity` raises at construction when the session is a text simulation and the resolved llm is a `DuplexRealtimeAdapter`:

```
a DuplexModel speaks only through audio, so it cannot run under a text simulation; run `lk agent simulate audio` instead
```

No new capability flag: every duplex model is audio-only by definition, so the type is the signal.

## Tests

Two tests in `tests/test_duplex_adapter.py`: the session refuses to start with `_text_only` patched on, and starts normally otherwise.

agents-js counterpart: https://github.com/livekit/agents-js/pull/2481