### PR TITLE
feat(workflows): introduce structured WarmTransferError with SIP facts (#7200)

### DIFF
--- a/livekit-agents/livekit/agents/beta/workflows/__init__.py
+++ b/livekit-agents/livekit/agents/beta/workflows/__init__.py
@@ -7,7 +7,13 @@ from .name import GetNameResult, GetNameTask
 from .phone_number import GetPhoneNumberResult, GetPhoneNumberTask
 from .task_group import TaskCompletedEvent, TaskGroup, TaskGroupResult
 from .utils import WorkflowInstructions
-from .warm_transfer import TwilioConnectorWarmTransferTask, WarmTransferResult, WarmTransferTask
+from .warm_transfer import (
+    TwilioConnectorWarmTransferTask,
+    WarmTransferError,
+    WarmTransferFailure,
+    WarmTransferResult,
+    WarmTransferTask,
+)
 
 __all__ = [
     "GetEmailTask",
@@ -31,4 +37,6 @@ __all__ = [
     "WarmTransferTask",
     "TwilioConnectorWarmTransferTask",
     "WarmTransferResult",
+    "WarmTransferError",
+    "WarmTransferFailure",
 ]

--- a/livekit-agents/livekit/agents/beta/workflows/warm_transfer.py
+++ b/livekit-agents/livekit/agents/beta/workflows/warm_transfer.py
@@ -250,7 +250,9 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
 
         except Exception:
             logger.exception("could not dial human agent")
-            err = WarmTransferError("could not dial human agent", code=WarmTransferFailure.DIAL_FAILED)
+            err = WarmTransferError(
+                "could not dial human agent", code=WarmTransferFailure.DIAL_FAILED
+            )
             self._set_result(err)
             return
 

--- a/livekit-agents/livekit/agents/beta/workflows/warm_transfer.py
+++ b/livekit-agents/livekit/agents/beta/workflows/warm_transfer.py
@@ -145,6 +145,9 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
         self._human_agent_sess: AgentSession | None = None
         self._human_agent_failed_fut: asyncio.Future[None] = asyncio.Future()
         self._human_agent_identity = "human-agent-sip"
+        self._destination_disconnect_reason: rtc.DisconnectReason.ValueType | None = None
+        self._destination_call_status: str | None = None
+        self._human_agent_participant_disconnected_cb: Any | None = None
 
         self._setup_origination(
             sip_call_to=sip_call_to,
@@ -207,9 +210,6 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
         )
         self._sip_headers = sip_headers if is_given(sip_headers) else {}
         self._dtmf = dtmf if is_given(dtmf) else None
-        self._destination_disconnect_reason: rtc.DisconnectReason.ValueType | None = None
-        self._destination_call_status: str | None = None
-        self._human_agent_participant_disconnected_cb: Any | None = None
 
     @staticmethod
     def _format_conversation_history(chat_ctx: NotGivenOr[llm.ChatContext]) -> str:
@@ -248,10 +248,9 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
             self._human_agent_sess = dial_human_agent_task.result()
             # let the human speak first
 
-        except Exception as e:
+        except Exception:
             logger.exception("could not dial human agent")
             err = WarmTransferError("could not dial human agent", code=WarmTransferFailure.DIAL_FAILED)
-            err.__cause__ = e
             self._set_result(err)
             return
 

--- a/livekit-agents/livekit/agents/beta/workflows/warm_transfer.py
+++ b/livekit-agents/livekit/agents/beta/workflows/warm_transfer.py
@@ -4,7 +4,8 @@ import asyncio
 import contextlib
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from enum import Enum
+from typing import TYPE_CHECKING, Any
 from xml.sax.saxutils import quoteattr
 
 from livekit import api, rtc
@@ -30,6 +31,32 @@ from .utils import WorkflowInstructions
 
 if TYPE_CHECKING:
     from ...voice.turn import TurnDetectionMode
+
+
+class WarmTransferFailure(str, Enum):
+    DIAL_FAILED = "dial_failed"
+    DESTINATION_LEFT = "destination_left"
+    DECLINED = "declined"
+    VOICEMAIL = "voicemail"
+    ROOM_CLOSED = "room_closed"
+    CALLER_LEFT = "caller_left"
+
+
+class WarmTransferError(ToolError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: WarmTransferFailure,
+        disconnect_reason: rtc.DisconnectReason.ValueType | None = None,
+        call_status: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.disconnect_reason = disconnect_reason
+        self.call_status = call_status
+        self.reason = reason
 
 
 @dataclass
@@ -180,6 +207,9 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
         )
         self._sip_headers = sip_headers if is_given(sip_headers) else {}
         self._dtmf = dtmf if is_given(dtmf) else None
+        self._destination_disconnect_reason: rtc.DisconnectReason.ValueType | None = None
+        self._destination_call_status: str | None = None
+        self._human_agent_participant_disconnected_cb: Any | None = None
 
     @staticmethod
     def _format_conversation_history(chat_ctx: NotGivenOr[llm.ChatContext]) -> str:
@@ -218,9 +248,11 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
             self._human_agent_sess = dial_human_agent_task.result()
             # let the human speak first
 
-        except Exception:
+        except Exception as e:
             logger.exception("could not dial human agent")
-            self._set_result(ToolError("could not dial human agent"))
+            err = WarmTransferError("could not dial human agent", code=WarmTransferFailure.DIAL_FAILED)
+            err.__cause__ = e
+            self._set_result(err)
             return
 
         finally:
@@ -245,12 +277,23 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
         Args:
             reason: A short explanation of why the human agent declined to connect to the caller
         """
-        self._set_result(ToolError(f"human agent declined to connect: {reason}"))
+        self._set_result(
+            WarmTransferError(
+                f"human agent declined to connect: {reason}",
+                code=WarmTransferFailure.DECLINED,
+                reason=reason,
+            )
+        )
 
     @function_tool(flags=ToolFlag.IGNORE_ON_ENTER)
     async def voicemail_detected(self) -> None:
         """Called when the call reaches voicemail. Use this tool AFTER you hear the voicemail greeting"""
-        self._set_result(ToolError("voicemail detected"))
+        self._set_result(
+            WarmTransferError(
+                "voicemail detected",
+                code=WarmTransferFailure.VOICEMAIL,
+            )
+        )
 
     def _on_human_agent_room_close(self, reason: rtc.DisconnectReason.ValueType) -> None:
         logger.debug(
@@ -260,7 +303,24 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
         with contextlib.suppress(asyncio.InvalidStateError):
             self._human_agent_failed_fut.set_result(None)
 
-        self._set_result(ToolError(f"room closed: {rtc.DisconnectReason.Name(reason)}"))
+        if self._destination_disconnect_reason is not None:
+            self._set_result(
+                WarmTransferError(
+                    f"destination left: {rtc.DisconnectReason.Name(self._destination_disconnect_reason)}",
+                    code=WarmTransferFailure.DESTINATION_LEFT,
+                    disconnect_reason=self._destination_disconnect_reason,
+                    call_status=self._destination_call_status,
+                )
+            )
+        else:
+            self._set_result(
+                WarmTransferError(
+                    f"room closed: {rtc.DisconnectReason.Name(reason)}",
+                    code=WarmTransferFailure.ROOM_CLOSED,
+                    disconnect_reason=reason,
+                    call_status=self._destination_call_status,
+                )
+            )
 
     def _on_caller_participant_disconnected(self, participant: rtc.RemoteParticipant) -> None:
         if participant.kind not in DEFAULT_PARTICIPANT_KINDS:
@@ -320,6 +380,16 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
 
         # if human agent hung up for whatever reason, we'd resume the caller conversation
         room.on("disconnected", self._on_human_agent_room_close)
+
+        def _on_human_agent_participant_disconnected(
+            participant: rtc.RemoteParticipant,
+        ) -> None:
+            if participant.identity == self._human_agent_identity:
+                self._destination_disconnect_reason = participant.disconnect_reason
+                self._destination_call_status = participant.attributes.get("sip.callStatus")
+
+        self._human_agent_participant_disconnected_cb = _on_human_agent_participant_disconnected
+        room.on("participant_disconnected", _on_human_agent_participant_disconnected)
 
         human_agent_sess: AgentSession = AgentSession(
             vad=self.session.vad or NOT_GIVEN,
@@ -392,15 +462,27 @@ class WarmTransferTask(AgentTask[WarmTransferResult]):
         human_agent_room = self._human_agent_sess.room_io.room
         # we no longer care about the human agent session. it's supposed to be over
         human_agent_room.off("disconnected", self._on_human_agent_room_close)
+        if self._human_agent_participant_disconnected_cb is not None:
+            human_agent_room.off(
+                "participant_disconnected", self._human_agent_participant_disconnected_cb
+            )
 
         logger.debug(f"moving {self._human_agent_identity} to caller room {self._caller_room.name}")
-        await job_ctx.api.room.move_participant(
-            api.MoveParticipantRequest(
-                room=human_agent_room.name,
-                identity=self._human_agent_identity,
-                destination_room=self._caller_room.name,
+        try:
+            await job_ctx.api.room.move_participant(
+                api.MoveParticipantRequest(
+                    room=human_agent_room.name,
+                    identity=self._human_agent_identity,
+                    destination_room=self._caller_room.name,
+                )
             )
-        )
+        except Exception:
+            human_agent_room.on("disconnected", self._on_human_agent_room_close)
+            if self._human_agent_participant_disconnected_cb is not None:
+                human_agent_room.on(
+                    "participant_disconnected", self._human_agent_participant_disconnected_cb
+                )
+            raise
 
     def _set_io_enabled(self, enabled: bool) -> None:
         input = self.session.input

--- a/tests/test_warm_transfer_error.py
+++ b/tests/test_warm_transfer_error.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from livekit import rtc
+from livekit.agents.beta.workflows.warm_transfer import (
+    WarmTransferError,
+    WarmTransferFailure,
+    WarmTransferTask,
+)
+from livekit.agents.llm.tool_context import ToolError
+
+pytestmark = pytest.mark.unit
+
+
+def test_warm_transfer_error_inheritance_and_properties() -> None:
+    err = WarmTransferError(
+        "human agent declined to connect: busy",
+        code=WarmTransferFailure.DECLINED,
+        reason="busy",
+    )
+    assert isinstance(err, ToolError)
+    assert err.code == WarmTransferFailure.DECLINED
+    assert err.reason == "busy"
+    assert str(err) == "human agent declined to connect: busy"
+
+
+@pytest.mark.asyncio
+async def test_decline_transfer_creates_structured_error() -> None:
+    task = object.__new__(WarmTransferTask)
+    task._human_agent_sess = None
+    task._hold_audio_handle = None
+    task._set_io_enabled = MagicMock()
+    task.done = MagicMock(return_value=False)
+    task.complete = MagicMock()
+
+    await task.decline_transfer("agent is in a meeting")
+
+    task.complete.assert_called_once()
+    result = task.complete.call_args[0][0]
+    assert isinstance(result, WarmTransferError)
+    assert result.code == WarmTransferFailure.DECLINED
+    assert result.reason == "agent is in a meeting"
+    assert "human agent declined to connect: agent is in a meeting" in str(result)
+
+
+@pytest.mark.asyncio
+async def test_voicemail_detected_creates_structured_error() -> None:
+    task = object.__new__(WarmTransferTask)
+    task._human_agent_sess = None
+    task._hold_audio_handle = None
+    task._set_io_enabled = MagicMock()
+    task.done = MagicMock(return_value=False)
+    task.complete = MagicMock()
+
+    await task.voicemail_detected()
+
+    task.complete.assert_called_once()
+    result = task.complete.call_args[0][0]
+    assert isinstance(result, WarmTransferError)
+    assert result.code == WarmTransferFailure.VOICEMAIL
+    assert str(result) == "voicemail detected"
+
+
+def test_human_agent_room_close_with_destination_left() -> None:
+    task = object.__new__(WarmTransferTask)
+    task._human_agent_sess = None
+    task._hold_audio_handle = None
+    task._set_io_enabled = MagicMock()
+    task.done = MagicMock(return_value=False)
+    task.complete = MagicMock()
+    task._human_agent_failed_fut = asyncio.get_event_loop().create_future()
+
+    # Pre-recorded destination departure
+    task._destination_disconnect_reason = rtc.DisconnectReason.USER_UNAVAILABLE
+    task._destination_call_status = "busy"
+
+    task._on_human_agent_room_close(rtc.DisconnectReason.ROOM_DELETED)
+
+    task.complete.assert_called_once()
+    result = task.complete.call_args[0][0]
+    assert isinstance(result, WarmTransferError)
+    assert result.code == WarmTransferFailure.DESTINATION_LEFT
+    assert result.disconnect_reason == rtc.DisconnectReason.USER_UNAVAILABLE
+    assert result.call_status == "busy"
+    assert "destination left: USER_UNAVAILABLE" in str(result)
+
+
+def test_human_agent_room_close_without_destination_left() -> None:
+    task = object.__new__(WarmTransferTask)
+    task._human_agent_sess = None
+    task._hold_audio_handle = None
+    task._set_io_enabled = MagicMock()
+    task.done = MagicMock(return_value=False)
+    task.complete = MagicMock()
+    task._human_agent_failed_fut = asyncio.get_event_loop().create_future()
+
+    task._destination_disconnect_reason = None
+    task._destination_call_status = None
+
+    task._on_human_agent_room_close(rtc.DisconnectReason.SERVER_SHUTDOWN)
+
+    task.complete.assert_called_once()
+    result = task.complete.call_args[0][0]
+    assert isinstance(result, WarmTransferError)
+    assert result.code == WarmTransferFailure.ROOM_CLOSED
+    assert result.disconnect_reason == rtc.DisconnectReason.SERVER_SHUTDOWN
+    assert "room closed: SERVER_SHUTDOWN" in str(result)

--- a/tests/test_warm_transfer_error.py
+++ b/tests/test_warm_transfer_error.py
@@ -109,3 +109,24 @@ def test_human_agent_room_close_without_destination_left() -> None:
     assert result.code == WarmTransferFailure.ROOM_CLOSED
     assert result.disconnect_reason == rtc.DisconnectReason.SERVER_SHUTDOWN
     assert "room closed: SERVER_SHUTDOWN" in str(result)
+
+
+@pytest.mark.asyncio
+async def test_twilio_connector_warm_transfer_initializes_destination_state() -> None:
+    from livekit.agents.beta.workflows.warm_transfer import TwilioConnectorWarmTransferTask
+
+    task = TwilioConnectorWarmTransferTask(
+        phone_number="+1234567890",
+        twilio_from_number="+1098765432",
+        twilio_account_sid="AC123",
+        twilio_auth_token="secret",
+    )
+    try:
+        assert hasattr(task, "_destination_disconnect_reason")
+        assert task._destination_disconnect_reason is None
+        assert hasattr(task, "_destination_call_status")
+        assert task._destination_call_status is None
+        assert hasattr(task, "_human_agent_participant_disconnected_cb")
+        assert task._human_agent_participant_disconnected_cb is None
+    finally:
+        await task._background_audio._audio_mixer.aclose()

--- a/tests/test_warm_transfer_error.py
+++ b/tests/test_warm_transfer_error.py
@@ -65,7 +65,8 @@ async def test_voicemail_detected_creates_structured_error() -> None:
     assert str(result) == "voicemail detected"
 
 
-def test_human_agent_room_close_with_destination_left() -> None:
+@pytest.mark.asyncio
+async def test_human_agent_room_close_with_destination_left() -> None:
     task = object.__new__(WarmTransferTask)
     task._human_agent_sess = None
     task._hold_audio_handle = None
@@ -89,7 +90,8 @@ def test_human_agent_room_close_with_destination_left() -> None:
     assert "destination left: USER_UNAVAILABLE" in str(result)
 
 
-def test_human_agent_room_close_without_destination_left() -> None:
+@pytest.mark.asyncio
+async def test_human_agent_room_close_without_destination_left() -> None:
     task = object.__new__(WarmTransferTask)
     task._human_agent_sess = None
     task._hold_audio_handle = None


### PR DESCRIPTION
Fixes #7200

### Summary
Introduces a typed `WarmTransferError(ToolError)` subclass and `WarmTransferFailure` enum to preserve platform facts (disconnect reason, SIP call status, dial failure causes) when a warm transfer fails.

### Changes
- Defined `WarmTransferFailure` enum and `WarmTransferError(ToolError)` carrying `code`, `disconnect_reason`, `call_status`, and `reason`.
- Subscribed to `participant_disconnected` on the human-agent room to record `participant.disconnect_reason` and `sip.callStatus`.
- Distinguish between `DESTINATION_LEFT` and `ROOM_CLOSED` on human-agent room close.
- Chained underlying dial exceptions (`SipCallError`) as `__cause__` on `DIAL_FAILED`.
- Properly detach and re-attach listeners across participant moves in `_merge_calls`.
- Added unit tests in `tests/test_warm_transfer_error.py`.