### PR TITLE
test(google): disarm GenAI client finalizers to prevent task leak across unit tests (#6881)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,19 +57,36 @@ _CATEGORY_HINT = (
 )
 
 
+def _parameterized_categories() -> frozenset[str]:
+    block = re.search(r"(?ms)^markers\s*=\s*\[(.*?)^\s*\]", _PYPROJECT.read_text(encoding="utf-8"))
+    names = re.findall(r'^\s*"(\w+)\(', block.group(1), re.MULTILINE) if block else []
+    return frozenset(names)
+
+
+PARAMETERIZED_CATEGORIES = _parameterized_categories()
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     _add_realtime_option(parser)
     group = parser.getgroup("categories", "test category selection")
     for category in CATEGORIES:
-        group.addoption(
-            f"--{category}",
-            nargs="?",
-            const=True,
-            default=None,
-            metavar="PROVIDER",
-            help=f"select only `{category}` tests; optionally narrow to a single "
-            f"provider/target (e.g. --{category} <name>). Repeatable categories are unioned.",
-        )
+        if category in PARAMETERIZED_CATEGORIES:
+            group.addoption(
+                f"--{category}",
+                nargs="?",
+                const=True,
+                default=None,
+                metavar="PROVIDER",
+                help=f"select only `{category}` tests; optionally narrow to a single "
+                f"provider/target (e.g. --{category} <name>). Repeatable categories are unioned.",
+            )
+        else:
+            group.addoption(
+                f"--{category}",
+                action="store_true",
+                default=None,
+                help=f"select only `{category}` tests.",
+            )
     group.addoption(
         "--list-categories",
         action="store_true",
@@ -198,7 +215,7 @@ def _selected_categories(config: pytest.Config) -> dict[str, object]:
     selected: dict[str, object] = {}
     for category in CATEGORIES:
         value = config.getoption(f"--{category}")
-        if value is not None:
+        if value is not None and value is not False:
             selected[category] = value
     return selected
 
@@ -307,6 +324,11 @@ def _is_ignorable_task(task) -> bool:
         coro_name = getattr(coro, "__qualname__", "") or type(coro).__name__
         if "async_generator_athrow" in coro_name:
             return True
+        if coro_name.endswith(".aclose"):
+            frame = getattr(coro, "cr_frame", None)
+            module = frame.f_globals.get("__name__", "") if frame else ""
+            if module.startswith("google.genai"):
+                return True
         mod = getattr(coro, "__module__", "")
         if "pytest" in mod or "pytest_asyncio" in mod:
             return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -324,11 +324,6 @@ def _is_ignorable_task(task) -> bool:
         coro_name = getattr(coro, "__qualname__", "") or type(coro).__name__
         if "async_generator_athrow" in coro_name:
             return True
-        if coro_name.endswith(".aclose"):
-            frame = getattr(coro, "cr_frame", None)
-            module = frame.f_globals.get("__name__", "") if frame else ""
-            if module.startswith("google.genai"):
-                return True
         mod = getattr(coro, "__module__", "")
         if "pytest" in mod or "pytest_asyncio" in mod:
             return True

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -44,19 +44,19 @@ def _disarm_client(session: RealtimeSession) -> None:
         client._api_client.__class__ = _DisarmedBaseApiClient
 
 
-# Disarm finalizers on classes as well to prevent aclose() tasks scheduling on active event loops
-AsyncClient.__del__ = lambda self: None  # type: ignore[assignment]
+@pytest.fixture(autouse=True)
+def _disarm_genai_finalizers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(AsyncClient, "__del__", lambda self: None)
 
+    def _safe_base_api_client_del(self: BaseApiClient) -> None:
+        try:
+            if not self._http_options.httpx_client:
+                self.close()
+        except Exception:
+            pass
 
-def _safe_base_api_client_del(self: BaseApiClient) -> None:
-    try:
-        if not self._http_options.httpx_client:
-            self.close()
-    except Exception:
-        pass
+    monkeypatch.setattr(BaseApiClient, "__del__", _safe_base_api_client_del)
 
-
-BaseApiClient.__del__ = _safe_base_api_client_del  # type: ignore[assignment]
 
 _orig_session_init = RealtimeSession.__init__
 

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -9,6 +9,8 @@ from typing import Any
 
 import pytest
 from google.genai import types
+from google.genai._api_client import BaseApiClient
+from google.genai.client import AsyncClient
 
 from livekit.agents import llm, utils
 from livekit.plugins.google.realtime.api_proto import ClientEvents
@@ -16,6 +18,55 @@ from livekit.plugins.google.realtime.realtime_api import RealtimeModel, Realtime
 from livekit.plugins.google.utils import create_function_response
 
 pytestmark = pytest.mark.unit
+
+
+class _DisarmedAsyncClient(AsyncClient):
+    def __del__(self) -> None:
+        pass
+
+
+class _DisarmedBaseApiClient(BaseApiClient):
+    def __del__(self) -> None:
+        try:
+            if not self._http_options.httpx_client:
+                self.close()
+        except Exception:
+            pass
+
+
+def _disarm_client(session: RealtimeSession) -> None:
+    client = session._client
+    if hasattr(client, "aio"):
+        client.aio.__class__ = _DisarmedAsyncClient
+        if hasattr(client.aio, "_api_client"):
+            client.aio._api_client.__class__ = _DisarmedBaseApiClient
+    if hasattr(client, "_api_client"):
+        client._api_client.__class__ = _DisarmedBaseApiClient
+
+
+# Disarm finalizers on classes as well to prevent aclose() tasks scheduling on active event loops
+AsyncClient.__del__ = lambda self: None  # type: ignore[assignment]
+
+
+def _safe_base_api_client_del(self: BaseApiClient) -> None:
+    try:
+        if not self._http_options.httpx_client:
+            self.close()
+    except Exception:
+        pass
+
+
+BaseApiClient.__del__ = _safe_base_api_client_del  # type: ignore[assignment]
+
+_orig_session_init = RealtimeSession.__init__
+
+
+def _session_init(self: RealtimeSession, *args: Any, **kwargs: Any) -> None:
+    _orig_session_init(self, *args, **kwargs)
+    _disarm_client(self)
+
+
+RealtimeSession.__init__ = _session_init  # type: ignore[assignment]
 
 
 def _is_genai_client_teardown(task: asyncio.Task[Any]) -> bool:
@@ -66,6 +117,7 @@ async def _make_session(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Realti
     """
     monkeypatch.setenv("GOOGLE_API_KEY", "fake-key")
     session = RealtimeModel().session()
+    _disarm_client(session)
     # cancel the connect loop before the event loop ever schedules it, so no
     # websocket connection is attempted
     session._msg_ch.close()
@@ -73,7 +125,15 @@ async def _make_session(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[Realti
     try:
         yield session
     finally:
+        _disarm_client(session)
         await session.aclose()
+        gc.collect()
+        if pending := [
+            task
+            for task in asyncio.all_tasks()
+            if not task.done() and _is_genai_client_teardown(task)
+        ]:
+            await asyncio.gather(*pending, return_exceptions=True)
 
 
 @asynccontextmanager
@@ -82,12 +142,21 @@ async def _make_configured_session(
 ) -> AsyncIterator[RealtimeSession]:
     monkeypatch.setenv("GOOGLE_API_KEY", "fake-key")
     session = RealtimeModel(**options).session()  # type: ignore[arg-type]
+    _disarm_client(session)
     session._msg_ch.close()
     await utils.aio.cancel_and_wait(session._main_atask)
     try:
         yield session
     finally:
+        _disarm_client(session)
         await session.aclose()
+        gc.collect()
+        if pending := [
+            task
+            for task in asyncio.all_tasks()
+            if not task.done() and _is_genai_client_teardown(task)
+        ]:
+            await asyncio.gather(*pending, return_exceptions=True)
 
 
 def _audio_content(**kwargs: object) -> types.LiveServerContent:


### PR DESCRIPTION
## Summary
- Disarm `google.genai.client.AsyncClient.__del__` and `BaseApiClient.__del__` in `tests/test_plugin_google_realtime.py` so that asynchronous client finalizers do not schedule `aclose()` tasks on subsequent unrelated tests' event loops during GC.
- Add `gc.collect()` and task drain in `_make_session` and `_make_configured_session`.
- Fix flag parsing in `tests/conftest.py` so boolean category flags (like `--unit`) do not swallow subsequent test file arguments.

Fixes #6881