### PR TITLE
fix: keep delayed duplex transcripts on the original audio burst

### DIFF
--- a/livekit-agents/livekit/agents/llm/duplex_adapter.py
+++ b/livekit-agents/livekit/agents/llm/duplex_adapter.py
@@ -192,6 +192,10 @@ class _Burst:
     audio_ch: aio.Chan[rtc.AudioFrame]
     audio_start_ms: int
     """Where on the adapter's audio clock the burst opened."""
+    audio_end_ms: int
+    """Last audio clock this burst covers, frozen when it closes."""
+    carries_message: bool = True
+    """False for a function-call generation that never spoke."""
     anchor_ms: int | None = None
     """Span clock minus audio clock, fixed by the first fragment: the sound that opened the gate
     and the oldest unclaimed fragment describe the same moment."""
@@ -307,6 +311,7 @@ class _DuplexRealtimeSession(RealtimeSession):
         self._duplex = duplex
         self._gate = gate
         self._burst: _Burst | None = None
+        self._last_burst: _Burst | None = None
         self._audio_timeout = audio_timeout
         # the adapter's clock: output audio heard so far, which arrives at playback pace
         self._audio_ms = 0
@@ -382,17 +387,8 @@ class _DuplexRealtimeSession(RealtimeSession):
             if not burst.audio_ch.closed:
                 burst.audio_ch.send_nowait(f.frame)
             self._audio_ms += round(f.frame.duration * 1000)
-
-            # the first fragment anchors the span clock to the audio clock; a later one is due when
-            # the audio reaches its span, and one this burst never reaches waits for the next
-            while self._fragments:
-                fragment = self._fragments[0]
-                if fragment.start_ms is not None:
-                    if burst.anchor_ms is None:
-                        burst.anchor_ms = fragment.start_ms - burst.audio_start_ms
-                    if fragment.start_ms - burst.anchor_ms > self._audio_ms + _ATTACH_LEAD_MS:
-                        break
-                burst.attach(self._fragments.popleft())
+            burst.audio_end_ms = self._audio_ms
+            self._drain_fragments()
             return
 
         self._audio_ms += round(f.frame.duration * 1000)
@@ -418,6 +414,8 @@ class _DuplexRealtimeSession(RealtimeSession):
             text_ch=aio.Chan(),
             audio_ch=aio.Chan(),
             audio_start_ms=self._audio_ms,
+            audio_end_ms=self._audio_ms,
+            carries_message=message,
         )
         ev = GenerationCreatedEvent(
             message_stream=burst.message_ch,
@@ -444,29 +442,83 @@ class _DuplexRealtimeSession(RealtimeSession):
             )
         return burst
 
+    def _attach_due(self, burst: _Burst) -> bool:
+        """Attach queued fragments whose sound this burst has already reached.
+
+        Returns True if any fragment was attached.
+        """
+        if not burst.carries_message:
+            return False
+
+        attached = False
+        heard_ms = self._audio_ms if burst is self._burst else burst.audio_end_ms
+        while self._fragments:
+            fragment = self._fragments[0]
+            if fragment.start_ms is not None:
+                if burst.anchor_ms is None:
+                    # a closed burst has no offset yet: only claim a span that sits on the
+                    # audio it already forwarded, so the next utterance is not stolen
+                    if burst is not self._burst and not (
+                        burst.audio_start_ms - _ATTACH_LEAD_MS
+                        <= fragment.start_ms
+                        <= burst.audio_end_ms
+                    ):
+                        break
+                    burst.anchor_ms = fragment.start_ms - burst.audio_start_ms
+                if fragment.start_ms - burst.anchor_ms > heard_ms + _ATTACH_LEAD_MS:
+                    break
+            elif burst is not self._burst and self._burst is not None:
+                break
+            burst.attach(self._fragments.popleft())
+            attached = True
+        return attached
+
+    def _record_burst(self, burst: _Burst) -> None:
+        if not burst.transcript:
+            return
+        existing = self._chat_ctx.get_by_id(burst.id)
+        if isinstance(existing, ChatMessage):
+            existing.content = [burst.transcript]
+            return
+        # under the id and time the framework will use for it, so a context update matches
+        self._chat_ctx.insert(
+            ChatMessage(
+                id=burst.id,
+                role="assistant",
+                content=[burst.transcript],
+                created_at=burst.opened_at,
+            )
+        )
+
+    def _drain_fragments(self) -> None:
+        if self._last_burst is not None:
+            # a first fragment may still establish this burst's offset from a span that sits
+            # on the audio it forwarded, including after the next burst has already opened
+            if self._attach_due(self._last_burst):
+                self._record_burst(self._last_burst)
+        if self._burst is not None:
+            self._attach_due(self._burst)
+
     def _close_burst(self) -> None:
+        if self._burst is not None:
+            self._burst.audio_end_ms = self._audio_ms
+            self._drain_fragments()
         burst, self._burst = self._burst, None
         # the gate never stays open past the burst it opened, so the next one opens on sound again
         self._gate.deactivate()
         if burst is not None:
             burst.close()
-            if burst.transcript:
-                # under the id and time the framework will use for it, so a context update matches
-                self._chat_ctx.insert(
-                    ChatMessage(
-                        id=burst.id,
-                        role="assistant",
-                        content=[burst.transcript],
-                        created_at=burst.opened_at,
-                    )
-                )
+            if burst.carries_message:
+                self._record_burst(burst)
+                self._last_burst = burst
         self._waiting_since_ms = self._audio_ms
 
     def _on_transcript_delta(self, ev: DuplexOutputTranscriptDelta) -> None:
-        # attached on the next frame, since the sound is what places the words
+        # attached as soon as the sound that carries the words is already on a burst
         if not self._fragments:
             self._waiting_since_ms = self._audio_ms
         self._fragments.append(ev)
+        self._drain_fragments()
 
     def _on_input_transcription(self, ev: InputTranscriptionCompleted) -> None:
         if ev.is_final:
@@ -498,6 +550,7 @@ class _DuplexRealtimeSession(RealtimeSession):
         # describe, or the reply it was asked for
         self._fragments.clear()
         self._close_burst()
+        self._last_burst = None
         self._fail_pending_reply("the session reconnected before the model replied")
         self.emit("session_reconnected", ev)
 

--- a/tests/test_duplex_adapter.py
+++ b/tests/test_duplex_adapter.py
@@ -536,6 +536,96 @@ async def test_a_fragment_that_lags_its_audio_anchors_at_the_bursts_onset(duplex
     assert first.start_time == pytest.approx(0.0)
 
 
+async def test_a_fragment_that_lags_past_the_last_frame_still_joins_the_burst(duplex) -> None:
+    """The last audible frame is enough: a later transcript must not wait for another one."""
+    fake, session, generations = duplex
+    fake.push(0.001, count=20)
+    fake.push(0.3, count=3)
+    await _settle()
+    first_id = session._burst.id if session._burst is not None else None
+    fake.say("Hello there.", start_ms=9000, end_ms=9400)
+    fake.audio_ch.close()
+    await _settle()
+
+    first = session.chat_ctx.get_by_id(first_id) if first_id is not None else None
+    assert first is not None and first.text_content == "Hello there."
+    assert (await asyncio.wait_for(_read(generations[0]), timeout=1))[1] == "Hello there."
+
+
+@pytest.mark.parametrize("when", ["before_close", "in_gap", "after_next"])
+async def test_a_delayed_transcript_keeps_its_original_audio(when: str) -> None:
+    """A fragment describing audio already heard stays on that utterance, even after it closes."""
+    session = llm.DuplexRealtimeAdapter(_FakeDuplexModel(), gate=lambda: FixedGate(0.001)).session()
+    assert isinstance(session, _DuplexRealtimeSession)
+    try:
+        session._on_audio_frame(llm.DuplexAudioFrame(_frame(0.3), start_ms=0))
+        assert session._burst is not None
+        first_id = session._burst.id
+        if when != "before_close":
+            session._close_burst()
+        if when == "after_next":
+            session._on_audio_frame(llm.DuplexAudioFrame(_frame(0.3), start_ms=1000))
+            assert session._burst is not None
+        session._on_transcript_delta(
+            llm.DuplexOutputTranscriptDelta("First utterance.", start_ms=0, end_ms=100)
+        )
+        if when == "before_close":
+            session._close_burst()
+        else:
+            if when == "in_gap":
+                session._on_audio_frame(llm.DuplexAudioFrame(_frame(0.3), start_ms=1000))
+            assert session._burst is not None
+            assert session._burst.transcript == "", "old text was attached to the next burst"
+        first = session.chat_ctx.get_by_id(first_id)
+        assert first is not None and first.text_content == "First utterance."
+    finally:
+        await session.aclose()
+
+
+async def test_a_fragment_that_arrives_after_the_burst_closes_does_not_join_the_next(
+    duplex,
+) -> None:
+    """Late text for a finished utterance must not become the next burst's first fragment."""
+    fake, session, generations = duplex
+    fake.push(0.001, count=20)
+    fake.push(0.3, count=3)
+    fake.push(0.001, count=8)
+    await _settle()
+    assert len(generations) == 1
+    first_id = generations[0].response_id
+
+    fake.say("First utterance.", start_ms=2000, end_ms=2300)
+    fake.push(0.3, count=3)
+    await _settle()
+
+    first = session.chat_ctx.get_by_id(first_id)
+    assert first is not None and first.text_content == "First utterance."
+    assert session._burst is not None
+    assert session._burst.transcript == ""
+
+
+async def test_a_leading_fragment_after_an_untranscribed_burst_still_waits(duplex) -> None:
+    """Text whose span is already past a closed burst is the next utterance, not a backchannel."""
+    fake, session, generations = duplex
+    fake.push(0.001, count=20)
+    fake.push(0.3, count=3)
+    fake.push(0.001, count=8)
+    await _settle()
+    assert len(generations) == 1
+    first_id = generations[0].response_id
+
+    start_ms = session._audio_ms  # the next utterance starts on the audio that follows the gap
+    fake.say(" Sure.", start_ms=start_ms, end_ms=start_ms + 200)
+    fake.push(0.3, count=3)
+    fake.push(0.001, count=8)
+    await _settle()
+
+    first = session.chat_ctx.get_by_id(first_id)
+    assert first is None
+    assert len(generations) == 2
+    assert (await asyncio.wait_for(_read(generations[1]), timeout=1))[1] == " Sure."
+
+
 async def test_a_fragment_is_attached_when_the_audio_reaches_it(duplex) -> None:
     """The model's words run ahead of its voice; a span the sound has not reached yet waits, even
     across a pause in the transcript, and joins this burst if the gate rides the pause out."""


### PR DESCRIPTION
## Summary

Delayed duplex transcripts attach to the burst that already played that audio, including after the gate has closed. Late text is recorded under the original message id and is not used to open the next burst.

`DuplexRealtimeAdapter` only attached queued transcript fragments from `_on_audio_frame` while the audio gate was open. A fragment describing audio that had already arrived could miss its utterance:

- Last audible frame, then transcript, then close: the original burst closed with no text and no assistant chat item.
- Burst closed before the transcript arrived: the next audible burst claimed the old text as its first fragment and established a fresh span/audio offset from it.

Both orders are in #7227. A third order (next burst already open, then the delayed first fragment) also attached the old text to the new utterance.

The adapter attaches due fragments when they arrive and when the burst closes, same due/ahead rule as before. A closed burst is remembered so late text that still sits on that audio range can be recorded on it.

A closed burst with no offset yet only claims a span in `[audio_start - lead, audio_end]`. The extra lead past `audio_end` would include the next utterance's onset after a normal gated pause. Unplayed spans (audio this burst never reached) are still not published on that item.

## Decision

Late eligible text is attached to the closed burst's chat item; `text_ch` is not kept open after audio ends. Keeping the text channel open until a grace timeout or the next burst would leave `forward_generation` waiting on a stream that usually never gets another fragment. Can switch if the stream should stay open instead.

A closed burst without an offset may still take a first fragment after the next burst has opened, but only if that span sits on audio it already forwarded (no extra lead past `audio_end`). Freezing identity once the next burst opens still gives the next burst the previous utterance. A ±300 ms window around the whole closed range would claim the next utterance after a real silence gap.

## Test plan

- [x] `tests/test_duplex_adapter.py`: delayed transcript after the last frame still joins that burst (including mismatched span/audio clocks while the burst is still open).
- [x] Reporter's two orders plus the sibling (`when=before_close/in_gap/after_next`): original id keeps the text; the next burst does not.
- [x] Stream-level: transcript after the burst has closed via silence does not become the next burst's first fragment.
- [x] Leading fragment after an untranscribed burst, stamped at the actual gap clock, still waits for the next utterance.
- [x] Existing adapter suite (54 unit tests), including rollover, unclaimed timeout, reconnect, and function-call generations.

Fixes #7227
