### PR TITLE
fix(sarvam): map wav output codec to audio/pcm to prevent missing RIFF error (#5267)

### DIFF
--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -26,6 +26,7 @@ import enum
 import json
 import os
 import platform
+import struct
 import weakref
 from dataclasses import dataclass, replace
 from typing import Literal
@@ -155,6 +156,28 @@ def _decode_telephony(codec: str, data: bytes) -> bytes:
         raise ValueError(f"_decode_telephony does not support codec: {codec}")
     pcm = table[np.frombuffer(data, dtype=np.uint8)]
     return pcm.astype("<i2").tobytes()
+
+
+def _extract_wav_pcm(audio_bytes: bytes) -> bytes:
+    """If audio_bytes starts with a RIFF/WAVE container, extract the raw PCM data.
+
+    Parses the RIFF chunk structure to locate the 'data' chunk instead of
+    assuming a fixed 44-byte header, handling metadata or extended format chunks.
+    """
+    if len(audio_bytes) < 12 or not audio_bytes.startswith(b"RIFF") or audio_bytes[8:12] != b"WAVE":
+        return audio_bytes
+
+    pos = 12
+    while pos + 8 <= len(audio_bytes):
+        chunk_id = audio_bytes[pos : pos + 4]
+        chunk_size = struct.unpack("<I", audio_bytes[pos + 4 : pos + 8])[0]
+        pos += 8
+        if chunk_id == b"data":
+            end = pos + chunk_size
+            return audio_bytes[pos:end] if end <= len(audio_bytes) else audio_bytes[pos:]
+        pos += chunk_size + (chunk_size % 2)
+
+    return audio_bytes[44:] if len(audio_bytes) >= 44 else audio_bytes
 
 
 # Supported languages in BCP-47 format
@@ -1348,12 +1371,8 @@ class SynthesizeStream(tts.SynthesizeStream):
                 return True
 
             audio_bytes = base64.b64decode(audio_data)
-            if (
-                self._opts.output_audio_codec == "wav"
-                and audio_bytes.startswith(b"RIFF")
-                and len(audio_bytes) >= 44
-            ):
-                audio_bytes = audio_bytes[44:]
+            if self._opts.output_audio_codec == "wav":
+                audio_bytes = _extract_wav_pcm(audio_bytes)
             if self._opts.output_audio_codec in _TELEPHONY_CODECS:
                 audio_bytes = _decode_telephony(self._opts.output_audio_codec, audio_bytes)
             output_emitter.push(audio_bytes)

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -86,7 +86,7 @@ ALLOWED_OUTPUT_AUDIO_CODECS: set[str] = {
 
 _CODEC_TO_MIME: dict[str, str] = {
     "mp3": "audio/mp3",
-    "wav": "audio/wav",
+    "wav": "audio/pcm",
     "opus": "audio/opus",
     "flac": "audio/flac",
     "aac": "audio/aac",

--- a/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/livekit/plugins/sarvam/tts.py
@@ -86,7 +86,7 @@ ALLOWED_OUTPUT_AUDIO_CODECS: set[str] = {
 
 _CODEC_TO_MIME: dict[str, str] = {
     "mp3": "audio/mp3",
-    "wav": "audio/pcm",
+    "wav": "audio/wav",
     "opus": "audio/opus",
     "flac": "audio/flac",
     "aac": "audio/aac",
@@ -985,6 +985,9 @@ class SynthesizeStream(tts.SynthesizeStream):
         self._client_request_id = request_id
         self._server_request_id = None
         mime_type = _codec_to_mime_type(self._opts.output_audio_codec)
+        if self._opts.output_audio_codec == "wav":
+            # Sarvam WebSocket streaming sends headerless raw PCM chunks for "wav"
+            mime_type = "audio/pcm"
         output_emitter.initialize(
             request_id=request_id,
             sample_rate=self._opts.speech_sample_rate,
@@ -1345,6 +1348,12 @@ class SynthesizeStream(tts.SynthesizeStream):
                 return True
 
             audio_bytes = base64.b64decode(audio_data)
+            if (
+                self._opts.output_audio_codec == "wav"
+                and audio_bytes.startswith(b"RIFF")
+                and len(audio_bytes) >= 44
+            ):
+                audio_bytes = audio_bytes[44:]
             if self._opts.output_audio_codec in _TELEPHONY_CODECS:
                 audio_bytes = _decode_telephony(self._opts.output_audio_codec, audio_bytes)
             output_emitter.push(audio_bytes)

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_language_probability.py
@@ -16,6 +16,8 @@ import pytest
 from livekit.agents import stt
 from livekit.plugins.sarvam.stt import SpeechStream
 
+pytestmark = pytest.mark.unit
+
 # ---------------------------------------------------------------------------
 # Helpers — build a minimal STT instance + fake the channel/logger/state that
 # `_handle_transcript_data` touches. We bypass __init__ so the test doesn't
@@ -39,6 +41,11 @@ def _make_stream_under_test() -> tuple[SpeechStream, list[Any]]:
     instance._build_log_context = lambda: {}  # type: ignore[attr-defined]
     instance._server_request_id = None  # type: ignore[attr-defined]
     instance._opts = MagicMock(language="en-IN")  # type: ignore[attr-defined]
+    instance._start_time_offset = 0.0  # type: ignore[attr-defined]
+    instance._pending_eos = False  # type: ignore[attr-defined]
+    instance._pending_final_data = None  # type: ignore[attr-defined]
+    instance._final_received_for_utterance = False  # type: ignore[attr-defined]
+    instance._eos_emitted_for_utterance = False  # type: ignore[attr-defined]
     return instance, captured
 
 

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_tts.py
@@ -220,3 +220,68 @@ async def test_synthesize_stream_with_wav_codec_strips_riff_header_if_present():
     total_samples = sum(ev.frame.samples_per_channel for ev in events)
     expected_samples = (len(wav_bytes) - 44) // 2
     assert total_samples == expected_samples
+
+
+@pytest.mark.asyncio
+async def test_synthesize_stream_with_wav_codec_handles_extended_chunks():
+    """Verify SynthesizeStream locates the data chunk even with metadata/extended chunks."""
+    import struct
+
+    sarvam_tts = TTS(
+        api_key="test-api-key",
+        speech_sample_rate=SAMPLE_RATE,
+        output_audio_codec="wav",
+    )
+
+    raw_pcm = _generate_raw_pcm(duration_ms=100, sample_rate=SAMPLE_RATE)
+    fmt_chunk = struct.pack("<4sIHHIIHH", b"fmt ", 16, 1, 1, SAMPLE_RATE, SAMPLE_RATE * 2, 2, 16)
+    junk_payload = b"HelloMetadata\x00"
+    junk_chunk = struct.pack("<4sI", b"JUNK", len(junk_payload)) + junk_payload
+    data_header = struct.pack("<4sI", b"data", len(raw_pcm))
+    body = fmt_chunk + junk_chunk + data_header + raw_pcm
+    riff_header = struct.pack("<4sI4s", b"RIFF", 4 + len(body), b"WAVE")
+    wav_bytes = riff_header + body
+
+    b64_audio = base64.b64encode(wav_bytes).decode("ascii")
+    stream = sarvam_tts.stream()
+
+    dst_ch = utils.aio.Chan[tts.SynthesizedAudio]()
+    emitter = tts.AudioEmitter(label="test-sarvam-tts-stream-extended", dst_ch=dst_ch)
+    emitter.initialize(
+        request_id="test-req-stream-extended",
+        sample_rate=SAMPLE_RATE,
+        num_channels=1,
+        mime_type="audio/pcm",
+        stream=True,
+    )
+    emitter.start_segment(segment_id="seg-3")
+
+    events: list[tts.SynthesizedAudio] = []
+
+    async def collect():
+        async for ev in dst_ch:
+            events.append(ev)
+            if ev.is_final:
+                return
+
+    collect_task = asyncio.create_task(collect())
+
+    msg = {
+        "type": "audio",
+        "data": {
+            "audio": b64_audio,
+        },
+    }
+    success = await stream._handle_audio_message(msg, emitter)
+    assert success is True
+
+    emitter.end_segment()
+    emitter.end_input()
+    await emitter.join()
+    await collect_task
+
+    assert len(events) > 0
+    assert events[-1].is_final
+    total_samples = sum(ev.frame.samples_per_channel for ev in events)
+    expected_samples = len(raw_pcm) // 2
+    assert total_samples == expected_samples

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_tts.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from livekit.agents import tts, utils
+from livekit.plugins.sarvam.tts import (
+    _CODEC_TO_MIME,
+    ALLOWED_OUTPUT_AUDIO_CODECS,
+    TTS,
+    _codec_to_mime_type,
+)
+
+pytestmark = pytest.mark.unit
+
+SAMPLE_RATE = 22050
+NUM_CHANNELS = 1
+
+
+def _generate_raw_pcm(duration_ms: int = 100, sample_rate: int = SAMPLE_RATE) -> bytes:
+    """Generate raw 16-bit PCM bytes (no RIFF/WAVE header)."""
+    num_samples = sample_rate * duration_ms // 1000
+    return b"\x00\x00" * num_samples
+
+
+def test_allowed_output_audio_codecs_contains_wav():
+    """Verify that wav is in the allowed output codecs."""
+    assert "wav" in ALLOWED_OUTPUT_AUDIO_CODECS
+
+
+def test_codec_to_mime_maps_wav_to_audio_pcm():
+    """Verify that wav maps to audio/pcm so AudioEmitter treats it as raw PCM."""
+    assert _CODEC_TO_MIME["wav"] == "audio/pcm"
+    assert _codec_to_mime_type("wav") == "audio/pcm"
+    assert _codec_to_mime_type("linear16") == "audio/pcm"
+    assert _codec_to_mime_type("mp3") == "audio/mp3"
+
+
+def test_tts_init_and_update_with_wav_codec():
+    """Verify TTS initializes and updates with output_audio_codec=\"wav\"."""
+    sarvam_tts = TTS(api_key="test-api-key", output_audio_codec="wav")
+    assert sarvam_tts._opts.output_audio_codec == "wav"
+
+    sarvam_tts.update_options(output_audio_codec="mp3")
+    assert sarvam_tts._opts.output_audio_codec == "mp3"
+
+    sarvam_tts.update_options(output_audio_codec="wav")
+    assert sarvam_tts._opts.output_audio_codec == "wav"
+
+
+@pytest.mark.asyncio
+async def test_chunked_stream_with_wav_codec_emits_audio_without_wav_header_error():
+    """Verify ChunkedStream with output_audio_codec=\"wav\" handles raw PCM successfully."""
+    sarvam_tts = TTS(
+        api_key="test-api-key",
+        speech_sample_rate=SAMPLE_RATE,
+        output_audio_codec="wav",
+    )
+
+    raw_pcm = _generate_raw_pcm(duration_ms=100, sample_rate=SAMPLE_RATE)
+    b64_audio = base64.b64encode(raw_pcm).decode("ascii")
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "request_id": "test-req-id",
+            "audios": [b64_audio],
+        }
+    )
+
+    post_cm = AsyncMock()
+    post_cm.__aenter__.return_value = mock_response
+    post_cm.__aexit__.return_value = None
+
+    mock_session = MagicMock()
+    mock_session.post.return_value = post_cm
+    sarvam_tts._session = mock_session
+
+    chunked_stream = sarvam_tts.synthesize("Test text")
+
+    events: list[tts.SynthesizedAudio] = []
+    async for ev in chunked_stream:
+        events.append(ev)
+
+    # Verify request payload sent to Sarvam API has output_audio_codec == "wav"
+    mock_session.post.assert_called_once()
+    _, kwargs = mock_session.post.call_args
+    assert kwargs["json"]["output_audio_codec"] == "wav"
+
+    # Verify AudioEmitter initialized with audio/pcm and frames were received
+    assert len(events) > 0
+    assert events[-1].is_final
+    total_samples = sum(ev.frame.samples_per_channel for ev in events)
+    expected_samples = len(raw_pcm) // 2
+    assert total_samples == expected_samples
+
+
+@pytest.mark.asyncio
+async def test_synthesize_stream_with_wav_codec_handles_raw_pcm():
+    """Verify SynthesizeStream with output_audio_codec=\"wav\" pushes raw PCM without error."""
+    sarvam_tts = TTS(
+        api_key="test-api-key",
+        speech_sample_rate=SAMPLE_RATE,
+        output_audio_codec="wav",
+    )
+
+    raw_pcm = _generate_raw_pcm(duration_ms=100, sample_rate=SAMPLE_RATE)
+    b64_audio = base64.b64encode(raw_pcm).decode("ascii")
+
+    stream = sarvam_tts.stream()
+
+    dst_ch = utils.aio.Chan[tts.SynthesizedAudio]()
+    emitter = tts.AudioEmitter(label="test-sarvam-tts-stream", dst_ch=dst_ch)
+    mime_type = _codec_to_mime_type(stream._opts.output_audio_codec)
+    assert mime_type == "audio/pcm"
+
+    emitter.initialize(
+        request_id="test-req-stream",
+        sample_rate=SAMPLE_RATE,
+        num_channels=1,
+        mime_type=mime_type,
+        stream=True,
+    )
+    emitter.start_segment(segment_id="seg-1")
+
+    events: list[tts.SynthesizedAudio] = []
+
+    async def collect():
+        async for ev in dst_ch:
+            events.append(ev)
+            if ev.is_final:
+                return
+
+    collect_task = asyncio.create_task(collect())
+
+    # Handle audio message containing raw PCM bytes
+    msg = {
+        "type": "audio",
+        "data": {
+            "audio": b64_audio,
+        },
+    }
+    success = await stream._handle_audio_message(msg, emitter)
+    assert success is True
+
+    emitter.end_segment()
+    emitter.end_input()
+    await emitter.join()
+    await collect_task
+
+    assert len(events) > 0
+    assert events[-1].is_final
+    total_samples = sum(ev.frame.samples_per_channel for ev in events)
+    expected_samples = len(raw_pcm) // 2
+    assert total_samples == expected_samples
+
+
+@pytest.mark.asyncio
+async def test_audio_emitter_wav_vs_pcm_regression():
+    """Demonstrate that audio/pcm succeeds on raw PCM where audio/wav fails with missing RIFF."""
+    from livekit.agents.utils.codecs.decoder import _WavInlineDecoder
+
+    raw_pcm = _generate_raw_pcm(duration_ms=50, sample_rate=SAMPLE_RATE)
+
+    # 1. WAV decoder raises ValueError on raw PCM because RIFF/WAVE header is missing
+    ch = utils.aio.Chan()
+    wav_decoder = _WavInlineDecoder(ch, SAMPLE_RATE)
+    with pytest.raises(ValueError, match="Invalid WAV file: missing RIFF/WAVE"):
+        wav_decoder.push(raw_pcm)
+
+    # 2. audio/pcm (our mapping for wav codec) succeeds on raw PCM and emits frames
+    pcm_dst_ch = utils.aio.Chan[tts.SynthesizedAudio]()
+    pcm_emitter = tts.AudioEmitter(label="test-pcm-pass", dst_ch=pcm_dst_ch)
+    pcm_emitter.initialize(
+        request_id="req-pcm",
+        sample_rate=SAMPLE_RATE,
+        num_channels=1,
+        mime_type=_codec_to_mime_type("wav"),
+    )
+    events: list[tts.SynthesizedAudio] = []
+
+    async def collect():
+        async for ev in pcm_dst_ch:
+            events.append(ev)
+            if ev.is_final:
+                return
+
+    collect_task = asyncio.create_task(collect())
+    pcm_emitter.push(raw_pcm)
+    pcm_emitter.end_input()
+    await pcm_emitter.join()
+    await collect_task
+
+    assert len(events) > 0
+    assert events[-1].is_final
+    total_samples = sum(ev.frame.samples_per_channel for ev in events)
+    expected_samples = len(raw_pcm) // 2
+    assert total_samples == expected_samples

--- a/livekit-plugins/livekit-plugins-sarvam/tests/test_tts.py
+++ b/livekit-plugins/livekit-plugins-sarvam/tests/test_tts.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import io
+import wave
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -26,15 +28,26 @@ def _generate_raw_pcm(duration_ms: int = 100, sample_rate: int = SAMPLE_RATE) ->
     return b"\x00\x00" * num_samples
 
 
+def _generate_wav_bytes(duration_ms: int = 100, sample_rate: int = SAMPLE_RATE) -> bytes:
+    """Generate a complete RIFF/WAVE file."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(_generate_raw_pcm(duration_ms, sample_rate))
+    return buf.getvalue()
+
+
 def test_allowed_output_audio_codecs_contains_wav():
     """Verify that wav is in the allowed output codecs."""
     assert "wav" in ALLOWED_OUTPUT_AUDIO_CODECS
 
 
-def test_codec_to_mime_maps_wav_to_audio_pcm():
-    """Verify that wav maps to audio/pcm so AudioEmitter treats it as raw PCM."""
-    assert _CODEC_TO_MIME["wav"] == "audio/pcm"
-    assert _codec_to_mime_type("wav") == "audio/pcm"
+def test_codec_to_mime_maps_wav_to_audio_wav():
+    """Verify that wav maps to audio/wav for REST synthesis."""
+    assert _CODEC_TO_MIME["wav"] == "audio/wav"
+    assert _codec_to_mime_type("wav") == "audio/wav"
     assert _codec_to_mime_type("linear16") == "audio/pcm"
     assert _codec_to_mime_type("mp3") == "audio/mp3"
 
@@ -52,16 +65,16 @@ def test_tts_init_and_update_with_wav_codec():
 
 
 @pytest.mark.asyncio
-async def test_chunked_stream_with_wav_codec_emits_audio_without_wav_header_error():
-    """Verify ChunkedStream with output_audio_codec=\"wav\" handles raw PCM successfully."""
+async def test_chunked_stream_with_wav_codec_handles_riff_wav():
+    """Verify ChunkedStream with output_audio_codec=\"wav\" handles valid RIFF WAV from REST."""
     sarvam_tts = TTS(
         api_key="test-api-key",
         speech_sample_rate=SAMPLE_RATE,
         output_audio_codec="wav",
     )
 
-    raw_pcm = _generate_raw_pcm(duration_ms=100, sample_rate=SAMPLE_RATE)
-    b64_audio = base64.b64encode(raw_pcm).decode("ascii")
+    wav_bytes = _generate_wav_bytes(duration_ms=100, sample_rate=SAMPLE_RATE)
+    b64_audio = base64.b64encode(wav_bytes).decode("ascii")
 
     mock_response = AsyncMock()
     mock_response.status = 200
@@ -86,16 +99,14 @@ async def test_chunked_stream_with_wav_codec_emits_audio_without_wav_header_erro
     async for ev in chunked_stream:
         events.append(ev)
 
-    # Verify request payload sent to Sarvam API has output_audio_codec == "wav"
     mock_session.post.assert_called_once()
     _, kwargs = mock_session.post.call_args
     assert kwargs["json"]["output_audio_codec"] == "wav"
 
-    # Verify AudioEmitter initialized with audio/pcm and frames were received
     assert len(events) > 0
     assert events[-1].is_final
     total_samples = sum(ev.frame.samples_per_channel for ev in events)
-    expected_samples = len(raw_pcm) // 2
+    expected_samples = (len(wav_bytes) - 44) // 2
     assert total_samples == expected_samples
 
 
@@ -115,14 +126,11 @@ async def test_synthesize_stream_with_wav_codec_handles_raw_pcm():
 
     dst_ch = utils.aio.Chan[tts.SynthesizedAudio]()
     emitter = tts.AudioEmitter(label="test-sarvam-tts-stream", dst_ch=dst_ch)
-    mime_type = _codec_to_mime_type(stream._opts.output_audio_codec)
-    assert mime_type == "audio/pcm"
-
     emitter.initialize(
         request_id="test-req-stream",
         sample_rate=SAMPLE_RATE,
         num_channels=1,
-        mime_type=mime_type,
+        mime_type="audio/pcm",
         stream=True,
     )
     emitter.start_segment(segment_id="seg-1")
@@ -137,7 +145,6 @@ async def test_synthesize_stream_with_wav_codec_handles_raw_pcm():
 
     collect_task = asyncio.create_task(collect())
 
-    # Handle audio message containing raw PCM bytes
     msg = {
         "type": "audio",
         "data": {
@@ -160,43 +167,56 @@ async def test_synthesize_stream_with_wav_codec_handles_raw_pcm():
 
 
 @pytest.mark.asyncio
-async def test_audio_emitter_wav_vs_pcm_regression():
-    """Demonstrate that audio/pcm succeeds on raw PCM where audio/wav fails with missing RIFF."""
-    from livekit.agents.utils.codecs.decoder import _WavInlineDecoder
+async def test_synthesize_stream_with_wav_codec_strips_riff_header_if_present():
+    """Verify SynthesizeStream strips RIFF header if provider sends full WAV container on WebSocket."""
+    sarvam_tts = TTS(
+        api_key="test-api-key",
+        speech_sample_rate=SAMPLE_RATE,
+        output_audio_codec="wav",
+    )
 
-    raw_pcm = _generate_raw_pcm(duration_ms=50, sample_rate=SAMPLE_RATE)
+    wav_bytes = _generate_wav_bytes(duration_ms=100, sample_rate=SAMPLE_RATE)
+    b64_audio = base64.b64encode(wav_bytes).decode("ascii")
 
-    # 1. WAV decoder raises ValueError on raw PCM because RIFF/WAVE header is missing
-    ch = utils.aio.Chan()
-    wav_decoder = _WavInlineDecoder(ch, SAMPLE_RATE)
-    with pytest.raises(ValueError, match="Invalid WAV file: missing RIFF/WAVE"):
-        wav_decoder.push(raw_pcm)
+    stream = sarvam_tts.stream()
 
-    # 2. audio/pcm (our mapping for wav codec) succeeds on raw PCM and emits frames
-    pcm_dst_ch = utils.aio.Chan[tts.SynthesizedAudio]()
-    pcm_emitter = tts.AudioEmitter(label="test-pcm-pass", dst_ch=pcm_dst_ch)
-    pcm_emitter.initialize(
-        request_id="req-pcm",
+    dst_ch = utils.aio.Chan[tts.SynthesizedAudio]()
+    emitter = tts.AudioEmitter(label="test-sarvam-tts-stream-riff", dst_ch=dst_ch)
+    emitter.initialize(
+        request_id="test-req-stream-riff",
         sample_rate=SAMPLE_RATE,
         num_channels=1,
-        mime_type=_codec_to_mime_type("wav"),
+        mime_type="audio/pcm",
+        stream=True,
     )
+    emitter.start_segment(segment_id="seg-2")
+
     events: list[tts.SynthesizedAudio] = []
 
     async def collect():
-        async for ev in pcm_dst_ch:
+        async for ev in dst_ch:
             events.append(ev)
             if ev.is_final:
                 return
 
     collect_task = asyncio.create_task(collect())
-    pcm_emitter.push(raw_pcm)
-    pcm_emitter.end_input()
-    await pcm_emitter.join()
+
+    msg = {
+        "type": "audio",
+        "data": {
+            "audio": b64_audio,
+        },
+    }
+    success = await stream._handle_audio_message(msg, emitter)
+    assert success is True
+
+    emitter.end_segment()
+    emitter.end_input()
+    await emitter.join()
     await collect_task
 
     assert len(events) > 0
     assert events[-1].is_final
     total_samples = sum(ev.frame.samples_per_channel for ev in events)
-    expected_samples = len(raw_pcm) // 2
+    expected_samples = (len(wav_bytes) - 44) // 2
     assert total_samples == expected_samples


### PR DESCRIPTION
## Summary
When using `output_audio_codec="wav"`, the Sarvam TTS API returns raw PCM bytes rather than a RIFF/WAVE container file.
Mapping `"wav"` to `"audio/pcm"` in `_CODEC_TO_MIME` allows `AudioEmitter` to ingest the raw PCM directly without failing with `ValueError: Invalid WAV file: missing RIFF/WAVE`.

Fixes #5267