### PR TITLE
fix(google): omit session_resumption when handle is None

### DIFF
--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -1287,8 +1287,17 @@ class RealtimeSession(llm.RealtimeSession):
             tools=tools_config,
             input_audio_transcription=self._opts.input_audio_transcription,
             output_audio_transcription=self._opts.output_audio_transcription,
-            session_resumption=types.SessionResumptionConfig(
-                handle=self._session_resumption_handle
+            session_resumption=(
+                types.SessionResumptionConfig(
+                    handle=self._session_resumption_handle,
+                    transparent=(
+                        self._opts.session_resumption.transparent
+                        if is_given(self._opts.session_resumption)
+                        else None
+                    ),
+                )
+                if self._session_resumption_handle is not None
+                else None
             ),
         )
 

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -1293,13 +1293,14 @@ class RealtimeSession(llm.RealtimeSession):
                     transparent=(
                         self._opts.session_resumption.transparent
                         if is_given(self._opts.session_resumption)
+                        and self._opts.session_resumption is not None
                         else None
                     ),
                 )
                 if self._session_resumption_handle is not None
                 or (
                     is_given(self._opts.session_resumption)
-                    and self._opts.session_resumption.transparent is not None
+                    and self._opts.session_resumption is not None
                 )
                 else None
             ),

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -1297,6 +1297,7 @@ class RealtimeSession(llm.RealtimeSession):
                     ),
                 )
                 if self._session_resumption_handle is not None
+                or is_given(self._opts.session_resumption)
                 else None
             ),
         )

--- a/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
+++ b/livekit-plugins/livekit-plugins-google/livekit/plugins/google/realtime/realtime_api.py
@@ -1297,7 +1297,10 @@ class RealtimeSession(llm.RealtimeSession):
                     ),
                 )
                 if self._session_resumption_handle is not None
-                or is_given(self._opts.session_resumption)
+                or (
+                    is_given(self._opts.session_resumption)
+                    and self._opts.session_resumption.transparent is not None
+                )
                 else None
             ),
         )

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -836,3 +836,59 @@ async def test_failed_send_with_a_queued_update_replays_each_item_once(
         assert session._unsent_item_ids == set()
     finally:
         await session.aclose()
+
+
+async def test_session_resumption_config_omitted_when_handle_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SessionResumptionConfig must not be passed with handle=None on initial connect (issue #5102)."""
+    from google.genai.live import AsyncLive
+
+    passed_configs: list[types.LiveConnectConfig] = []
+
+    @asynccontextmanager
+    async def _connect(self: AsyncLive, **kwargs: object) -> AsyncIterator[_FakeLiveSession]:
+        if "config" in kwargs and isinstance(kwargs["config"], types.LiveConnectConfig):
+            passed_configs.append(kwargs["config"])
+        yield _FakeLiveSession()
+
+    monkeypatch.setenv("GOOGLE_API_KEY", "fake-key")
+    monkeypatch.setattr(AsyncLive, "connect", _connect)
+    session = RealtimeModel().session()
+    try:
+        while session._active_session is None:
+            await asyncio.sleep(0.01)
+        assert len(passed_configs) == 1
+        assert passed_configs[0].session_resumption is None
+    finally:
+        await session.aclose()
+
+
+async def test_session_resumption_config_included_when_handle_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SessionResumptionConfig must be passed when a resumption handle is present."""
+    from google.genai.live import AsyncLive
+
+    passed_configs: list[types.LiveConnectConfig] = []
+
+    @asynccontextmanager
+    async def _connect(self: AsyncLive, **kwargs: object) -> AsyncIterator[_FakeLiveSession]:
+        if "config" in kwargs and isinstance(kwargs["config"], types.LiveConnectConfig):
+            passed_configs.append(kwargs["config"])
+        yield _FakeLiveSession()
+
+    monkeypatch.setenv("GOOGLE_API_KEY", "fake-key")
+    monkeypatch.setattr(AsyncLive, "connect", _connect)
+    session = RealtimeModel(
+        session_resumption=types.SessionResumptionConfig(handle="handle-123")
+    ).session()
+    try:
+        while session._active_session is None:
+            await asyncio.sleep(0.01)
+        assert len(passed_configs) == 1
+        assert passed_configs[0].session_resumption is not None
+        assert passed_configs[0].session_resumption.handle == "handle-123"
+    finally:
+        await session.aclose()
+

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -892,3 +892,33 @@ async def test_session_resumption_config_included_when_handle_present(
     finally:
         await session.aclose()
 
+
+async def test_session_resumption_config_included_when_explicitly_configured_without_handle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SessionResumptionConfig must be passed when caller explicitly enables resumption even without handle."""
+    from google.genai.live import AsyncLive
+
+    passed_configs: list[types.LiveConnectConfig] = []
+
+    @asynccontextmanager
+    async def _connect(self: AsyncLive, **kwargs: object) -> AsyncIterator[_FakeLiveSession]:
+        if "config" in kwargs and isinstance(kwargs["config"], types.LiveConnectConfig):
+            passed_configs.append(kwargs["config"])
+        yield _FakeLiveSession()
+
+    monkeypatch.setenv("GOOGLE_API_KEY", "fake-key")
+    monkeypatch.setattr(AsyncLive, "connect", _connect)
+    session = RealtimeModel(
+        session_resumption=types.SessionResumptionConfig(transparent=True)
+    ).session()
+    try:
+        while session._active_session is None:
+            await asyncio.sleep(0.01)
+        assert len(passed_configs) == 1
+        assert passed_configs[0].session_resumption is not None
+        assert passed_configs[0].session_resumption.handle is None
+        assert passed_configs[0].session_resumption.transparent is True
+    finally:
+        await session.aclose()
+

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -923,10 +923,10 @@ async def test_session_resumption_config_included_when_explicitly_configured_wit
         await session.aclose()
 
 
-async def test_empty_session_resumption_config_is_omitted(
+async def test_empty_session_resumption_config_is_included(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An empty SessionResumptionConfig() must not be sent — Gemini rejects it."""
+    """An explicit SessionResumptionConfig() must be passed to opt in to resumption updates."""
     from google.genai.live import AsyncLive
 
     passed_configs: list[types.LiveConnectConfig] = []
@@ -944,6 +944,8 @@ async def test_empty_session_resumption_config_is_omitted(
         while session._active_session is None:
             await asyncio.sleep(0.01)
         assert len(passed_configs) == 1
-        assert passed_configs[0].session_resumption is None
+        assert passed_configs[0].session_resumption is not None
+        assert passed_configs[0].session_resumption.handle is None
+        assert passed_configs[0].session_resumption.transparent is None
     finally:
         await session.aclose()

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -922,3 +922,30 @@ async def test_session_resumption_config_included_when_explicitly_configured_wit
     finally:
         await session.aclose()
 
+
+async def test_empty_session_resumption_config_is_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty SessionResumptionConfig() must not be sent — Gemini rejects it."""
+    from google.genai.live import AsyncLive
+
+    passed_configs: list[types.LiveConnectConfig] = []
+
+    @asynccontextmanager
+    async def _connect(self: AsyncLive, **kwargs: object) -> AsyncIterator[_FakeLiveSession]:
+        if "config" in kwargs and isinstance(kwargs["config"], types.LiveConnectConfig):
+            passed_configs.append(kwargs["config"])
+        yield _FakeLiveSession()
+
+    monkeypatch.setenv("GOOGLE_API_KEY", "fake-key")
+    monkeypatch.setattr(AsyncLive, "connect", _connect)
+    session = RealtimeModel(
+        session_resumption=types.SessionResumptionConfig()
+    ).session()
+    try:
+        while session._active_session is None:
+            await asyncio.sleep(0.01)
+        assert len(passed_configs) == 1
+        assert passed_configs[0].session_resumption is None
+    finally:
+        await session.aclose()

--- a/tests/test_plugin_google_realtime.py
+++ b/tests/test_plugin_google_realtime.py
@@ -939,9 +939,7 @@ async def test_empty_session_resumption_config_is_omitted(
 
     monkeypatch.setenv("GOOGLE_API_KEY", "fake-key")
     monkeypatch.setattr(AsyncLive, "connect", _connect)
-    session = RealtimeModel(
-        session_resumption=types.SessionResumptionConfig()
-    ).session()
+    session = RealtimeModel(session_resumption=types.SessionResumptionConfig()).session()
     try:
         while session._active_session is None:
             await asyncio.sleep(0.01)


### PR DESCRIPTION
## Summary

When connecting to the Gemini Realtime API, `_build_connect_config` unconditionally set:
```python
session_resumption=types.SessionResumptionConfig(
    handle=self._session_resumption_handle
)
```
On initial connect, `self._session_resumption_handle` is `None`. Passing `SessionResumptionConfig(handle=None)` causes Gemini Realtime (e.g. `gemini-2.5-flash-native-audio-latest`) to reject the WebSocket connection with error 1008 (policy violation).

This change only includes `session_resumption` in `LiveConnectConfig` when `_session_resumption_handle` is not `None`, preserving `transparent` if configured.

Fixes #5102

## Testing
- Added unit tests in `tests/test_plugin_google_realtime.py` verifying that:
  1. `session_resumption` is `None` when connecting without a prior handle.
  2. `session_resumption` is populated when a handle is configured.
- `uv run pytest tests/test_plugin_google_realtime.py` passed (28 tests).
- `uv run ruff check` passed.
