### PR TITLE
fix(deps): pin anthropic below 1

### DIFF
--- a/livekit-plugins/livekit-plugins-anthropic/pyproject.toml
+++ b/livekit-plugins/livekit-plugins-anthropic/pyproject.toml
@@ -21,7 +21,11 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3 :: Only",
 ]
-dependencies = ["livekit-agents>=1.8.1", "anthropic>=0.41", "httpx"]
+dependencies = [
+    "livekit-agents>=1.8.1",
+    "anthropic>=0.41,<1",  # 1.0 switched to httpx2 and dropped temperature/top_k (#7235)
+    "httpx",
+]
 
 [project.urls]
 Documentation = "https://docs.livekit.io"

--- a/uv.lock
+++ b/uv.lock
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.41" },
+    { name = "anthropic", specifier = ">=0.41,<1" },
     { name = "httpx" },
     { name = "livekit-agents", editable = "livekit-agents" },
 ]


### PR DESCRIPTION
Fixes #7235

## Problem

anthropic 1.0 switched the SDK to httpx2 and dropped `temperature` and `top_k` from `messages.create`. The plugin builds its own `httpx.AsyncClient` and hands it over as `http_client`, and it passes both of those params through to `create()`, so neither works on 1.x. The dependency was declared as `anthropic>=0.41` with no upper bound, so a fresh install resolves 1.x and `anthropic.LLM(...)` raises `TypeError: Invalid http_client argument; httpx.AsyncClient is from the httpx package, but this SDK uses httpx2` before any request goes out. Any non-empty API key reproduces it.

## Changes

Capped the plugin dependency at `anthropic>=0.41,<1` and updated the matching specifier in `uv.lock`. The resolved version does not move, 0.117.0 already satisfies the bound, so nothing else in the lock changes and no code is touched. Supporting 1.x properly means reworking the client construction and the sampling params, which is a larger change than this.