### PR TITLE
fix(aio): drain blocked senders when closing channels

### DIFF
--- a/livekit-agents/livekit/agents/utils/aio/channel.py
+++ b/livekit-agents/livekit/agents/utils/aio/channel.py
@@ -133,8 +133,9 @@ class Chan(Generic[T]):
     def close(self) -> None:
         self._closed = True
         self._close_ev.set()
-        for putter in self._puts:
-            if not putter.cancelled():
+        while self._puts:
+            putter = self._puts.popleft()
+            if not putter.done():
                 putter.set_exception(ChanClosed())
 
         while len(self._gets) > self.qsize():

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -28,6 +28,42 @@ async def test_channel():
     assert sum == 10
 
 
+@pytest.mark.parametrize("wait_for_senders", [False, True])
+async def test_channel_close_with_blocked_senders(wait_for_senders):
+    channel = aio.Chan[int](maxsize=1)
+    channel.send_nowait(1)
+    started = [asyncio.Event(), asyncio.Event()]
+
+    async def send(value, ready):
+        ready.set()
+        await channel.send(value)
+
+    senders = [asyncio.create_task(send(i + 2, ready)) for i, ready in enumerate(started)]
+    try:
+        for ready in started:
+            await ready.wait()
+        channel.close()
+        if wait_for_senders:
+            for sender in senders:
+                with pytest.raises(aio.ChanClosed):
+                    await sender
+
+        # Both immediate and later shutdown paths may close the same channel.
+        channel.close()
+        for sender in senders:
+            with pytest.raises(aio.ChanClosed):
+                await sender
+        assert channel.recv_nowait() == 1
+        with pytest.raises(aio.ChanClosed):
+            await channel.recv()
+        with pytest.raises(aio.ChanClosed):
+            await channel.send(4)
+    finally:
+        for sender in senders:
+            sender.cancel()
+        await asyncio.gather(*senders, return_exceptions=True)
+
+
 async def test_interval():
     interval = aio.interval(0.1)
 


### PR DESCRIPTION
Closing a full bounded `Chan` wakes blocked senders but leaves their completed futures in `_puts`. A second `close()`, either immediately or after the senders finish, calls `set_exception()` on those futures and raises `InvalidStateError` during shutdown.

Drain the sender waiters when closing and only signal unfinished futures. Regression tests exercise both close timings through the public channel API, verify that all blocked senders receive `ChanClosed`, and that the buffered item remains readable.

Validation:
- Both regressions fail on unchanged `34a4e8f`; the 12 existing tests in `test_aio.py` pass there.
- All 19 tests in `tests/test_aio.py` and `tests/test_aio_itertools.py` pass on Python 3.13.14.
- Repository-wide Ruff checks and formatting (1,041 files), scoped Linux-target mypy for the channel module, and `git diff --check` pass.
- The configured all-plugin type check stops at the local environment's missing `livekit.plugins.anam` `py.typed` marker, identically on the unchanged base. The full SDK/provider integration suite was not run locally.
