### PR TITLE
fix(voice): strip break and markup tags before adding say() text to chat_ctx (#4802)

### DIFF
--- a/livekit-agents/livekit/agents/tts/_provider_format.py
+++ b/livekit-agents/livekit/agents/tts/_provider_format.py
@@ -1045,12 +1045,20 @@ def strip_all_markup(text: str) -> str:
 
 
 _SSML_BREAK_RE = re.compile(r"<\s*/?\s*break\b[^>]*\/?>", re.IGNORECASE)
+_SSML_STRUCTURAL_RE = re.compile(
+    r"<\s*(?P<tag>p|s)\b[^>]*>(.*?)</\s*(?P=tag)\s*>",
+    re.IGNORECASE | re.DOTALL,
+)
 _SSML_WRAPPING_RE = re.compile(
-    r"<\s*(?P<tag>phoneme|sub|say-as|prosody|emphasis|voice|lang|speak|p|s|w|audio|mstts:[a-zA-Z0-9_-]+)\b[^>]*>(.*?)</\s*(?P=tag)\s*>",
+    r"<\s*(?P<tag>phoneme|sub|say-as|prosody|emphasis|voice|lang|speak|w|audio|mstts:[a-zA-Z0-9_-]+)\b[^>]*>(.*?)</\s*(?P=tag)\s*>",
     re.IGNORECASE | re.DOTALL,
 )
 _SSML_STANDALONE_RE = re.compile(
     r"<\s*/?\s*(?:speak|p|s|mark)\b[^>]*\/?>",
+    re.IGNORECASE,
+)
+_SSML_INCOMPLETE_RE = re.compile(
+    r"<\s*(?:phoneme|sub|say-as|prosody|emphasis|voice|lang|speak|p|s|w|audio|mstts:[a-zA-Z0-9_-]+)\b[^>]*>",
     re.IGNORECASE,
 )
 
@@ -1063,12 +1071,19 @@ def strip_chat_markup(text: str) -> str:
     and strips provider-specific expressive markup tags.
     """
     if "<" not in text:
-        return text
+        return text.strip()
 
     # Replace break tags with a space to preserve word boundaries
     text = _SSML_BREAK_RE.sub(" ", text)
 
-    # Unwrap SSML wrapping tags to keep inner text
+    # Replace structural SSML tags (<p>, <s>) with inner text + space separator
+    while True:
+        replaced = _SSML_STRUCTURAL_RE.sub(r"\2 ", text)
+        if replaced == text:
+            break
+        text = replaced
+
+    # Unwrap inline SSML wrapping tags to keep inner text
     while True:
         unwrapped = _SSML_WRAPPING_RE.sub(r"\2", text)
         if unwrapped == text:
@@ -1077,6 +1092,9 @@ def strip_chat_markup(text: str) -> str:
 
     # Remove standalone / framing tags
     text = _SSML_STANDALONE_RE.sub(" ", text)
+
+    # Strip incomplete (unmatched) opening SSML tags left by interruptions
+    text = _SSML_INCOMPLETE_RE.sub("", text)
 
     # Strip provider-specific markup (Cartesia, Inworld, xAI, expr markers)
     text = strip_all_markup(text)

--- a/livekit-agents/livekit/agents/tts/_provider_format.py
+++ b/livekit-agents/livekit/agents/tts/_provider_format.py
@@ -1049,16 +1049,20 @@ _SSML_STRUCTURAL_RE = re.compile(
     r"<\s*(?P<tag>p|s)\b[^>]*>(.*?)</\s*(?P=tag)\s*>",
     re.IGNORECASE | re.DOTALL,
 )
+_SSML_TAG_PATTERN = (
+    r"phoneme|sub|say-as|prosody|emphasis|voice|lang|speak|w|audio|"
+    r"[a-zA-Z][a-zA-Z0-9_-]*:[a-zA-Z0-9_-]+"
+)
 _SSML_WRAPPING_RE = re.compile(
-    r"<\s*(?P<tag>phoneme|sub|say-as|prosody|emphasis|voice|lang|speak|w|audio|mstts:[a-zA-Z0-9_-]+)\b[^>]*>(.*?)</\s*(?P=tag)\s*>",
+    rf"<\s*(?P<tag>{_SSML_TAG_PATTERN})\b[^>]*>(.*?)</\s*(?P=tag)\s*>",
     re.IGNORECASE | re.DOTALL,
 )
 _SSML_STANDALONE_RE = re.compile(
-    r"<\s*/?\s*(?:speak|p|s|mark)\b[^>]*\/?>",
+    rf"<\s*/?\s*(?:speak|p|s|mark|{_SSML_TAG_PATTERN})\b[^>]*\/?>",
     re.IGNORECASE,
 )
 _SSML_INCOMPLETE_RE = re.compile(
-    r"<\s*(?:phoneme|sub|say-as|prosody|emphasis|voice|lang|speak|p|s|w|audio|mstts:[a-zA-Z0-9_-]+)\b[^>]*>",
+    rf"<\s*(?:p|s|{_SSML_TAG_PATTERN})\b[^>]*>",
     re.IGNORECASE,
 )
 

--- a/livekit-agents/livekit/agents/tts/_provider_format.py
+++ b/livekit-agents/livekit/agents/tts/_provider_format.py
@@ -1044,6 +1044,48 @@ def strip_all_markup(text: str) -> str:
     return split_all_markup(text)[0]
 
 
+_SSML_BREAK_RE = re.compile(r"<\s*/?\s*break\b[^>]*\/?>", re.IGNORECASE)
+_SSML_WRAPPING_RE = re.compile(
+    r"<\s*(?P<tag>phoneme|sub|say-as|prosody|emphasis|voice|lang|speak|p|s|w|audio|mstts:[a-zA-Z0-9_-]+)\b[^>]*>(.*?)</\s*(?P=tag)\s*>",
+    re.IGNORECASE | re.DOTALL,
+)
+_SSML_STANDALONE_RE = re.compile(
+    r"<\s*/?\s*(?:speak|p|s|mark)\b[^>]*\/?>",
+    re.IGNORECASE,
+)
+
+
+def strip_chat_markup(text: str) -> str:
+    """Strip expressive markup and SSML tags before storing text in chat context.
+
+    Preserves word boundaries when removing <break> tags, unwraps common SSML tags
+    (such as <phoneme>, <prosody>, <say-as>, <emphasis>) while keeping their inner text,
+    and strips provider-specific expressive markup tags.
+    """
+    if "<" not in text:
+        return text
+
+    # Replace break tags with a space to preserve word boundaries
+    text = _SSML_BREAK_RE.sub(" ", text)
+
+    # Unwrap SSML wrapping tags to keep inner text
+    while True:
+        unwrapped = _SSML_WRAPPING_RE.sub(r"\2", text)
+        if unwrapped == text:
+            break
+        text = unwrapped
+
+    # Remove standalone / framing tags
+    text = _SSML_STANDALONE_RE.sub(" ", text)
+
+    # Strip provider-specific markup (Cartesia, Inworld, xAI, expr markers)
+    text = strip_all_markup(text)
+
+    # Collapse any introduced horizontal whitespace runs
+    text = re.sub(r"[^\S\r\n]+", " ", text)
+    return text.strip()
+
+
 def strip_expr_markup(text: str) -> str:
     """Strip only the ``<expr/>`` dialect, leaving all other markup untouched.
 

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -42,6 +42,7 @@ from ..telemetry import (
     utils as trace_utils,
 )
 from ..tokenize.basic import split_words
+from ..tts._provider_format import strip_all_markup
 from ..types import NOT_GIVEN, FlushSentinel, NotGivenOr
 from ..utils.misc import is_given
 from ._utils import _set_participant_attributes
@@ -3326,15 +3327,17 @@ class AgentActivity(RecognitionHooks):
                 _record_user_turn_stages(current_span, _previous_user_metrics)
 
         if forwarded_text and add_to_chat_ctx:
-            msg = self._agent._chat_ctx.add_message(
-                role="assistant",
-                content=forwarded_text,
-                interrupted=speech_handle.interrupted,
-                created_at=started_speaking_at if started_speaking_at is not None else time.time(),
-                metrics=assistant_metrics,
-            )
-            speech_handle._item_added([msg])
-            self._session._conversation_item_added(msg)
+            clean_text = strip_all_markup(forwarded_text).strip()
+            if clean_text:
+                msg = self._agent._chat_ctx.add_message(
+                    role="assistant",
+                    content=clean_text,
+                    interrupted=speech_handle.interrupted,
+                    created_at=started_speaking_at if started_speaking_at is not None else time.time(),
+                    metrics=assistant_metrics,
+                )
+                speech_handle._item_added([msg])
+                self._session._conversation_item_added(msg)
 
         if self._session.agent_state == "speaking":
             self._session._update_agent_state(

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -42,7 +42,7 @@ from ..telemetry import (
     utils as trace_utils,
 )
 from ..tokenize.basic import split_words
-from ..tts._provider_format import strip_all_markup
+from ..tts._provider_format import strip_chat_markup
 from ..types import NOT_GIVEN, FlushSentinel, NotGivenOr
 from ..utils.misc import is_given
 from ._utils import _set_participant_attributes
@@ -3327,7 +3327,7 @@ class AgentActivity(RecognitionHooks):
                 _record_user_turn_stages(current_span, _previous_user_metrics)
 
         if forwarded_text and add_to_chat_ctx:
-            clean_text = strip_all_markup(forwarded_text).strip()
+            clean_text = strip_chat_markup(forwarded_text)
             if clean_text:
                 msg = self._agent._chat_ctx.add_message(
                     role="assistant",

--- a/livekit-agents/livekit/agents/voice/agent_activity.py
+++ b/livekit-agents/livekit/agents/voice/agent_activity.py
@@ -3333,7 +3333,9 @@ class AgentActivity(RecognitionHooks):
                     role="assistant",
                     content=clean_text,
                     interrupted=speech_handle.interrupted,
-                    created_at=started_speaking_at if started_speaking_at is not None else time.time(),
+                    created_at=started_speaking_at
+                    if started_speaking_at is not None
+                    else time.time(),
                     metrics=assistant_metrics,
                 )
                 speech_handle._item_added([msg])

--- a/tests/test_say_break_tag.py
+++ b/tests/test_say_break_tag.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from livekit.agents import Agent, AgentSession
+from livekit.agents.tts._provider_format import strip_chat_markup
 from tests.fake_llm import FakeLLM
 from tests.fake_tts import FakeTTS
 
@@ -64,3 +65,23 @@ async def test_say_strips_break_tags_from_chat_ctx() -> None:
         assert messages[3].text_content == "tomato"
     finally:
         await session.aclose()
+
+
+def test_strip_chat_markup_whitespace_only() -> None:
+    """Whitespace-only text should return empty string."""
+    assert strip_chat_markup("  ") == ""
+    assert strip_chat_markup("   \t  ") == ""
+
+
+def test_strip_chat_markup_structural_ssml_boundaries() -> None:
+    """Adjacent <p> and <s> blocks should preserve word boundaries."""
+    assert strip_chat_markup("<p>Hello</p><p>world</p>") == "Hello world"
+    assert strip_chat_markup("<s>First.</s><s>Second.</s>") == "First. Second."
+
+
+def test_strip_chat_markup_incomplete_ssml_tags() -> None:
+    """Incomplete SSML tags from interruptions should be stripped."""
+    assert strip_chat_markup(
+        '<phoneme alphabet="ipa" ph="təˈmeɪtoʊ">tomato'
+    ) == "tomato"
+    assert strip_chat_markup('<prosody rate="fast">hello') == "hello"

--- a/tests/test_say_break_tag.py
+++ b/tests/test_say_break_tag.py
@@ -83,3 +83,28 @@ def test_strip_chat_markup_incomplete_ssml_tags() -> None:
     """Incomplete SSML tags from interruptions should be stripped."""
     assert strip_chat_markup('<phoneme alphabet="ipa" ph="təˈmeɪtoʊ">tomato') == "tomato"
     assert strip_chat_markup('<prosody rate="fast">hello') == "hello"
+
+
+def test_strip_chat_markup_provider_specific_ssml() -> None:
+    """Provider-specific SSML (e.g. Amazon Polly, Azure) should be unwrapped or stripped."""
+    assert (
+        strip_chat_markup('<amazon:effect name="drc">Breaking news</amazon:effect>')
+        == "Breaking news"
+    )
+    assert (
+        strip_chat_markup(
+            '<amazon:domain name="news"><amazon:effect name="drc">Breaking news</amazon:effect></amazon:domain>'
+        )
+        == "Breaking news"
+    )
+    assert (
+        strip_chat_markup(
+            'Normal speech <amazon:breath duration="medium" volume="default"/> continues.'
+        )
+        == "Normal speech continues."
+    )
+    assert (
+        strip_chat_markup('<mstts:express-as style="cheerful">Have a nice day!</mstts:express-as>')
+        == "Have a nice day!"
+    )
+    assert strip_chat_markup('<amazon:effect name="drc">Interrupted') == "Interrupted"

--- a/tests/test_say_break_tag.py
+++ b/tests/test_say_break_tag.py
@@ -81,7 +81,5 @@ def test_strip_chat_markup_structural_ssml_boundaries() -> None:
 
 def test_strip_chat_markup_incomplete_ssml_tags() -> None:
     """Incomplete SSML tags from interruptions should be stripped."""
-    assert strip_chat_markup(
-        '<phoneme alphabet="ipa" ph="təˈmeɪtoʊ">tomato'
-    ) == "tomato"
+    assert strip_chat_markup('<phoneme alphabet="ipa" ph="təˈmeɪtoʊ">tomato') == "tomato"
     assert strip_chat_markup('<prosody rate="fast">hello') == "hello"

--- a/tests/test_say_break_tag.py
+++ b/tests/test_say_break_tag.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+from livekit.agents import Agent, AgentSession
+from tests.fake_llm import FakeLLM
+from tests.fake_tts import FakeTTS
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_say_strips_break_tags_from_chat_ctx() -> None:
+    agent = Agent(instructions="test", llm=FakeLLM(), tts=FakeTTS(fake_audio_duration=0.01))
+    session = AgentSession(
+        vad=None,
+        turn_handling={"turn_detection": None},
+    )
+    await session.start(agent)
+    try:
+        # Standard self-closing break tag
+        handle = session.say('Hello <break time="1s"/> world!')
+        await handle.wait_for_playout()
+
+        messages = [msg for msg in agent.chat_ctx.messages() if msg.role == "assistant"]
+        assert len(messages) == 1
+        assert messages[0].text_content == "Hello world!"
+        assert "<break" not in messages[0].text_content
+
+        # Multiple and enclosing break tags
+        handle2 = session.say(
+            '<break time="500ms"/> Good morning! <break time="1s"/> How can I help? </break>'
+        )
+        await handle2.wait_for_playout()
+
+        messages = [msg for msg in agent.chat_ctx.messages() if msg.role == "assistant"]
+        assert len(messages) == 2
+        assert messages[1].text_content == "Good morning! How can I help?"
+        assert "<break" not in messages[1].text_content
+
+        # Message with only a break tag does not leave an empty message
+        handle3 = session.say('<break time="1s"/>')
+        await handle3.wait_for_playout()
+
+        messages = [msg for msg in agent.chat_ctx.messages() if msg.role == "assistant"]
+        assert len(messages) == 2
+    finally:
+        await session.aclose()

--- a/tests/test_say_break_tag.py
+++ b/tests/test_say_break_tag.py
@@ -44,5 +44,23 @@ async def test_say_strips_break_tags_from_chat_ctx() -> None:
 
         messages = [msg for msg in agent.chat_ctx.messages() if msg.role == "assistant"]
         assert len(messages) == 2
+
+        # Break tag without surrounding whitespace preserves word boundary
+        handle4 = session.say('Hello<break time="1s"/>world')
+        await handle4.wait_for_playout()
+
+        messages = [msg for msg in agent.chat_ctx.messages() if msg.role == "assistant"]
+        assert len(messages) == 3
+        assert messages[2].text_content == "Hello world"
+
+        # SSML tags like phoneme, prosody, and say-as unwrapped
+        handle5 = session.say(
+            '<speak><prosody rate="fast"><phoneme alphabet="ipa" ph="təˈmeɪtoʊ">tomato</phoneme></prosody></speak>'
+        )
+        await handle5.wait_for_playout()
+
+        messages = [msg for msg in agent.chat_ctx.messages() if msg.role == "assistant"]
+        assert len(messages) == 4
+        assert messages[3].text_content == "tomato"
     finally:
         await session.aclose()


### PR DESCRIPTION
Fixes #4802

### Summary
When using `session.say()` with text containing pause tags like `<break time="1s"/>` or provider markup tags, the tags are synthesized as pauses by the TTS engine, but previously leaked directly into the `ChatContext` assistant message. Storing these raw tags in chat history caused subsequent LLM turns to be few-shotted into emitting unsupported markup tags.

### Changes
- In `AgentActivity._tts_task_impl`, sanitize `forwarded_text` with `strip_all_markup` before adding it as an assistant message to `chat_ctx`.
- Trims surrounding whitespace and ensures pure-pause calls (containing only break tags) do not produce empty messages in context.
- Added hermetic unit test in `tests/test_say_break_tag.py`.