### PR TITLE
fix(liveavatar): honor agent.state_updated for speaking and barge-in

### DIFF
--- a/livekit-plugins/livekit-plugins-liveavatar/livekit/plugins/liveavatar/avatar.py
+++ b/livekit-plugins/livekit-plugins-liveavatar/livekit/plugins/liveavatar/avatar.py
@@ -329,20 +329,7 @@ class AvatarSession(BaseAvatarSession):
                             message="LiveAvatar connection closed unexpectedly."
                         )
                 event = json.loads(msg.data)
-                event_type = event.get("type")
-                if event_type == "session.state_updated":
-                    state = event.get("state")
-                    logger.debug(f"LiveAvatar session state: {state}")
-                    if state == "connected":
-                        self._session_connected.set()
-                elif event_type == "agent.speak_interrupted":
-                    self._handle_agent_speak_interrupted(event)
-                elif event_type == "agent.speak_ended":
-                    self._handle_agent_speak_ended(event)
-                elif event_type == "agent.speak_started":
-                    self._handle_agent_speak_started(event)
-                else:
-                    logger.debug(f"Unhandled LiveAvatar event: {event_type}")
+                self._handle_server_event(event)
 
         io_tasks = [
             asyncio.create_task(_forward_audio(), name="_forward_audio_task"),
@@ -370,10 +357,50 @@ class AvatarSession(BaseAvatarSession):
             await self._audio_buffer.aclose()
             await ws_conn.close()
 
+    def _handle_server_event(self, event: dict) -> None:
+        event_type = event.get("type")
+        if event_type == "session.state_updated":
+            state = event.get("state")
+            logger.debug(f"LiveAvatar session state: {state}")
+            if state == "connected":
+                self._session_connected.set()
+        elif event_type == "agent.speak_interrupted":
+            self._handle_agent_speak_interrupted(event)
+        elif event_type == "agent.speak_ended":
+            self._handle_agent_speak_ended(event)
+        elif event_type == "agent.speak_started":
+            self._handle_agent_speak_started(event)
+        elif event_type == "agent.state_updated":
+            self._handle_agent_state_updated(event)
+        elif event_type == "agent.audio_buffer_cleared":
+            self._handle_agent_speak_interrupted(event)
+        elif event_type in (
+            "agent.audio_buffer_appended",
+            "agent.audio_buffer_committed",
+        ):
+            # command acks; playback follows speak_* / agent.state_updated
+            logger.debug(f"LiveAvatar {event_type}")
+        elif event_type == "error":
+            logger.error(f"LiveAvatar error: {event.get('error', event)}")
+        elif event_type == "warning":
+            logger.warning(f"LiveAvatar warning: {event.get('warning', event)}")
+        else:
+            logger.debug(f"Unhandled LiveAvatar event: {event_type}")
+
+    def _handle_agent_state_updated(self, event: dict) -> None:
+        new_state = event.get("new_state", event.get("state"))
+        logger.debug(f"LiveAvatar agent state: {event.get('previous_state')} -> {new_state}")
+        if new_state == "talking":
+            self._handle_agent_speak_started(event)
+        elif new_state in ("idle", "listening") and self._avatar_speaking:
+            self._handle_agent_speak_ended(event)
+
     def _handle_agent_speak_interrupted(self, event: dict) -> None:
         self._avatar_interrupted = True
 
     def _handle_agent_speak_ended(self, event: dict) -> None:
+        if not self._avatar_speaking and not self._audio_playing:
+            return
         self._avatar_speaking = False
         if not self._avatar_interrupted:
             self._audio_buffer.notify_playback_finished(
@@ -384,6 +411,8 @@ class AvatarSession(BaseAvatarSession):
             self._audio_playing = False
 
     def _handle_agent_speak_started(self, event: dict) -> None:
+        already_speaking = self._avatar_speaking
         self._avatar_speaking = True
         self._avatar_interrupted = False
-        self._audio_buffer.notify_playback_started()
+        if not already_speaking:
+            self._audio_buffer.notify_playback_started()

--- a/tests/test_plugin_liveavatar.py
+++ b/tests/test_plugin_liveavatar.py
@@ -1,0 +1,156 @@
+"""Unit tests for LiveAvatar WebSocket event dispatch.
+
+The LiveAvatar LITE protocol emits ``agent.state_updated`` and
+``agent.audio_buffer_*`` acks in addition to the original speak_* events.
+These tests drive ``AvatarSession._handle_server_event`` with a fake audio
+buffer so they stay hermetic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import pytest
+
+from livekit.agents.utils.aio.channel import ChanEmpty
+from livekit.plugins.liveavatar.avatar import AvatarSession
+
+pytestmark = [pytest.mark.unit, pytest.mark.plugin("liveavatar")]
+
+
+class _FakeAudioBuffer:
+    def __init__(self) -> None:
+        self.started = 0
+        self.finished: list[tuple[float, bool]] = []
+
+    def notify_playback_started(self) -> None:
+        self.started += 1
+
+    def notify_playback_finished(self, playback_position: float, interrupted: bool) -> None:
+        self.finished.append((playback_position, interrupted))
+
+
+@pytest.fixture
+def avatar(monkeypatch: pytest.MonkeyPatch) -> tuple[AvatarSession, _FakeAudioBuffer]:
+    def _fake_api(*_args: Any, **_kwargs: Any) -> object:
+        return object()
+
+    monkeypatch.setattr("livekit.plugins.liveavatar.avatar.LiveAvatarAPI", _fake_api)
+    session = AvatarSession(api_key="test-key", avatar_id="av-1")
+    buf = _FakeAudioBuffer()
+    session._audio_buffer = buf  # type: ignore[assignment]
+    return session, buf
+
+
+def test_session_connected_still_unblocks_forwarding(avatar):
+    session, _ = avatar
+    assert not session._session_connected.is_set()
+    session._handle_server_event({"type": "session.state_updated", "state": "connected"})
+    assert session._session_connected.is_set()
+
+
+def test_state_updated_talking_marks_speaking_and_playback_started(avatar):
+    session, buf = avatar
+    session._handle_server_event(
+        {
+            "type": "agent.state_updated",
+            "previous_state": "listening",
+            "new_state": "talking",
+        }
+    )
+    assert session._avatar_speaking is True
+    assert buf.started == 1
+    assert buf.finished == []
+
+
+def test_state_updated_listening_finishes_playback(avatar):
+    session, buf = avatar
+    session._playback_position = 1.25
+    session._handle_server_event(
+        {"type": "agent.state_updated", "previous_state": "idle", "new_state": "talking"}
+    )
+    session._handle_server_event(
+        {
+            "type": "agent.state_updated",
+            "previous_state": "talking",
+            "new_state": "listening",
+        }
+    )
+    assert session._avatar_speaking is False
+    assert buf.started == 1
+    assert buf.finished == [(1.25, False)]
+
+
+def test_buffer_acks_do_not_drive_speaking_state(avatar):
+    session, buf = avatar
+    session._handle_server_event({"type": "agent.audio_buffer_appended"})
+    session._handle_server_event({"type": "agent.audio_buffer_committed"})
+    assert session._avatar_speaking is False
+    assert buf.started == 0
+    assert buf.finished == []
+
+
+def test_speak_started_and_talking_are_idempotent(avatar):
+    session, buf = avatar
+    session._handle_server_event({"type": "agent.speak_started"})
+    session._handle_server_event(
+        {"type": "agent.state_updated", "previous_state": "idle", "new_state": "talking"}
+    )
+    assert session._avatar_speaking is True
+    assert buf.started == 1
+
+
+def test_audio_buffer_cleared_marks_interrupted(avatar):
+    session, buf = avatar
+    session._handle_server_event(
+        {"type": "agent.state_updated", "previous_state": "idle", "new_state": "talking"}
+    )
+    session._handle_server_event({"type": "agent.audio_buffer_cleared"})
+    session._handle_server_event(
+        {"type": "agent.state_updated", "previous_state": "talking", "new_state": "idle"}
+    )
+    assert session._avatar_interrupted is True
+    assert session._avatar_speaking is False
+    assert buf.finished == []
+
+
+def test_error_event_is_logged(avatar, caplog: pytest.LogCaptureFixture):
+    session, buf = avatar
+    with caplog.at_level(logging.ERROR, logger="livekit.plugins.liveavatar"):
+        session._handle_server_event(
+            {
+                "type": "error",
+                "error": {"type": "invalid_request_error", "message": "bad audio"},
+            }
+        )
+    assert "invalid_request_error" in caplog.text
+    assert session._avatar_speaking is False
+    assert buf.started == 0
+
+
+async def test_barge_in_sends_interrupt_after_talking(avatar):
+    session, _buf = avatar
+    session._handle_server_event(
+        {"type": "agent.state_updated", "previous_state": "idle", "new_state": "talking"}
+    )
+    session._audio_playing = True
+    session._on_clear_buffer()
+    if session._tasks:
+        await asyncio.gather(*session._tasks)
+
+    msg = session._msg_ch.recv_nowait()
+    assert msg["type"] == "agent.interrupt"
+
+
+async def test_barge_in_skips_interrupt_when_never_talking(avatar):
+    session, _buf = avatar
+    session._handle_server_event({"type": "agent.audio_buffer_appended"})
+    session._audio_playing = True
+    session._on_clear_buffer()
+    if session._tasks:
+        await asyncio.gather(*session._tasks)
+
+    with pytest.raises(ChanEmpty):
+        session._msg_ch.recv_nowait()


### PR DESCRIPTION
## Summary

`agent.state_updated` with `new_state == "talking"` follows the existing speak-started path; leaving talking (`idle` / `listening`) follows speak-ended. `speak_*` still work and are idempotent if a session emits both. Buffer append/commit are treated as command acks, not playback lifecycle. `agent.audio_buffer_cleared` is treated as the interrupt ack. `error` / `warning` are logged at the matching level.

LiveAvatar LITE emits `agent.state_updated` (`idle` / `listening` / `talking`) and `agent.audio_buffer_*` acks during a conversation. The plugin only handled `session.state_updated` and `agent.speak_*`, so `_avatar_speaking` never became true, playback start/finish were never notified from the server, and barge-in skipped `agent.interrupt`.

## Decision

Speaking and playback are driven from `agent.state_updated`, not `audio_buffer_appended` → started and `audio_buffer_committed` → ended (the mapping sketched in the issue). The [LITE events spec](https://docs.liveavatar.com/docs/lite-mode/events) defines buffer events as command acks and `agent.state_updated` as the avatar speaking signal; the reporter also observed `agent.state_updated` on a real sandbox session. Mapping commit to "playback finished" would end playout on the `speak_end` ack, which can fire while the avatar is still talking. Can switch if append/commit should own playback instead.

Fixes #7232

## Test plan

- [x] Unit tests in `tests/test_plugin_liveavatar.py` (`pytest.mark.unit`): `agent.state_updated` talking/listening updates `_avatar_speaking` and playback notifications; buffer append/commit do not; speak_started + talking is one playback-started; barge-in sends `agent.interrupt` after talking and does not after append-only.
- [x] Those tests fail without the dispatch change (5 failed, 4 passed) and pass with it, plus existing `livekit-plugins/livekit-plugins-liveavatar/tests/test_api.py`.
- [ ] Live LITE/sandbox conversation with `LIVEAVATAR_API_KEY` / `LIVEAVATAR_AVATAR_ID`: DEBUG should no longer print Unhandled for `agent.state_updated` / `agent.audio_buffer_*`, and interrupting mid-reply should send `agent.interrupt`.
