### PR TITLE
feat(voice): allow tts_text_transforms to be configured per-agent (#7015)

### DIFF
--- a/livekit-agents/livekit/agents/voice/agent.py
+++ b/livekit-agents/livekit/agents/voice/agent.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import AsyncGenerator, AsyncIterable, Coroutine, Generator
+from collections.abc import AsyncGenerator, AsyncIterable, Coroutine, Generator, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from .agent_session import AgentSession, ExpressiveOptions
     from .audio_recognition import AudioRecognition
     from .io import TimedString
+    from .transcription.text_transforms import TextTransforms
     from .turn import TurnDetectionMode
 
 
@@ -63,6 +64,7 @@ class Agent:
         expressive: NotGivenOr[bool | ExpressiveOptions] = NOT_GIVEN,
         min_consecutive_speech_delay: NotGivenOr[float] = NOT_GIVEN,
         use_tts_aligned_transcript: NotGivenOr[bool] = NOT_GIVEN,
+        tts_text_transforms: NotGivenOr[Sequence[TextTransforms] | None] = NOT_GIVEN,
         # deprecated
         turn_detection: NotGivenOr[TurnDetectionMode | None] = NOT_GIVEN,
         min_endpointing_delay: NotGivenOr[float] = NOT_GIVEN,
@@ -120,6 +122,7 @@ class Agent:
         endpointing = turn_handling.get("endpointing", {})
         self._min_consecutive_speech_delay = min_consecutive_speech_delay
         self._use_tts_aligned_transcript = use_tts_aligned_transcript
+        self._tts_text_transforms = tts_text_transforms
         self._min_endpointing_delay = endpointing.get("min_delay", NOT_GIVEN)
         self._max_endpointing_delay = endpointing.get("max_delay", NOT_GIVEN)
         self._turn_handling = turn_handling
@@ -285,8 +288,9 @@ class Agent:
         ] = NOT_GIVEN,
         tts: NotGivenOr[tts.TTS | TTSModels | str | None] = NOT_GIVEN,
         expressive: NotGivenOr[bool | ExpressiveOptions] = NOT_GIVEN,
+        tts_text_transforms: NotGivenOr[Sequence[TextTransforms] | None] = NOT_GIVEN,
     ) -> None:
-        """Swap the STT, VAD, LLM, or TTS on this agent, or change its expressive setting.
+        """Swap the STT, VAD, LLM, or TTS on this agent, or change its expressive setting or TTS text transforms.
         Only the options passed are changed.
 
         Useful for switching a component mid-call (e.g. a different STT language or TTS voice).
@@ -321,6 +325,8 @@ class Agent:
                 self._tts = tts
             if is_given(expressive):
                 self._expressive = expressive
+            if is_given(tts_text_transforms):
+                self._tts_text_transforms = tts_text_transforms
             return
 
         self._activity._update_models(new_stt=stt, new_vad=vad, new_llm=llm, new_tts=tts)
@@ -328,6 +334,8 @@ class Agent:
             # after _update_models so a rejected model swap leaves expressive untouched;
             # resolved per turn (agent value over session), no live plumbing needed
             self._expressive = expressive
+        if is_given(tts_text_transforms):
+            self._tts_text_transforms = tts_text_transforms
 
     # -- Pipeline nodes --
     # They can all be overriden by subclasses, by default they use the STT/LLM/TTS specified in the
@@ -847,6 +855,18 @@ class Agent:
             NotGivenOr[bool]: Whether to use TTS-aligned transcript.
         """
         return self._use_tts_aligned_transcript
+
+    @property
+    def tts_text_transforms(self) -> NotGivenOr[Sequence[TextTransforms] | None]:
+        """
+        The transforms to apply to the text before sending it to the TTS node.
+
+        If this property was not set at Agent creation or via update_options, the session's value will be used at runtime instead.
+
+        Returns:
+            NotGivenOr[Sequence[TextTransforms] | None]: The TTS text transforms.
+        """
+        return self._tts_text_transforms
 
     @property
     def session(self) -> AgentSession:

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -6,7 +6,7 @@ import contextvars
 import heapq
 import json
 import time
-from collections.abc import AsyncGenerator, AsyncIterable, Coroutine, Iterator
+from collections.abc import AsyncGenerator, AsyncIterable, Coroutine, Iterator, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -111,6 +111,7 @@ from .turn import (
 if TYPE_CHECKING:
     from ..llm import mcp
     from .agent_session import AgentSession, ExpressiveOptions
+    from .transcription.text_transforms import TextTransforms
 
 
 _AgentActivityContextVar = contextvars.ContextVar["AgentActivity"]("agents_activity")
@@ -721,6 +722,12 @@ class AgentActivity(RecognitionHooks):
         )
 
         return use_aligned_transcript is True
+
+    @property
+    def tts_text_transforms(self) -> Sequence[TextTransforms] | None:
+        if is_given(self._agent.tts_text_transforms):
+            return self._agent.tts_text_transforms
+        return self._session.options.tts_text_transforms
 
     async def update_instructions(self, instructions: str) -> None:
         self._agent._instructions = instructions
@@ -3208,7 +3215,7 @@ class AgentActivity(RecognitionHooks):
                     node=self._agent.tts_node,
                     input=audio_source,
                     model_settings=model_settings,
-                    text_transforms=self._session.options.tts_text_transforms,
+                    text_transforms=self.tts_text_transforms,
                     model=self.tts.model if self.tts else None,
                     provider=self.tts.provider if self.tts else None,
                 )
@@ -3548,7 +3555,7 @@ class AgentActivity(RecognitionHooks):
                         node=self._agent.tts_node,
                         input=tts_text,
                         model_settings=model_settings,
-                        text_transforms=self._session.options.tts_text_transforms,
+                        text_transforms=self.tts_text_transforms,
                         model=self.tts.model if self.tts else None,
                         provider=self.tts.provider if self.tts else None,
                     )
@@ -4355,7 +4362,7 @@ class AgentActivity(RecognitionHooks):
                         node=self._agent.tts_node,
                         input=tts_text_input,
                         model_settings=model_settings,
-                        text_transforms=self._session.options.tts_text_transforms,
+                        text_transforms=self.tts_text_transforms,
                         model=self.tts.model if self.tts else None,
                         provider=self.tts.provider if self.tts else None,
                     )

--- a/tests/test_agent_update_options.py
+++ b/tests/test_agent_update_options.py
@@ -239,3 +239,33 @@ async def test_update_options_vad_check_is_atomic() -> None:
         assert agent.vad is old_vad
     finally:
         await session.aclose()
+
+
+def test_agent_tts_text_transforms_init_and_update() -> None:
+    agent = Agent(instructions="test", tts_text_transforms=["filter_emoji"])
+    assert agent.tts_text_transforms == ["filter_emoji"]
+
+    agent.update_options(tts_text_transforms=["filter_markdown"])
+    assert agent.tts_text_transforms == ["filter_markdown"]
+
+
+@pytest.mark.asyncio
+async def test_agent_tts_text_transforms_resolution_in_session() -> None:
+    agent = Agent(instructions="test", llm=FakeLLM(), tts=FakeTTS())
+    session = AgentSession(
+        turn_handling={"turn_detection": None},
+        tts_text_transforms=["filter_markdown"],
+    )
+    await session.start(agent)
+    try:
+        activity = session._activity
+        assert activity is not None
+        # Falls back to session options when unset on agent
+        assert activity.tts_text_transforms == ["filter_markdown"]
+
+        # Updating agent overrides session options
+        agent.update_options(tts_text_transforms=["filter_emoji"])
+        assert activity.tts_text_transforms == ["filter_emoji"]
+    finally:
+        await session.aclose()
+

--- a/tests/test_agent_update_options.py
+++ b/tests/test_agent_update_options.py
@@ -268,4 +268,3 @@ async def test_agent_tts_text_transforms_resolution_in_session() -> None:
         assert activity.tts_text_transforms == ["filter_emoji"]
     finally:
         await session.aclose()
-


### PR DESCRIPTION
Fixes #7015

### Summary
Allow configuring `tts_text_transforms` directly on `Agent` instances as well as dynamically updating them via `Agent.update_options(tts_text_transforms=...)`.

### Changes
- `Agent.__init__`: Added `tts_text_transforms: NotGivenOr[Sequence[TextTransforms] | None] = NOT_GIVEN` parameter and property getter.
- `Agent.update_options`: Added `tts_text_transforms` parameter to support switching transforms mid-session.
- `AgentActivity`: Added property resolving agent's `tts_text_transforms` over `session.options.tts_text_transforms` when provided.
- Added unit tests in `tests/test_agent_update_options.py` verifying initialization, updates, and session fallback/override.