### PR TITLE
fix(cli): prebuffer console playback so realtime-paced audio doesn't underrun

### DIFF
--- a/livekit-agents/livekit/agents/cli/_legacy.py
+++ b/livekit-agents/livekit/agents/cli/_legacy.py
@@ -167,14 +167,6 @@ class ConsoleAudioOutput(io.AudioOutput):
         self._segment_id = 0
 
     @property
-    def audio_lock(self) -> threading.Lock:
-        return self._audio_lock
-
-    @property
-    def audio_buffer(self) -> bytearray:
-        return self._output_buf
-
-    @property
     def paused(self) -> bool:
         return self._paused_at is not None
 
@@ -267,6 +259,31 @@ class ConsoleAudioOutput(io.AudioOutput):
             self._output_buf_empty.set()
             self._playback_started_fired = False
             self._segment_id += 1
+
+    def read_into(self, outdata: np.ndarray, frames: int) -> None:
+        """Fill ``outdata`` with the next ``frames`` samples of playback. Called from the audio thread."""
+        with self._audio_lock:
+            if self.paused:
+                outdata[:] = 0
+            else:
+                bytes_needed = frames * 2
+                if len(self._output_buf) < bytes_needed:
+                    available_bytes = len(self._output_buf)
+                    if available_bytes > 0:
+                        self._maybe_mark_playback_started()
+                    outdata[: available_bytes // 2, 0] = np.frombuffer(
+                        self._output_buf,
+                        dtype=np.int16,
+                        count=available_bytes // 2,
+                    )
+                    outdata[available_bytes // 2 :, 0] = 0
+                    del self._output_buf[:available_bytes]  # TODO: optimize
+                    self._loop.call_soon_threadsafe(self.mark_output_empty)
+                else:
+                    self._maybe_mark_playback_started()
+                    chunk = self._output_buf[:bytes_needed]
+                    outdata[:, 0] = np.frombuffer(chunk, dtype=np.int16, count=frames)
+                    del self._output_buf[:bytes_needed]
 
     def _maybe_mark_playback_started(self) -> None:
         """Mark the playback as started if it hasn't been already. Must be called under ``audio_lock``."""
@@ -733,28 +750,7 @@ class AgentsConsole:
         self._output_delay = time.outputBufferDacTime - time.currentTime
 
         FRAME_SAMPLES = 240
-        with self._io_audio_output.audio_lock:
-            if self._io_audio_output.paused:
-                outdata[:] = 0
-            else:
-                bytes_needed = frames * 2
-                if len(self._io_audio_output.audio_buffer) < bytes_needed:
-                    available_bytes = len(self._io_audio_output.audio_buffer)
-                    if available_bytes > 0:
-                        self._io_audio_output._maybe_mark_playback_started()
-                    outdata[: available_bytes // 2, 0] = np.frombuffer(
-                        self._io_audio_output.audio_buffer,
-                        dtype=np.int16,
-                        count=available_bytes // 2,
-                    )
-                    outdata[available_bytes // 2 :, 0] = 0
-                    del self._io_audio_output.audio_buffer[:available_bytes]  # TODO: optimize
-                    self.io_loop.call_soon_threadsafe(self._io_audio_output.mark_output_empty)
-                else:
-                    self._io_audio_output._maybe_mark_playback_started()
-                    chunk = self._io_audio_output.audio_buffer[:bytes_needed]
-                    outdata[:, 0] = np.frombuffer(chunk, dtype=np.int16, count=frames)
-                    del self._io_audio_output.audio_buffer[:bytes_needed]
+        self._io_audio_output.read_into(outdata, frames)
 
         num_chunks = frames // FRAME_SAMPLES
         for i in range(num_chunks):

--- a/livekit-agents/livekit/agents/cli/_legacy.py
+++ b/livekit-agents/livekit/agents/cli/_legacy.py
@@ -114,6 +114,10 @@ class _ExitCli(SystemExit):
 ConsoleMode = Literal["text", "audio"]
 
 SAMPLE_RATE = 24000
+# a duplex model streams at real-time pace, so the speaker needs this much margin against
+# network jitter before the head of a segment is played; the default is the largest arrival
+# gap observed with GPT-Live rounded up to whole callbacks
+PREBUFFER_DURATION = 0.3
 
 
 class ConsoleAudioInput(io.AudioInput):
@@ -156,6 +160,8 @@ class ConsoleAudioOutput(io.AudioOutput):
 
         self._output_buf = bytearray()
         self._audio_lock = threading.Lock()
+        # true from the first frame of a segment until PREBUFFER_DURATION is queued or flushed
+        self._priming = False
         self._output_buf_empty = asyncio.Event()
         self._output_buf_empty.set()
         self._interrupted_ev = asyncio.Event()
@@ -180,16 +186,20 @@ class ConsoleAudioOutput(io.AudioOutput):
             logger.error("capture_frame called while previous flush is in progress")
             await self._flush_task
 
-        if not self._pushed_duration:
-            self._capture_start = time.monotonic()
-
-        self._pushed_duration += frame.duration
         with self._audio_lock:
+            if not self._pushed_duration:
+                self._capture_start = time.monotonic()
+                self._priming = True
+
+            self._pushed_duration += frame.duration
             self._output_buf += frame.data  # TODO: optimize
             self._output_buf_empty.clear()
 
     def flush(self) -> None:
         super().flush()
+        with self._audio_lock:
+            self._priming = False
+
         if self._pushed_duration:
             if self._flush_task and not self._flush_task.done():
                 logger.error("flush called while previous flush is in progress")
@@ -201,6 +211,7 @@ class ConsoleAudioOutput(io.AudioOutput):
         with self._audio_lock:
             self._output_buf.clear()
             self._output_buf_empty.set()
+            self._priming = False
             # redundant (_wait_for_playout does the same, albeit async) but defensive
             self._segment_id += 1
             self._playback_started_fired = False
@@ -263,6 +274,11 @@ class ConsoleAudioOutput(io.AudioOutput):
     def read_into(self, outdata: np.ndarray, frames: int) -> None:
         """Fill ``outdata`` with the next ``frames`` samples of playback. Called from the audio thread."""
         with self._audio_lock:
+            if self._priming and len(self._output_buf) < int(PREBUFFER_DURATION * SAMPLE_RATE) * 2:
+                outdata[:] = 0
+                return
+
+            self._priming = False
             if self.paused:
                 outdata[:] = 0
             else:

--- a/tests/test_cli_console_output.py
+++ b/tests/test_cli_console_output.py
@@ -1,0 +1,70 @@
+"""The console speaker holds back the head of each segment until ``PREBUFFER_DURATION`` of audio
+is queued or the segment is flushed. A duplex model streams at real-time pace, so without this
+margin every network hiccup drained the buffer and played as a zero-filled click mid-word."""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+
+from livekit import rtc
+from livekit.agents.cli._legacy import SAMPLE_RATE, ConsoleAudioOutput
+
+pytestmark = pytest.mark.unit
+
+BLOCK = SAMPLE_RATE // 10  # one sounddevice callback
+
+
+def _frame(value: int) -> rtc.AudioFrame:
+    return rtc.AudioFrame(
+        data=np.full(BLOCK, value, dtype=np.int16).tobytes(),
+        sample_rate=SAMPLE_RATE,
+        num_channels=1,
+        samples_per_channel=BLOCK,
+    )
+
+
+def _read(out: ConsoleAudioOutput) -> np.ndarray:
+    buf = np.empty((BLOCK, 1), dtype=np.int16)
+    out.read_into(buf, BLOCK)
+    return buf[:, 0]
+
+
+async def test_segment_head_waits_for_prebuffer() -> None:
+    out = ConsoleAudioOutput(asyncio.get_running_loop())
+    await out.capture_frame(_frame(1))
+    assert not _read(out).any()
+    await out.capture_frame(_frame(2))
+    await out.capture_frame(_frame(3))
+    assert _read(out)[0] == 1
+
+
+async def test_flush_releases_a_short_segment() -> None:
+    out = ConsoleAudioOutput(asyncio.get_running_loop())
+    await out.capture_frame(_frame(1))
+    out.flush()
+    assert _read(out)[0] == 1
+    await asyncio.sleep(0.01)
+
+
+async def test_underrun_mid_segment_does_not_reprime() -> None:
+    out = ConsoleAudioOutput(asyncio.get_running_loop())
+    for v in (1, 2, 3):
+        await out.capture_frame(_frame(v))
+    for _ in range(3):
+        _read(out)
+    assert not _read(out).any()
+    await out.capture_frame(_frame(4))
+    assert _read(out)[0] == 4
+
+
+async def test_next_segment_primes_again() -> None:
+    out = ConsoleAudioOutput(asyncio.get_running_loop())
+    await out.capture_frame(_frame(1))
+    out.flush()
+    _read(out)
+    await asyncio.sleep(0.01)
+    await out.capture_frame(_frame(2))
+    assert not _read(out).any()


### PR DESCRIPTION
## Problem

Running a duplex model (e.g. `GPTLiveModel`) under `python agent.py console` produces audible clicks and stutters mid-word.

A duplex model streams its voice at real-time pace: one 100 ms frame every ~100 ms. The console speaker callback also pulls 100 ms per tick, so the buffer runs with a single block of margin. Whenever the gap between two arriving frames exceeds ~100 ms, the callback finds the buffer empty and zero-fills the block. That inserted silence is the click.

TTS pipelines never hit this because TTS delivers audio much faster than real time and the buffer stays deep.

### Measured

Instrumented `_sd_output_callback` and let the agent speak its greeting with no mic input. Frames arrived every ~100 ms with occasional 150–180 ms gaps; each gap produced a buffer depth of zero mid-utterance.

Before (samples queued per 100 ms callback, one utterance):
```
2400 2400 2400 2400 2400 2400 2400 2400 2400 2400 2400 2400 2400 2400 2400 0 4800 4800 ... 4800 2400 0
```
After:
```
2400 4800 7200 7200 7200 7200 ... 7200 7200 4800 2400 0
```

## Fix

`ConsoleAudioOutput` holds the head of each segment until 300 ms is queued, or until the segment is flushed (so short utterances are not delayed past their end). A mid-segment underrun does not re-prime, so the failure mode stays a single short gap rather than a longer one.

Commits:
1. Pure move: the drain logic leaves `AgentsConsole._sd_output_callback` and becomes `ConsoleAudioOutput.read_into`, so it can be unit tested.
2. The prebuffer, with tests in `tests/test_cli_console_output.py`.

## Follow-up

`lk agent console` (Go, `pkg/console/pipeline.go`) pads its playback ring with silence the same way and likely needs the same margin. Not measured yet.