### PR TITLE
fix(respeecher): invalidate the pool on model change instead of retiring it

### DIFF
--- a/livekit-plugins/livekit-plugins-respeecher/livekit/plugins/respeecher/tts.py
+++ b/livekit-plugins/livekit-plugins-respeecher/livekit/plugins/respeecher/tts.py
@@ -163,7 +163,6 @@ class TTS(tts.TTS):
             connect_cb=self._connect_ws,
             close_cb=self._close_ws,
         )
-        self._retired_pools: list[utils.ConnectionPool[aiohttp.ClientWebSocketResponse]] = []
 
     @property
     def model(self) -> str:
@@ -202,16 +201,11 @@ class TTS(tts.TTS):
         """Update TTS options"""
         if is_given(model) and model != self._opts.model:
             self._opts.model = model
-            # The model is baked into the WebSocket URL, so existing pooled
-            # connections can't serve the new model. Retire the old pool
-            # (letting any in-flight stream finish using its connection) and
-            # route new requests through a fresh pool. The retired pool is
-            # closed during aclose().
-            self._retired_pools.append(self._pool)
-            self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
-                connect_cb=self._connect_ws,
-                close_cb=self._close_ws,
-            )
+            # The model is baked into the WebSocket URL, so pooled connections
+            # can't serve the new one. invalidate() stops reusing them: idle ones
+            # are closed on the next drain, and one a stream is still using keeps
+            # working until it is returned, then is closed.
+            self._pool.invalidate()
 
         if is_given(voice_id):
             self._opts.voice_id = voice_id
@@ -239,9 +233,6 @@ class TTS(tts.TTS):
 
         self._streams.clear()
         await self._pool.aclose()
-        for pool in self._retired_pools:
-            await pool.aclose()
-        self._retired_pools.clear()
 
 
 class ChunkedStream(tts.ChunkedStream):

--- a/tests/test_plugin_respeecher_tts.py
+++ b/tests/test_plugin_respeecher_tts.py
@@ -1,0 +1,106 @@
+# Copyright 2023 LiveKit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Respeecher TTS: the model is part of the websocket URL.
+
+``_connect_ws`` builds ``{base}{model}/tts/websocket?...``, so a pooled connection is
+bound to the model it was opened with. Changing the model has to stop those
+connections being reused — and has to close them, not just set them aside where
+nothing will ever drain them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from livekit.plugins.respeecher import TTS
+
+pytestmark = pytest.mark.plugin("respeecher")
+
+EN = "/public/tts/en-rt"
+UA = "/public/tts/ua-rt"
+
+
+class _FakeWS:
+    def __init__(self, model: str) -> None:
+        self.model = model
+
+    def __repr__(self) -> str:
+        return f"_FakeWS({self.model})"
+
+
+@pytest.fixture
+def closed(monkeypatch: pytest.MonkeyPatch) -> list[_FakeWS]:
+    """Replace the network with fakes that record the model each socket was opened with.
+
+    Patched on the class so that every pool the TTS builds uses them, including one
+    created after construction.
+    """
+    closed_sockets: list[_FakeWS] = []
+
+    async def fake_connect(self: TTS, timeout: float) -> _FakeWS:
+        return _FakeWS(self._opts.model)
+
+    async def fake_close(self: TTS, ws: _FakeWS) -> None:
+        closed_sockets.append(ws)
+
+    monkeypatch.setattr(TTS, "_connect_ws", fake_connect)
+    monkeypatch.setattr(TTS, "_close_ws", fake_close)
+    return closed_sockets
+
+
+@pytest.mark.asyncio
+async def test_changing_model_closes_the_idle_pooled_connection(closed: list[_FakeWS]) -> None:
+    """An idle socket opened for the old model is closed, not left open until aclose()."""
+    tts = TTS(api_key="test-key", model=EN)
+
+    old = await tts._pool.get(timeout=10.0)
+    tts._pool.put(old)  # finished with it: idle in the pool
+
+    tts.update_options(model=UA)
+    new = await tts._pool.get(timeout=10.0)  # next acquisition drains the pool
+
+    assert new is not old
+    assert new.model == UA, "the next connection must be opened for the new model"
+    assert old in closed, "the old model's idle socket was left open"
+
+
+@pytest.mark.asyncio
+async def test_changing_model_lets_an_in_use_connection_finish(closed: list[_FakeWS]) -> None:
+    """A socket a stream is still using survives the change, and is closed once returned."""
+    tts = TTS(api_key="test-key", model=EN)
+
+    in_use = await tts._pool.get(timeout=10.0)  # checked out, never returned yet
+    tts.update_options(model=UA)
+    await tts._pool.get(timeout=10.0)
+
+    assert in_use not in closed, "changing the model severed a stream in flight"
+
+    tts._pool.put(in_use)  # the stream finished with it
+    await tts._pool.get(timeout=10.0)
+    assert in_use in closed, "the returned old-model socket was never closed"
+
+
+@pytest.mark.asyncio
+async def test_same_model_keeps_the_pooled_connection(closed: list[_FakeWS]) -> None:
+    """Re-setting the current model must not throw away a warm connection."""
+    tts = TTS(api_key="test-key", model=EN)
+
+    warm = await tts._pool.get(timeout=10.0)
+    tts._pool.put(warm)
+
+    tts.update_options(model=EN)
+
+    assert await tts._pool.get(timeout=10.0) is warm
+    assert closed == []


### PR DESCRIPTION
## Problem

Respeecher bakes the model into the websocket URL:

```python
full_ws_url = f"{ws_url}{self._opts.model}/tts/websocket?api_key=...&source=...&version=..."
```

so `update_options(model=...)` can't reuse pooled connections. It handles that by setting the whole pool aside and building a new one:

```python
self._retired_pools.append(self._pool)
self._pool = utils.ConnectionPool[aiohttp.ClientWebSocketResponse](
    connect_cb=self._connect_ws,
    close_cb=self._close_ws,
)
```

The retired pools are only closed in `aclose()`. Nothing drains them in between, which leaks in two ways:

1. **Idle sockets opened for the old model stay open** until the TTS is closed. Every model change adds another pool's worth.
2. **A stream in flight during the change returns its socket to the retired pool.** `SynthesizeStream` acquires through `self._tts._pool.connection(...)`, so its `put()` lands on the pool that was just set aside — where it becomes idle and is never closed either.

## Why this shape

The retire-the-pool approach was the right call when it was written: at the time `invalidate()` swept checked-out connections into `_to_close`, so it would have severed a stream in flight. #7139 changed that — `invalidate()` now retires checked-out connections and closes them when they are returned, and closes idle ones on the next drain.

That is exactly the behaviour the comment here describes wanting ("letting any in-flight stream finish using its connection"), so the plugin can use it directly:

```python
if is_given(model) and model != self._opts.model:
    self._opts.model = model
    self._pool.invalidate()
```

and `_retired_pools` goes away. One pool for the life of the TTS, so a stream always returns its socket to the pool that will close it. Same pattern as asyncai (#7132), neuphonic (#7133) and cartesia (#7140).

The `model != self._opts.model` guard is kept, so re-setting the current model still keeps a warm connection.

## Tests

New `tests/test_plugin_respeecher_tts.py`. The network is replaced by fakes patched onto the `TTS` class, so every pool it builds — including one created after construction — uses them:

- `test_changing_model_closes_the_idle_pooled_connection`
- `test_changing_model_lets_an_in_use_connection_finish`
- `test_same_model_keeps_the_pooled_connection`

Against the original `tts.py`, the first two fail with the leak they describe and the third still passes (it guards against over-invalidating):

```
FAILED test_changing_model_closes_the_idle_pooled_connection
    AssertionError: the old model's idle socket was left open
FAILED test_changing_model_lets_an_in_use_connection_finish
    AssertionError: the returned old-model socket was never closed
2 failed, 1 passed
```

With the change: `3 passed`. `ruff check` and `ruff format --check` clean.

Note for anyone running these locally: they rely on the post-#7139 `ConnectionPool`, so make sure `livekit-agents` resolves to the working tree rather than an installed release.

---
