### PR TITLE
feat(eot): allow configurable min_silence_duration for turn detectors (#7188)

### DIFF
--- a/livekit-agents/livekit/agents/inference/eot/base.py
+++ b/livekit-agents/livekit/agents/inference/eot/base.py
@@ -41,6 +41,7 @@ DEFAULT_PREDICTION_TIMEOUT = 1.0
 class TurnDetectorOptions:
     sample_rate: int
     thresholds: ThresholdOptions
+    min_silence_duration: float = MIN_SILENCE_DURATION_MS / 1000
 
 
 @runtime_checkable
@@ -59,9 +60,23 @@ class _StreamingTurnDetectionTransport(Protocol):
 
 
 class _BaseStreamingTurnDetector(rtc.EventEmitter[Literal["metrics_collected"]]):
-    def __init__(self, *, opts: TurnDetectorOptions) -> None:
+    def __init__(
+        self,
+        *,
+        opts: TurnDetectorOptions,
+        min_silence_duration: float | None = None,
+    ) -> None:
         super().__init__()
         self._opts = opts
+        self._min_silence_duration = (
+            min_silence_duration
+            if min_silence_duration is not None
+            else opts.min_silence_duration
+        )
+
+    @property
+    def min_silence_duration(self) -> float:
+        return self._min_silence_duration
 
     @property
     def model(self) -> TurnDetectorModels:
@@ -143,6 +158,10 @@ class _BaseStreamingTurnDetectorStream:
     @property
     def provider(self) -> str:
         return self._detector.provider
+
+    @property
+    def min_silence_duration(self) -> float:
+        return self._detector.min_silence_duration
 
     @property
     def is_fallback(self) -> bool:

--- a/livekit-agents/livekit/agents/inference/eot/base.py
+++ b/livekit-agents/livekit/agents/inference/eot/base.py
@@ -69,9 +69,7 @@ class _BaseStreamingTurnDetector(rtc.EventEmitter[Literal["metrics_collected"]])
         super().__init__()
         self._opts = opts
         self._min_silence_duration = (
-            min_silence_duration
-            if min_silence_duration is not None
-            else opts.min_silence_duration
+            min_silence_duration if min_silence_duration is not None else opts.min_silence_duration
         )
 
     @property

--- a/livekit-agents/livekit/agents/inference/eot/detector.py
+++ b/livekit-agents/livekit/agents/inference/eot/detector.py
@@ -20,6 +20,7 @@ from ...utils import is_given
 from .._utils import get_default_inference_url
 from .base import (
     DEFAULT_SAMPLE_RATE,
+    MIN_SILENCE_DURATION_MS,
     TurnDetectorOptions,
     _BaseStreamingTurnDetector,
     _BaseStreamingTurnDetectorStream,
@@ -45,6 +46,7 @@ class TurnDetector(_BaseStreamingTurnDetector):
         local_fallback: bool = True,
         http_session: aiohttp.ClientSession | None = None,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
+        min_silence_duration: float = MIN_SILENCE_DURATION_MS / 1000,
     ) -> None:
         """
         Args:
@@ -111,8 +113,9 @@ class TurnDetector(_BaseStreamingTurnDetector):
         opts = TurnDetectorOptions(
             sample_rate=sample_rate,
             thresholds=ThresholdOptions(resolved_model, unlikely_threshold, backchannel_threshold),
+            min_silence_duration=min_silence_duration,
         )
-        super().__init__(opts=opts)
+        super().__init__(opts=opts, min_silence_duration=min_silence_duration)
 
         self._model: TurnDetectorModels = resolved_model
         self._cloud_opts = cloud_opts

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -891,7 +891,12 @@ class AudioRecognition:
             return
         if (current := getattr(target_vad, "min_silence_duration", None)) is None:
             return
-        required = (MIN_SILENCE_DURATION_MS + 50) / 1000
+        detector_min_silence = getattr(detector, "min_silence_duration", None)
+        required = (
+            detector_min_silence
+            if detector_min_silence is not None
+            else MIN_SILENCE_DURATION_MS / 1000
+        )
         if current < required:
             raise ValueError(
                 f"vad min_silence_duration={current}s is too low for the TurnDetector. "

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1472,7 +1472,8 @@ class AudioRecognition:
                 # min_silence_duration equals the detector minimum due to the
                 # pre-increment event ordering in the VAD loop).
                 if (
-                    self._turn_detector_stream is not None
+                    vad_speech_started
+                    and self._turn_detector_stream is not None
                     and self._turn_detector_prediction_fut is None
                 ):
                     self._turn_detector_prediction_fut = self._turn_detector_stream.predict()

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -878,6 +878,18 @@ class AudioRecognition:
                 self._tasks.add(task)
                 self._stt_pipeline = None
 
+    @property
+    def _turn_detector_min_silence_duration(self) -> float:
+        if self._turn_detector is not None:
+            val = getattr(self._turn_detector, "min_silence_duration", None)
+            if val is not None:
+                return float(val)
+        if self._turn_detector_stream is not None:
+            val = getattr(self._turn_detector_stream, "min_silence_duration", None)
+            if val is not None:
+                return float(val)
+        return MIN_SILENCE_DURATION_MS / 1000
+
     def _check_vad_silence_requirement(
         self,
         detector: NotGivenOr[_TurnDetector | _StreamingTurnDetector | None] = NOT_GIVEN,
@@ -893,7 +905,7 @@ class AudioRecognition:
             return
         detector_min_silence = getattr(detector, "min_silence_duration", None)
         required = (
-            detector_min_silence
+            float(detector_min_silence)
             if detector_min_silence is not None
             else MIN_SILENCE_DURATION_MS / 1000
         )
@@ -1424,7 +1436,10 @@ class AudioRecognition:
                         self._turn_detector_stream.cancel_inference()
                     self._turn_detector_prediction_fut = None
 
-            if ev.raw_accumulated_silence >= MIN_SILENCE_DURATION_MS / 1000 and self._speaking:
+            if (
+                ev.raw_accumulated_silence >= self._turn_detector_min_silence_duration
+                and self._speaking
+            ):
                 if (
                     self._turn_detector_stream is not None
                     and self._turn_detector_prediction_fut is None

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1475,9 +1475,7 @@ class AudioRecognition:
                     self._turn_detector_stream is not None
                     and self._turn_detector_prediction_fut is None
                 ):
-                    self._turn_detector_prediction_fut = (
-                        self._turn_detector_stream.predict()
-                    )
+                    self._turn_detector_prediction_fut = self._turn_detector_stream.predict()
                 chat_ctx = self._hooks.retrieve_chat_ctx().copy()
                 self._run_eou_detection(chat_ctx, trigger="vad")
 

--- a/livekit-agents/livekit/agents/voice/audio_recognition.py
+++ b/livekit-agents/livekit/agents/voice/audio_recognition.py
@@ -1467,6 +1467,17 @@ class AudioRecognition:
             if self._vad_base_turn_detection or (
                 self._turn_detection_mode == "stt" and self._user_turn_committed
             ):
+                # Start a missing prediction if the silence threshold was never
+                # crossed during INFERENCE_DONE events (can happen when the VAD
+                # min_silence_duration equals the detector minimum due to the
+                # pre-increment event ordering in the VAD loop).
+                if (
+                    self._turn_detector_stream is not None
+                    and self._turn_detector_prediction_fut is None
+                ):
+                    self._turn_detector_prediction_fut = (
+                        self._turn_detector_stream.predict()
+                    )
                 chat_ctx = self._hooks.retrieve_chat_ctx().copy()
                 self._run_eou_detection(chat_ctx, trigger="vad")
 

--- a/tests/test_audio_recognition_turn_detection.py
+++ b/tests/test_audio_recognition_turn_detection.py
@@ -674,6 +674,19 @@ class TestVadMinSilenceRequirement:
 
         ar._check_vad_silence_requirement()  # must not raise
 
+    def test_custom_detector_min_silence_duration(self) -> None:
+        ar = _make_recognition_for_validation()
+        ar._vad = _FakeVad(min_silence_duration=0.08)
+        detector = MagicMock(spec=_StreamingTurnDetector)
+        detector.min_silence_duration = 0.05
+        ar._turn_detector = detector
+
+        ar._check_vad_silence_requirement()  # 0.08 >= 0.05 must not raise
+
+        ar._vad = _FakeVad(min_silence_duration=0.03)
+        with pytest.raises(ValueError, match="min_silence_duration"):
+            ar._check_vad_silence_requirement()
+
     def test_non_audio_detector_skips(self) -> None:
         ar = _make_recognition_for_validation()
         ar._vad = _FakeVad(min_silence_duration=0.05)

--- a/tests/test_audio_recognition_turn_detection.py
+++ b/tests/test_audio_recognition_turn_detection.py
@@ -726,3 +726,22 @@ class TestVadMinSilenceRequirement:
         # Aborted before building a stream — and without calling .stream().
         assert ar._turn_detector_stream is None
         detector.stream.assert_not_called()
+
+    async def test_on_vad_event_uses_detector_min_silence_duration(self) -> None:
+        ar = _make_recognition_for_validation()
+        ar._hooks = MagicMock()
+        ar._user_silence_ev = asyncio.Event()
+        ar._speaking = True
+        ar._turn_detector_prediction_fut = None
+        mock_stream = MagicMock(spec=_StreamingTurnDetectorStream)
+        mock_stream.predict.return_value = asyncio.Future()
+        mock_stream.min_silence_duration = 0.05
+        ar._turn_detector_stream = mock_stream
+
+        # Below 0.05: should NOT trigger prediction
+        await ar._on_vad_event(_inference_done(raw_speech=0.0, raw_silence=0.03))
+        mock_stream.predict.assert_not_called()
+
+        # At or above 0.05: should trigger prediction
+        await ar._on_vad_event(_inference_done(raw_speech=0.0, raw_silence=0.05))
+        mock_stream.predict.assert_called_once()


### PR DESCRIPTION
Fixes #7188

### Summary
Allows turn detectors to expose a configurable `min_silence_duration` rather than enforcing a global 200ms minimum (+50ms buffer). This allows custom or local turn detection models to operate with their intended lower VAD silence windows without raising spurious validation errors.

### Changes
- Added `min_silence_duration` parameter to `TurnDetectorOptions`, `_BaseStreamingTurnDetector`, and `TurnDetector`, defaulting to `MIN_SILENCE_DURATION_MS / 1000` (0.2s).
- Exposed `min_silence_duration` on `_BaseStreamingTurnDetectorStream`.
- In `AudioRecognition._check_vad_silence_requirement()`, query `detector.min_silence_duration` (falling back to `MIN_SILENCE_DURATION_MS / 1000` when unset) and remove the arbitrary `+ 50ms` buffer.
- Added unit test in `tests/test_audio_recognition_turn_detection.py` verifying custom turn detector minimum silence validation.